### PR TITLE
Generalise files to artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 `ogcat` stands for OpenGHG Catalog.
 
-`ogcat` is a lightweight local file catalog for managed file ingest, flexible metadata, and simple search. Today it provides a self-describing on-disk catalog layout, a small Python API, and a CLI for creating catalogs, adding files by copy or move, listing metadata field descriptions, and locating stored paths.
+`ogcat` is a lightweight artifact catalog with a managed-file MVP. Today it provides a
+self-describing on-disk catalog layout, a small Python API, and a CLI for creating catalogs,
+adding files by copy or move, listing metadata field descriptions, and locating stored paths.
 
 ## Scope
 
-- local, file-based catalogs
+- local catalogs centred on managed file ingest
 - a self-describing catalog layout with `catalog.json`, `db.json`, and `files/`
 - path-based managed ingest using `copy` or `move`
 - flexible JSON-serialisable user metadata
@@ -29,7 +31,9 @@
 
 - Catalog spec: `catalog.json` stores the catalog name, storage layout templates, default ingest mode, field resolution order, and descriptive metadata field definitions.
 - Repository abstraction: catalog records are stored through a repository protocol so the rest of the package does not depend directly on TinyDB details.
-- Records: each record stores reserved top-level fields plus `user_metadata`, `derived_metadata`, and `naming_metadata`.
+- Records: each record stores reserved top-level fields plus `user_metadata`, `derived_metadata`,
+  and `naming_metadata`. Records now also carry a small `record_type` and `locator` so the model
+  can grow beyond copied or moved local files without changing the basic catalog shape.
 - Naming and templates: file placement under `files/` is driven by simple directory and filename templates evaluated from record id, source filename parts, timestamps, and user metadata.
 - Derived metadata extractors: optional extractors can add lightweight summaries after ingest. The current implementation includes a netCDF extractor when `xarray` is installed.
 - Search and CLI: search supports exact equality, substring contains, and regex matching, with flattened field lookup and dotted-path access for nested metadata. The CLI exposes the same search model and adds shell-oriented output modes.
@@ -159,14 +163,26 @@ Current search is intentionally small. It does not support numeric range queries
 
 ## Storage Model
 
-Current storage is path-based managed ingest. Files are copied or moved into the catalog's `files/` tree, and the resulting stored path is recorded in the catalog database alongside metadata and naming information.
+Current storage is still path-based managed ingest for the MVP. Files are copied or moved into the
+catalog's `files/` tree, and the resulting stored path is recorded in the catalog database
+alongside metadata and naming information.
+
+Records now also include a minimal locator block:
+
+- `record_type`: what kind of artifact the record represents, for example `managed_file`
+- `locator`: how that artifact is located, currently most often a local `path`
+
+For compatibility, managed local files still keep `stored_abspath` and `stored_relpath`. Those
+fields remain the simple path-facing surface for today's workflows while the locator model opens a
+path toward external references, directory-like stores, and future transform targets.
 
 `catalog.json` stores the naming templates and descriptive metadata field definitions so a catalog remains understandable without additional application state. `metadata_fields` are descriptive only today; they are not enforced as typed schemas.
 
 ## Current Limitations
 
 - the only supported backend today is TinyDB behind the repository abstraction
-- records are catalogued files, not yet more general artefacts with other locator types
+- non-file record types are only partially modelled so far; readers, managers, and richer URI
+  handling are still future work
 - derived metadata extraction is intentionally small and currently focused on optional netCDF summaries
 - there are no typed per-record schemas, readers, or manager bindings yet
 - richer readers, managers, and import workflows are future work
@@ -179,4 +195,6 @@ The current direction is:
 - next: generalise from managed files to catalogued artefacts with clearer record typing and locator handling
 - later: typed schemas, reader hooks, manager bindings, and scan or import workflows
 
-See [docs/architecture.md](/Users/bm13805/Documents/ogcat/docs/architecture.md) and [docs/roadmap.md](/Users/bm13805/Documents/ogcat/docs/roadmap.md) for more detail.
+See [docs/architecture.md](/Users/bm13805/Documents/ogcat/docs/architecture.md),
+[docs/design-note-artifact-locators.md](/Users/bm13805/Documents/ogcat/docs/design-note-artifact-locators.md),
+and [docs/roadmap.md](/Users/bm13805/Documents/ogcat/docs/roadmap.md) for more detail.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,6 @@ The current direction is:
 - next: generalise from managed files to catalogued artefacts with clearer record typing and locator handling
 - later: typed schemas, reader hooks, manager bindings, and scan or import workflows
 
-See [docs/architecture.md](/Users/bm13805/Documents/ogcat/docs/architecture.md),
-[docs/design-note-artifact-locators.md](/Users/bm13805/Documents/ogcat/docs/design-note-artifact-locators.md),
-and [docs/roadmap.md](/Users/bm13805/Documents/ogcat/docs/roadmap.md) for more detail.
+See [docs/architecture.md](docs/architecture.md),
+[docs/design-note-artifact-locators.md](docs/design-note-artifact-locators.md),
+and [docs/roadmap.md](docs/roadmap.md) for more detail.

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ ogcat search --catalog ./example-catalog --where derived_metadata.netcdf.dims.ti
 Show a record or print its stored path:
 
 ```bash
-ogcat show rec_000001 --catalog ./example-catalog
-ogcat path rec_000001 --catalog ./example-catalog
+ogcat show 1 --catalog ./example-catalog
+ogcat path 1 --catalog ./example-catalog
 ```
 
 Inspect catalog info and declared metadata fields:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,9 @@
 # Architecture
 
-`ogcat` is a small, spec-driven catalog for managed files. The current implementation is deliberately narrow: it creates a catalog on disk, stores records in a lightweight database, ingests files by copy or move, derives a small amount of metadata when possible, and exposes search through both Python and CLI.
+`ogcat` is a small, spec-driven catalog for managed artifacts, with managed local files as the
+current MVP. The current implementation is deliberately narrow: it creates a catalog on disk,
+stores records in a lightweight database, ingests files by copy or move, derives a small amount of
+metadata when possible, and exposes search through both Python and CLI.
 
 ## Current Architecture
 
@@ -25,6 +28,29 @@ The catalog root is self-describing:
 ```
 
 `catalog.json` defines how the catalog behaves. `db.json` stores records. `files/` is the managed storage root for ingested files.
+
+## First Pass Artifact Generalisation
+
+The current record model now separates two ideas that were previously collapsed into one stored
+path:
+
+- `record_type`: what the catalogued thing is, such as `managed_file`
+- `locator`: how that thing is located, such as a local `path` or a future URI
+
+This is intentionally small. The goal is not to introduce a full abstraction framework, only to
+stop the internal model from assuming every record is a copied or moved local file forever.
+
+For the current MVP:
+
+- `add_file()` still performs managed ingest by copy or move
+- managed file records store a `path` locator
+- compatibility fields `stored_abspath` and `stored_relpath` remain present for today's APIs and
+  CLI
+- `Catalog.path()` resolves only path-backed records and returns `None` for records that are
+  missing or not path-backed
+
+This leaves room for later work on managed directory-like stores, external references, and
+pre-allocated transform targets without forcing those features into the first pass.
 
 ## Why Hide TinyDB Behind a Repository Abstraction
 
@@ -72,7 +98,7 @@ The current derived metadata layer is intentionally small. For netCDF files, if 
 
 The present architecture is intentionally constrained.
 
-- records represent managed files with stored paths; there is no general locator abstraction yet
+- richer locator handling is still future work; today the generalisation is intentionally minimal
 - TinyDB is the only supported backend
 - metadata field descriptions are not typed schemas and are not validated on ingest
 - search supports exact equality, contains, and regex matching only

--- a/docs/design-note-artifact-locators.md
+++ b/docs/design-note-artifact-locators.md
@@ -49,6 +49,10 @@ break in record shape.
 `record_type` and `locator`. That keeps the current managed-file path simple while creating a small
 entry point for future non-file records.
 
+Artifact ids remain present on records and in CLI lookup, but they are now repository-generated.
+With the TinyDB backend, these ids follow TinyDB's document-id sequence. `add_artifact(...)`
+and `add_artifacts(...)` do not accept caller-supplied record ids.
+
 ## Intentionally Out Of Scope
 
 This pass does not implement:

--- a/docs/design-note-artifact-locators.md
+++ b/docs/design-note-artifact-locators.md
@@ -1,0 +1,63 @@
+# Design Note: Artifact Locators
+
+This note describes the first architectural step from "catalogued local files" toward
+"catalogued artifacts".
+
+## Chosen Shape
+
+`CatalogRecord` now has two small additions:
+
+- `record_type`: a short string describing what the record represents
+- `locator`: a small nested block describing how that record is located
+
+The locator shape is intentionally minimal:
+
+```json
+{
+  "kind": "path",
+  "value": "/abs/path/to/object",
+  "relative_path": "files/example.nc"
+}
+```
+
+That is enough to support today's managed local files while leaving room for later locator kinds
+such as URIs.
+
+## Backward Compatibility
+
+Managed local files remain the current default:
+
+- `Catalog.add_file(...)` still copies or moves a local file into the catalog
+- `stored_abspath` and `stored_relpath` are still written for managed local files
+- `Catalog.path(record_id)` still works for managed local files
+
+Older JSON records that do not yet include `record_type` or `locator` are upgraded on read by
+deriving a path locator from `stored_abspath` and `stored_relpath`.
+
+## Why Keep `stored_abspath` and `stored_relpath` For Now
+
+For this pass, the locator becomes the more general concept, but the stored path fields remain as
+compatibility shims for the current MVP. This keeps the code and CLI readable while avoiding a hard
+break in record shape.
+
+## New API Surface
+
+`Catalog.add_file(...)` is now a convenience wrapper around a more general
+`Catalog.add_artifact(...)` method.
+
+`add_artifact(...)` does not perform file operations. It registers a record with an explicit
+`record_type` and `locator`. That keeps the current managed-file path simple while creating a small
+entry point for future non-file records.
+
+## Intentionally Out Of Scope
+
+This pass does not implement:
+
+- reader APIs
+- manager bindings
+- full URI support
+- managed directory-store ingest
+- transform target allocation workflows
+
+Those are future layers that can now be added on top of a record model that is no longer locked to
+copied or moved local files only.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -33,6 +33,14 @@ Why it makes sense:
 - avoids losing per-file fidelity
 - improves usability for monthly-series datasets such as footprints
 
+Related CLI follow-up:
+
+- current CLI search output is still record-oriented
+- future work could add grouped or collapsed search views, especially for
+  monthly file series
+- output modes such as `--paths` may need explicit semantics for mixed
+  path-backed and non-path-backed result sets
+
 ## Collection Records
 
 Another direction is to represent one logical collection instead of one record

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -111,3 +111,62 @@ Examples:
 
 This should stay advisory rather than executable application state. The catalog
 can describe what something is, while higher-level code decides how to open it.
+
+## Follow-Up PR: Repository-Owned Search And Record Identity
+
+This should be treated as a focused architectural cleanup PR.
+
+Problem statement:
+
+- the current repository interface is too thin
+- `Catalog.search(...)` currently loads `repository.all()` and filters in Python
+- that leaks search policy out of the backend layer and prevents backends such
+  as TinyDB, SQLite, or MongoDB from owning query execution
+- `CatalogRecord` currently requires `id`, even though record identity is really
+  assigned by the repository/database layer
+- `allocate_record_ids()` is a workaround for that mismatch and should likely be
+  removed
+
+Preferred direction:
+
+- move search behind the repository interface
+- adopt "option 1" for record identity:
+  - `CatalogRecord.id` becomes optional before persistence
+  - repository `insert(...)` / `insert_many(...)` assign ids
+  - catalog-facing methods return persisted records with ids populated
+
+Suggested scope:
+
+- add a repository search method, likely reusing the current search inputs:
+  - `where`
+  - `contains`
+  - `regex`
+  - `ignore_case`
+- provide a simple backend implementation for TinyDB
+- update `Catalog.search(...)` to delegate to the repository instead of calling
+  `all()` and filtering in Python
+- remove `allocate_record_ids()` from the repository interface
+- update `Catalog.add_file(...)`, `add_artifact(...)`, and `add_artifacts(...)`
+  so they build records without ids and persist them through repository methods
+  that return ids or persisted records
+- keep the public `Catalog` API lightweight
+- avoid introducing a large ORM-like abstraction layer
+
+Questions to resolve in that PR:
+
+- should repository `insert(...)` return the assigned id, or the full persisted
+  `CatalogRecord`?
+- what is the cleanest shape for batch insert return values?
+- how should managed-file naming behave if templates want `{id}` before the
+  record is persisted?
+- should id-based naming remain supported, or should it become discouraged or
+  removed from the default design?
+- how much query expressiveness should the repository interface expose before it
+  becomes too backend-specific?
+
+Desired outcome:
+
+- repository backends own both identity assignment and search execution
+- `CatalogRecord` no longer needs caller-supplied ids
+- the catalog layer becomes thinner and less tied to backend implementation
+  details

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,0 +1,105 @@
+# Ideas
+
+This note collects possible next-step ideas that build on the current artifact
+locator work without committing the core package to them yet.
+
+## Grouped Search Results
+
+Current search returns one record per matching artifact. That is the right base
+behavior for precise file-level lookup, but it can be noisy for datasets that
+are naturally monthly file series.
+
+Possible extension:
+
+- keep one record per file in storage
+- add a helper that groups search results by selected keys such as:
+  - `site`
+  - `inlet`
+  - `model`
+  - `met_model`
+  - `domain`
+  - `species`
+- return summary fields such as:
+  - `record_count`
+  - `start_date_min`
+  - `start_date_max`
+  - `years`
+  - `months`
+  - possible gap information later
+
+Why it makes sense:
+
+- preserves the current simple storage model
+- avoids losing per-file fidelity
+- improves usability for monthly-series datasets such as footprints
+
+## Collection Records
+
+Another direction is to represent one logical collection instead of one record
+per file.
+
+Example:
+
+- one record for `/group/chem/acrg/LPDM/fp_NAME/EUROPE/MHD-10magl/co2/`
+- metadata could include:
+  - `site=MHD`
+  - `inlet=10m`
+  - `model=NAME`
+  - `met_model=UKV`
+  - `domain=EUROPE`
+  - `species=co2`
+  - `file_count`
+  - `start_date`
+  - `end_date`
+  - `file_pattern`
+
+This would likely be a different `record_type`, such as:
+
+- `external_collection`
+- `managed_store`
+
+Why it makes sense:
+
+- better matches "one dataset, many files"
+- leaves room for directory-backed stores and transform outputs
+
+Tradeoff:
+
+- collection records are convenient summaries, but they lose direct one-record
+  per-file visibility unless paired with file-level records or derived indexes
+
+## Non-Path Locators
+
+The current model already leaves room for non-path locators such as URIs, but
+support is intentionally thin.
+
+Examples:
+
+- `s3://bucket/path/to/data.zarr`
+- `gs://bucket/path/to/file.nc`
+- other opaque references that are not local filesystem paths
+
+Possible next steps:
+
+- keep `locator.kind` explicit, for example `path`, `uri`, or another small set
+- preserve non-path values verbatim instead of passing them through `Path(...)`
+- add lightweight helpers for path-backed versus non-path-backed behavior
+- consider optional higher-level integrations with tools such as `fsspec` later
+
+Why it makes sense:
+
+- avoids locking the model to local files only
+- supports cloud or remote references without forcing a heavy abstraction layer
+
+## Reader Hints For Collections
+
+For collection-like artifacts, it may later be useful to attach a lightweight
+reader hint rather than a full plugin system.
+
+Examples:
+
+- `artifact_type="netcdf_monthly_series"`
+- `reader_hint="xarray.open_mfdataset"`
+
+This should stay advisory rather than executable application state. The catalog
+can describe what something is, while higher-level code decides how to open it.

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -33,6 +33,10 @@ Records created by this script include metadata for:
 The current `fp_NAME` tree implies `model=NAME`, but that field is still written
 explicitly so the records remain readable and future comparisons with other LPDM
 models are straightforward.
+
+Run this example from an environment where `ogcat` is installed, for example:
+
+- `pip install -e .`
 """
 
 from __future__ import annotations
@@ -40,18 +44,12 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-SRC_ROOT = REPO_ROOT / "src"
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
 
-from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn  # noqa: E402
-
-from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription  # noqa: E402
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription
 
 FOOTPRINT_FILE_RE = re.compile(
     r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -60,9 +60,9 @@ FOOTPRINT_FILE_RE = re.compile(
     r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"
     r"_(?:(?P<model>NAME|FLEXPART)_)?"
     r"(?:(?P<met_model>[A-Z0-9]+)_)?"
-    r"(?:(?P<domain>[A-Z0-9]+)_(?P<species>[a-z0-9-]+)"
-    r"|(?P<species_first>[a-z0-9-]+)_(?P<domain_last>[A-Z0-9]+)"
-    r"|(?P<domain_only>[A-Z0-9]+))"
+    r"(?:(?P<domain>[A-Za-z0-9-]+)_(?P<species>[a-z0-9-]+)"
+    r"|(?P<species_first>[a-z0-9-]+)_(?P<domain_last>[A-Za-z0-9-]+)"
+    r"|(?P<domain_only>[A-Za-z0-9-]+))"
     r"_(?P<year>\d{4})(?P<month>\d{2})\.nc$"
 )
 
@@ -281,6 +281,8 @@ def build_catalog(
 
     all_paths = list(discovered_paths.values())
     existing_record_number = _max_record_number(catalog)
+    next_record_number = existing_record_number + 1
+    batch_size = 250
     skipped: list[Path] = []
     added_count = 0
     print(f"Discovered {len(all_paths)} candidate NetCDF files.")
@@ -294,6 +296,7 @@ def build_catalog(
     )
     with progress:
         task_id = progress.add_task("Cataloging footprint files", total=len(all_paths))
+        pending_artifacts: list[dict[str, object]] = []
         for index, path in enumerate(all_paths, start=1):
             if index == 1 or index % 250 == 0 or index == len(all_paths):
                 print(
@@ -306,16 +309,28 @@ def build_catalog(
                 progress.advance(task_id)
                 continue
 
-            catalog.add_artifact(
-                record_id=f"rec_{existing_record_number + index:06d}",
-                record_type="external_reference",
-                locator=ArtifactLocator.path(path),
-                metadata=metadata.to_user_metadata(),
-                original_filename=path.name,
-                suffixes=path.suffixes,
+            pending_artifacts.append(
+                {
+                    "record_id": f"rec_{next_record_number:06d}",
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path(path),
+                    "metadata": metadata.to_user_metadata(),
+                    "original_filename": path.name,
+                    "suffixes": path.suffixes,
+                }
             )
-            added_count += 1
+            next_record_number += 1
+
+            if len(pending_artifacts) >= batch_size:
+                catalog.add_artifacts(pending_artifacts)
+                added_count += len(pending_artifacts)
+                pending_artifacts.clear()
+
             progress.advance(task_id)
+
+        if pending_artifacts:
+            catalog.add_artifacts(pending_artifacts)
+            added_count += len(pending_artifacts)
 
     return catalog, added_count, skipped
 

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -275,8 +275,6 @@ def build_catalog(
             discovered_paths[str(path)] = path
 
     all_paths = list(discovered_paths.values())
-    existing_record_number = _max_record_number(catalog)
-    next_record_number = existing_record_number + 1
     batch_size = 250
     skipped: list[Path] = []
     added_count = 0
@@ -306,7 +304,6 @@ def build_catalog(
 
             pending_artifacts.append(
                 {
-                    "record_id": f"rec_{next_record_number:06d}",
                     "record_type": "external_reference",
                     "locator": ArtifactLocator.path(path),
                     "metadata": metadata.to_user_metadata(),
@@ -314,7 +311,6 @@ def build_catalog(
                     "suffixes": path.suffixes,
                 }
             )
-            next_record_number += 1
 
             if len(pending_artifacts) >= batch_size:
                 catalog.add_artifacts(pending_artifacts)
@@ -328,19 +324,6 @@ def build_catalog(
             added_count += len(pending_artifacts)
 
     return catalog, added_count, skipped
-
-
-def _max_record_number(catalog: Catalog) -> int:
-    """Return the largest existing sequential record number in the catalog."""
-    max_number = 0
-    for record in catalog.repository.all():
-        if not record.id.startswith("rec_"):
-            continue
-        try:
-            max_number = max(max_number, int(record.id.split("_", 1)[1]))
-        except ValueError:
-            continue
-    return max_number
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -54,8 +54,6 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, T
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription  # noqa: E402
 
 KNOWN_LPDM_MODELS = {"NAME", "FLEXPART"}
-SITE_INLET_RE = re.compile(r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl$")
-YYYYMM_RE = re.compile(r"^(?P<year>\d{4})(?P<month>\d{2})$")
 FOOTPRINT_FILE_RE = re.compile(
     r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"
     r"_(?:(?P<model>NAME|FLEXPART)_)?"
@@ -298,7 +296,7 @@ def build_catalog(
         task_id = progress.add_task("Cataloging footprint files", total=len(all_paths))
         pending_artifacts: list[dict[str, object]] = []
         for index, path in enumerate(all_paths, start=1):
-            if index == 1 or index % 250 == 0 or index == len(all_paths):
+            if index == 1 or index % batch_size == 0 or index == len(all_paths):
                 print(
                     f"Processing file {index:,} of {len(all_paths):,}: {path.name}",
                     flush=True,

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -53,7 +53,6 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, T
 
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription  # noqa: E402
 
-KNOWN_LPDM_MODELS = {"NAME", "FLEXPART"}
 FOOTPRINT_FILE_RE = re.compile(
     r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"
     r"_(?:(?P<model>NAME|FLEXPART)_)?"

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -49,11 +49,22 @@ SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn  # noqa: E402
+
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription  # noqa: E402
 
 KNOWN_LPDM_MODELS = {"NAME", "FLEXPART"}
 SITE_INLET_RE = re.compile(r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl$")
 YYYYMM_RE = re.compile(r"^(?P<year>\d{4})(?P<month>\d{2})$")
+FOOTPRINT_FILE_RE = re.compile(
+    r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"
+    r"_(?:(?P<model>NAME|FLEXPART)_)?"
+    r"(?:(?P<met_model>[A-Z0-9]+)_)?"
+    r"(?:(?P<domain>[A-Z0-9]+)_(?P<species>[a-z0-9-]+)"
+    r"|(?P<species_first>[a-z0-9-]+)_(?P<domain_last>[A-Z0-9]+)"
+    r"|(?P<domain_only>[A-Z0-9]+))"
+    r"_(?P<year>\d{4})(?P<month>\d{2})\.nc$"
+)
 
 
 @dataclass(slots=True)
@@ -152,60 +163,22 @@ def parse_footprint_path(path: Path, *, default_model: str = "NAME") -> Footprin
         Parsed footprint metadata, or `None` when the file name does not match one
         of the supported footprint patterns.
     """
-    stem_tokens = path.stem.split("_")
-    if len(stem_tokens) < 3:
+    match = FOOTPRINT_FILE_RE.fullmatch(path.name)
+    if match is None:
         return None
 
-    site_inlet_match = SITE_INLET_RE.match(stem_tokens[0])
-    if site_inlet_match is None:
-        return None
-
-    yyyymm_match = YYYYMM_RE.match(stem_tokens[-1])
-    if yyyymm_match is None:
-        return None
-
-    site = site_inlet_match.group("site").upper()
-    inlet = site_inlet_match.group("inlet")
-    year = int(yyyymm_match.group("year"))
-    month = int(yyyymm_match.group("month"))
-
-    model: str
-    met_model: str | None = None
-    domain: str | None = None
-    species: str | None = None
-    middle_tokens = stem_tokens[1:-1]
-
-    if middle_tokens and middle_tokens[0].upper() in KNOWN_LPDM_MODELS:
-        model = middle_tokens[0].upper()
-        remainder = middle_tokens[1:]
-        if len(remainder) == 1:
-            domain = remainder[0].upper()
-        elif len(remainder) == 2:
-            domain = remainder[0].upper()
-            species = remainder[1].lower()
-        elif len(remainder) == 3:
-            met_model = remainder[0].upper()
-            domain = remainder[1].upper()
-            species = remainder[2].lower()
-        else:
-            return None
-    else:
-        model = default_model.upper()
-        if len(middle_tokens) == 1:
-            domain = middle_tokens[0].upper()
-        elif len(middle_tokens) == 2:
-            first_token = middle_tokens[0]
-            if first_token.upper() == first_token:
-                met_model = first_token.upper()
-            else:
-                species = first_token.lower()
-            domain = middle_tokens[1].upper()
-        elif len(middle_tokens) == 3:
-            met_model = middle_tokens[0].upper()
-            species = middle_tokens[1].lower()
-            domain = middle_tokens[2].upper()
-        else:
-            return None
+    site = match.group("site").upper()
+    inlet = match.group("inlet")
+    year = int(match.group("year"))
+    month = int(match.group("month"))
+    model = (match.group("model") or default_model).upper()
+    met_model = match.group("met_model")
+    domain = (
+        match.group("domain")
+        or match.group("domain_last")
+        or match.group("domain_only")
+    )
+    species = match.group("species") or match.group("species_first")
 
     if species is None and path.parent.name != path.parent.name.upper():
         species = path.parent.name.lower()
@@ -306,24 +279,58 @@ def build_catalog(
         for path in discover_paths_from_listing(listing_path):
             discovered_paths[str(path)] = path
 
+    all_paths = list(discovered_paths.values())
+    existing_record_number = _max_record_number(catalog)
     skipped: list[Path] = []
     added_count = 0
-    for path in discovered_paths.values():
-        metadata = parse_footprint_path(path)
-        if metadata is None:
-            skipped.append(path)
-            continue
+    print(f"Discovered {len(all_paths)} candidate NetCDF files.")
 
-        catalog.add_artifact(
-            record_type="external_reference",
-            locator=ArtifactLocator.path(path),
-            metadata=metadata.to_user_metadata(),
-            original_filename=path.name,
-            suffixes=path.suffixes,
-        )
-        added_count += 1
+    progress = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        transient=False,
+    )
+    with progress:
+        task_id = progress.add_task("Cataloging footprint files", total=len(all_paths))
+        for index, path in enumerate(all_paths, start=1):
+            if index == 1 or index % 250 == 0 or index == len(all_paths):
+                print(
+                    f"Processing file {index:,} of {len(all_paths):,}: {path.name}",
+                    flush=True,
+                )
+            metadata = parse_footprint_path(path)
+            if metadata is None:
+                skipped.append(path)
+                progress.advance(task_id)
+                continue
+
+            catalog.add_artifact(
+                record_id=f"rec_{existing_record_number + index:06d}",
+                record_type="external_reference",
+                locator=ArtifactLocator.path(path),
+                metadata=metadata.to_user_metadata(),
+                original_filename=path.name,
+                suffixes=path.suffixes,
+            )
+            added_count += 1
+            progress.advance(task_id)
 
     return catalog, added_count, skipped
+
+
+def _max_record_number(catalog: Catalog) -> int:
+    """Return the largest existing sequential record number in the catalog."""
+    max_number = 0
+    for record in catalog.repository.all():
+        if not record.id.startswith("rec_"):
+            continue
+        try:
+            max_number = max(max_number, int(record.id.split("_", 1)[1]))
+        except ValueError:
+            continue
+    return max_number
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -1,0 +1,387 @@
+"""Create an ogcat catalog for ACRG NAME footprint files on Blue Pebble.
+
+This example catalogs existing footprint files as external path-backed artifacts.
+It uses `Catalog.add_artifact(...)` together with `ArtifactLocator.path(...)`, so
+the files stay where they already live on the shared filesystem. Nothing is
+copied or moved into the catalog.
+
+The script is aimed at the ACRG shared footprint tree on Blue Pebble, for
+example:
+
+- `/group/chem/acrg/LPDM/fp_NAME/EASTASIA/BCOB-10magl/inert/`
+  `BCOB-10magl_NAME_UMG_EASTASIA_inert_202301.nc`
+- `/group/chem/acrg/LPDM/fp_NAME/WESTUSA/SIO-10magl/inert/`
+  `SIO-10magl_NAME_UMG_WESTUSA_inert_202401.nc`
+
+It also supports building the catalog from a saved recursive `ls -R` listing when
+the shared filesystem is not mounted locally. That is useful for development and
+for documenting the structure from a machine that cannot directly read the Blue
+Pebble storage.
+
+Records created by this script include metadata for:
+
+- `site`
+- `inlet`
+- `model`
+- `met_model`
+- `domain`
+- `species`
+- `year`
+- `month`
+- `start_date`
+
+The current `fp_NAME` tree implies `model=NAME`, but that field is still written
+explicitly so the records remain readable and future comparisons with other LPDM
+models are straightforward.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription  # noqa: E402
+
+KNOWN_LPDM_MODELS = {"NAME", "FLEXPART"}
+SITE_INLET_RE = re.compile(r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl$")
+YYYYMM_RE = re.compile(r"^(?P<year>\d{4})(?P<month>\d{2})$")
+
+
+@dataclass(slots=True)
+class FootprintMetadata:
+    """Parsed metadata for one footprint file."""
+
+    site: str
+    inlet: str
+    model: str
+    met_model: str | None
+    domain: str
+    species: str | None
+    year: int
+    month: int
+
+    def to_user_metadata(self) -> dict[str, object]:
+        """Convert parsed metadata into catalog user metadata."""
+        return {
+            "site": self.site,
+            "inlet": self.inlet,
+            "model": self.model,
+            "met_model": self.met_model,
+            "domain": self.domain,
+            "species": self.species,
+            "year": self.year,
+            "month": self.month,
+            "start_date": f"{self.year:04d}-{self.month:02d}-01",
+        }
+
+
+def _metadata_fields() -> list[MetadataFieldDescription]:
+    """Return descriptive metadata fields for the footprint catalog."""
+    return [
+        MetadataFieldDescription(
+            name="site",
+            description="ACRG site code extracted from the footprint filename.",
+            example="BCOB",
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="inlet",
+            description="Inlet height extracted from the footprint filename.",
+            example="10m",
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="model",
+            description="LPDM model name.",
+            example="NAME",
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="met_model",
+            description="Meteorological driver model, when encoded in the filename.",
+            example="UMG",
+        ),
+        MetadataFieldDescription(
+            name="domain",
+            description="Spatial footprint domain.",
+            example="EASTASIA",
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="species",
+            description="Species or footprint flavour, when encoded in the path or filename.",
+            example="inert",
+        ),
+        MetadataFieldDescription(
+            name="year",
+            description="Calendar year for the monthly footprint file.",
+            example=2024,
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="month",
+            description="Calendar month for the monthly footprint file.",
+            example=1,
+            required=True,
+        ),
+        MetadataFieldDescription(
+            name="start_date",
+            description="Convenience monthly start date derived from year and month.",
+            example="2024-01-01",
+        ),
+    ]
+
+
+def parse_footprint_path(path: Path, *, default_model: str = "NAME") -> FootprintMetadata | None:
+    """Parse footprint metadata from a path.
+
+    Args:
+        path: Path to a footprint NetCDF file.
+        default_model: Model to use for legacy filenames that do not encode it.
+
+    Returns:
+        Parsed footprint metadata, or `None` when the file name does not match one
+        of the supported footprint patterns.
+    """
+    stem_tokens = path.stem.split("_")
+    if len(stem_tokens) < 3:
+        return None
+
+    site_inlet_match = SITE_INLET_RE.match(stem_tokens[0])
+    if site_inlet_match is None:
+        return None
+
+    yyyymm_match = YYYYMM_RE.match(stem_tokens[-1])
+    if yyyymm_match is None:
+        return None
+
+    site = site_inlet_match.group("site").upper()
+    inlet = site_inlet_match.group("inlet")
+    year = int(yyyymm_match.group("year"))
+    month = int(yyyymm_match.group("month"))
+
+    model: str
+    met_model: str | None = None
+    domain: str | None = None
+    species: str | None = None
+    middle_tokens = stem_tokens[1:-1]
+
+    if middle_tokens and middle_tokens[0].upper() in KNOWN_LPDM_MODELS:
+        model = middle_tokens[0].upper()
+        remainder = middle_tokens[1:]
+        if len(remainder) == 1:
+            domain = remainder[0].upper()
+        elif len(remainder) == 2:
+            domain = remainder[0].upper()
+            species = remainder[1].lower()
+        elif len(remainder) == 3:
+            met_model = remainder[0].upper()
+            domain = remainder[1].upper()
+            species = remainder[2].lower()
+        else:
+            return None
+    else:
+        model = default_model.upper()
+        if len(middle_tokens) == 1:
+            domain = middle_tokens[0].upper()
+        elif len(middle_tokens) == 2:
+            first_token = middle_tokens[0]
+            if first_token.upper() == first_token:
+                met_model = first_token.upper()
+            else:
+                species = first_token.lower()
+            domain = middle_tokens[1].upper()
+        elif len(middle_tokens) == 3:
+            met_model = middle_tokens[0].upper()
+            species = middle_tokens[1].lower()
+            domain = middle_tokens[2].upper()
+        else:
+            return None
+
+    if species is None and path.parent.name != path.parent.name.upper():
+        species = path.parent.name.lower()
+
+    if domain is None:
+        return None
+
+    return FootprintMetadata(
+        site=site,
+        inlet=inlet,
+        model=model,
+        met_model=met_model,
+        domain=domain,
+        species=species,
+        year=year,
+        month=month,
+    )
+
+
+def discover_paths_from_source_root(source_root: Path) -> list[Path]:
+    """Discover footprint files by scanning the source tree."""
+    return sorted(path for path in source_root.rglob("*.nc") if path.is_file())
+
+
+def discover_paths_from_listing(listing_path: Path) -> list[Path]:
+    """Discover footprint files from a saved recursive directory listing."""
+    listing_text = _read_listing_text(listing_path)
+    current_dir: Path | None = None
+    paths: list[Path] = []
+
+    for raw_line in listing_text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.endswith(":"):
+            current_dir = Path(stripped[:-1])
+            continue
+        if current_dir is None:
+            continue
+        candidate = current_dir / stripped
+        if candidate.suffix == ".nc":
+            paths.append(candidate)
+
+    return sorted(paths)
+
+
+def _read_listing_text(listing_path: Path) -> str:
+    """Read a listing file as text, converting RTF on macOS when possible."""
+    if listing_path.suffix.lower() != ".rtf":
+        return listing_path.read_text(encoding="utf-8")
+
+    try:
+        result = subprocess.run(
+            ["textutil", "-convert", "txt", "-stdout", str(listing_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "RTF listings require `textutil`, or convert the file to plain text first."
+        ) from exc
+
+    return result.stdout
+
+
+def build_catalog(
+    *,
+    catalog_root: Path,
+    source_root: Path | None,
+    listing_path: Path | None,
+    catalog_name: str,
+    append: bool,
+) -> tuple[Catalog, int, list[Path]]:
+    """Build a catalog from a footprint tree or saved listing."""
+    if source_root is None and listing_path is None:
+        raise ValueError("Provide at least one of --source-root or --listing.")
+
+    if (catalog_root / "catalog.json").exists():
+        catalog = Catalog.open(catalog_root)
+        if not append and catalog.describe()["record_count"] != 0:
+            raise ValueError(
+                "Catalog already exists and is not empty. Use --append to add more records."
+            )
+    else:
+        spec = CatalogSpec(
+            catalog_name=catalog_name,
+            metadata_fields=_metadata_fields(),
+        )
+        catalog = Catalog.create(catalog_root, spec)
+
+    discovered_paths: dict[str, Path] = {}
+    if source_root is not None:
+        for path in discover_paths_from_source_root(source_root):
+            discovered_paths[str(path)] = path
+    if listing_path is not None:
+        for path in discover_paths_from_listing(listing_path):
+            discovered_paths[str(path)] = path
+
+    skipped: list[Path] = []
+    added_count = 0
+    for path in discovered_paths.values():
+        metadata = parse_footprint_path(path)
+        if metadata is None:
+            skipped.append(path)
+            continue
+
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator.path(path),
+            metadata=metadata.to_user_metadata(),
+            original_filename=path.name,
+            suffixes=path.suffixes,
+        )
+        added_count += 1
+
+    return catalog, added_count, skipped
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "catalog_root",
+        type=Path,
+        help="Directory where the ogcat catalog should be created.",
+    )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=Path("/group/chem/acrg/LPDM/fp_NAME"),
+        help="Root of the current fp_NAME footprint tree.",
+    )
+    parser.add_argument(
+        "--listing",
+        type=Path,
+        help="Optional plain-text or RTF file containing `ls -R` output.",
+    )
+    parser.add_argument(
+        "--catalog-name",
+        default="acrg-name-footprints",
+        help="Name written into catalog.json.",
+    )
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="Append to an existing non-empty catalog instead of failing.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the example script."""
+    args = parse_args(argv)
+    source_root = args.source_root if args.source_root and args.source_root.exists() else None
+
+    catalog, added_count, skipped = build_catalog(
+        catalog_root=args.catalog_root,
+        source_root=source_root,
+        listing_path=args.listing,
+        catalog_name=args.catalog_name,
+        append=args.append,
+    )
+
+    print(f"Catalog root: {catalog.root}")
+    print(f"Added records: {added_count}")
+    print(f"Total records: {catalog.describe()['record_count']}")
+
+    if skipped:
+        print(f"Skipped {len(skipped)} path(s) that did not match the expected footprint patterns.")
+        for path in skipped[:10]:
+            print(f"  - {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,7 +1,7 @@
 """Public package interface for ogcat."""
 
 from ogcat.catalog import Catalog
-from ogcat.models import CatalogRecord, MetadataFieldDescription
+from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.spec import CatalogSpec
 
-__all__ = ["Catalog", "CatalogRecord", "CatalogSpec", "MetadataFieldDescription"]
+__all__ = ["ArtifactLocator", "Catalog", "CatalogRecord", "CatalogSpec", "MetadataFieldDescription"]

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -271,6 +271,7 @@ class Catalog:
             resolved_original_path = str(original_path)
         else:
             resolved_original_path = original_path
+        locator_path = locator.as_path()
 
         return CatalogRecord(
             id=resolved_record_id,
@@ -278,7 +279,7 @@ class Catalog:
             time_added=resolved_time_added,
             record_type=record_type,
             locator=locator,
-            stored_abspath=str(locator.as_path()) if locator.as_path() is not None else None,
+            stored_abspath=str(locator_path) if locator_path is not None else None,
             stored_relpath=locator.relative_path,
             storage_mode=storage_mode,
             original_path=resolved_original_path,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -42,10 +42,6 @@ class Catalog:
         repository = _open_repository(root_path, spec)
         return cls(root=root_path, spec=spec, repository=repository)
 
-    def _next_record_id(self) -> str:
-        """Generate the next simple sequential record id."""
-        return _format_record_id(_max_record_number(record.id for record in self.repository.all()) + 1)
-
     def add_file(
         self,
         path: str | Path,
@@ -62,7 +58,7 @@ class Catalog:
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
 
-        record_id = self._next_record_id()
+        record_id = self.repository.allocate_record_ids(1)[0]
         timestamp = _utc_timestamp()
         date_added = timestamp[:10]
 
@@ -91,8 +87,8 @@ class Catalog:
         # NOTE: derived metadata is not used for location and filename creation
         derived_metadata = extract_derived_metadata(target)
         locator = ArtifactLocator.path(target, relative_path=rel_path)
-
-        return self.add_artifact(
+        record = self._build_artifact_record(
+            record_id=record_id,
             record_type="managed_file",
             locator=locator,
             metadata=metadata,
@@ -106,9 +102,10 @@ class Catalog:
                 "filename_template": self.spec.filename_template,
                 "resolved_filename": resolved_filename,
             },
-            record_id=record_id,
             time_added=timestamp,
         )
+        self.repository.insert(record)
+        return record
 
     def add_artifact(
         self,
@@ -122,7 +119,6 @@ class Catalog:
         suffixes: list[str] | None = None,
         derived_metadata: MetadataDict | None = None,
         naming_metadata: MetadataDict | None = None,
-        record_id: str | None = None,
         time_added: str | None = None,
     ) -> CatalogRecord:
         """Add an artifact record without performing any file operation.
@@ -132,6 +128,7 @@ class Catalog:
         delegates here.
         """
         record = self._build_artifact_record(
+            record_id=self.repository.allocate_record_ids(1)[0],
             record_type=record_type,
             locator=locator,
             metadata=metadata,
@@ -141,7 +138,6 @@ class Catalog:
             suffixes=suffixes,
             derived_metadata=derived_metadata,
             naming_metadata=naming_metadata,
-            record_id=record_id,
             time_added=time_added,
         )
         self.repository.insert(record)
@@ -160,19 +156,14 @@ class Catalog:
         validated_items = [
             _validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)
         ]
-
-        next_record_number = _max_record_number(record.id for record in self.repository.all()) + 1
-        for validated in validated_items:
-            explicit_record_id = validated.get("record_id")
-            if explicit_record_id is None:
-                continue
-            next_record_number = max(
-                next_record_number,
-                _max_record_number([str(explicit_record_id)]) + 1,
-            )
+        allocated_record_ids = self.repository.allocate_record_ids(len(validated_items))
 
         records: list[CatalogRecord] = []
-        for index, validated in enumerate(validated_items):
+        for record_id, (index, validated) in zip(
+            allocated_record_ids,
+            enumerate(validated_items),
+            strict=True,
+        ):
             try:
                 locator = _coerce_artifact_locator(validated["locator"])
             except TypeError as exc:
@@ -180,13 +171,9 @@ class Catalog:
             except ValueError as exc:
                 raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
 
-            record_id = None if validated.get("record_id") is None else str(validated["record_id"])
-            if record_id is None:
-                record_id = _format_record_id(next_record_number)
-                next_record_number += 1
-
             records.append(
                 self._build_artifact_record(
+                    record_id=record_id,
                     record_type=str(validated["record_type"]),
                     locator=locator,
                     metadata=validated.get("metadata"),  # type: ignore[arg-type]
@@ -204,7 +191,6 @@ class Catalog:
                     suffixes=validated.get("suffixes"),  # type: ignore[arg-type]
                     derived_metadata=validated.get("derived_metadata"),  # type: ignore[arg-type]
                     naming_metadata=validated.get("naming_metadata"),  # type: ignore[arg-type]
-                    record_id=record_id,
                     time_added=(
                         None if validated.get("time_added") is None else str(validated["time_added"])
                     ),
@@ -272,6 +258,7 @@ class Catalog:
     def _build_artifact_record(
         self,
         *,
+        record_id: str,
         record_type: str,
         locator: ArtifactLocator,
         metadata: MetadataDict | None = None,
@@ -281,11 +268,9 @@ class Catalog:
         suffixes: list[str] | None = None,
         derived_metadata: MetadataDict | None = None,
         naming_metadata: MetadataDict | None = None,
-        record_id: str | None = None,
         time_added: str | None = None,
     ) -> CatalogRecord:
         """Build an artifact record without persisting it."""
-        resolved_record_id = record_id or self._next_record_id()
         resolved_time_added = time_added or _utc_timestamp()
         if original_path is None:
             resolved_original_path = None
@@ -296,7 +281,7 @@ class Catalog:
         locator_path = locator.as_path()
 
         return CatalogRecord(
-            id=resolved_record_id,
+            id=record_id,
             catalog=self.spec.catalog_name,
             time_added=resolved_time_added,
             record_type=record_type,
@@ -344,23 +329,7 @@ def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]
     if missing_keys:
         missing = ", ".join(missing_keys)
         raise ValueError(f"artifact batch item {index} is missing required key(s): {missing}")
+    if "record_id" in item:
+        raise ValueError(f"artifact batch item {index} must not supply record_id")
 
     return item
-
-
-def _max_record_number(record_ids: object) -> int:
-    """Return the highest sequential record number from an iterable of ids."""
-    max_number = 0
-    for record_id in record_ids:
-        if not isinstance(record_id, str) or not record_id.startswith("rec_"):
-            continue
-        try:
-            max_number = max(max_number, int(record_id.split("_", 1)[1]))
-        except ValueError:
-            continue
-    return max_number
-
-
-def _format_record_id(number: int) -> str:
-    """Format a sequential record number as the standard record id."""
-    return f"rec_{number:06d}"

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -44,16 +44,7 @@ class Catalog:
 
     def _next_record_id(self) -> str:
         """Generate the next simple sequential record id."""
-        prefix = "rec"
-        existing_ids = [record.id for record in self.repository.all()]
-        max_number = 0
-        for record_id in existing_ids:
-            if record_id.startswith(f"{prefix}_"):
-                try:
-                    max_number = max(max_number, int(record_id.split("_", 1)[1]))
-                except ValueError:
-                    continue
-        return f"{prefix}_{max_number + 1:06d}"
+        return _format_record_id(_max_record_number(record.id for record in self.repository.all()) + 1)
 
     def add_file(
         self,
@@ -166,30 +157,59 @@ class Catalog:
         `add_artifact()`. This keeps the public artifact API small while allowing
         batch-oriented callers to avoid one-at-a-time repository writes.
         """
-        records = [
-            self._build_artifact_record(
-                record_type=str(validated["record_type"]),
-                locator=_coerce_artifact_locator(validated["locator"]),
-                metadata=validated.get("metadata"),  # type: ignore[arg-type]
-                storage_mode=(
-                    None if validated.get("storage_mode") is None else str(validated["storage_mode"])
-                ),
-                original_path=validated.get("original_path"),  # type: ignore[arg-type]
-                original_filename=(
-                    None
-                    if validated.get("original_filename") is None
-                    else str(validated["original_filename"])
-                ),
-                suffixes=validated.get("suffixes"),  # type: ignore[arg-type]
-                derived_metadata=validated.get("derived_metadata"),  # type: ignore[arg-type]
-                naming_metadata=validated.get("naming_metadata"),  # type: ignore[arg-type]
-                record_id=None if validated.get("record_id") is None else str(validated["record_id"]),
-                time_added=None if validated.get("time_added") is None else str(validated["time_added"]),
-            )
-            for validated in (
-                _validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)
-            )
+        validated_items = [
+            _validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)
         ]
+
+        next_record_number = _max_record_number(record.id for record in self.repository.all()) + 1
+        for validated in validated_items:
+            explicit_record_id = validated.get("record_id")
+            if explicit_record_id is None:
+                continue
+            next_record_number = max(
+                next_record_number,
+                _max_record_number([str(explicit_record_id)]) + 1,
+            )
+
+        records: list[CatalogRecord] = []
+        for index, validated in enumerate(validated_items):
+            try:
+                locator = _coerce_artifact_locator(validated["locator"])
+            except TypeError as exc:
+                raise TypeError(f"artifact batch item {index}: invalid locator: {exc}") from exc
+            except ValueError as exc:
+                raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
+
+            record_id = None if validated.get("record_id") is None else str(validated["record_id"])
+            if record_id is None:
+                record_id = _format_record_id(next_record_number)
+                next_record_number += 1
+
+            records.append(
+                self._build_artifact_record(
+                    record_type=str(validated["record_type"]),
+                    locator=locator,
+                    metadata=validated.get("metadata"),  # type: ignore[arg-type]
+                    storage_mode=(
+                        None
+                        if validated.get("storage_mode") is None
+                        else str(validated["storage_mode"])
+                    ),
+                    original_path=validated.get("original_path"),  # type: ignore[arg-type]
+                    original_filename=(
+                        None
+                        if validated.get("original_filename") is None
+                        else str(validated["original_filename"])
+                    ),
+                    suffixes=validated.get("suffixes"),  # type: ignore[arg-type]
+                    derived_metadata=validated.get("derived_metadata"),  # type: ignore[arg-type]
+                    naming_metadata=validated.get("naming_metadata"),  # type: ignore[arg-type]
+                    record_id=record_id,
+                    time_added=(
+                        None if validated.get("time_added") is None else str(validated["time_added"])
+                    ),
+                )
+            )
         self.repository.insert_many(records)
         return records
 
@@ -326,3 +346,21 @@ def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]
         raise ValueError(f"artifact batch item {index} is missing required key(s): {missing}")
 
     return item
+
+
+def _max_record_number(record_ids: object) -> int:
+    """Return the highest sequential record number from an iterable of ids."""
+    max_number = 0
+    for record_id in record_ids:
+        if not isinstance(record_id, str) or not record_id.startswith("rec_"):
+            continue
+        try:
+            max_number = max(max_number, int(record_id.split("_", 1)[1]))
+        except ValueError:
+            continue
+    return max_number
+
+
+def _format_record_id(number: int) -> str:
+    """Format a sequential record number as the standard record id."""
+    return f"rec_{number:06d}"

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -169,7 +169,7 @@ class Catalog:
         records = [
             self._build_artifact_record(
                 record_type=str(item["record_type"]),
-                locator=item["locator"],  # type: ignore[arg-type]
+                locator=_coerce_artifact_locator(item["locator"]),
                 metadata=item.get("metadata"),  # type: ignore[arg-type]
                 storage_mode=(
                     None if item.get("storage_mode") is None else str(item["storage_mode"])
@@ -265,7 +265,12 @@ class Catalog:
         """Build an artifact record without persisting it."""
         resolved_record_id = record_id or self._next_record_id()
         resolved_time_added = time_added or _utc_timestamp()
-        resolved_original_path = None if original_path is None else str(Path(original_path))
+        if original_path is None:
+            resolved_original_path = None
+        elif isinstance(original_path, Path):
+            resolved_original_path = str(original_path)
+        else:
+            resolved_original_path = original_path
 
         return CatalogRecord(
             id=resolved_record_id,
@@ -296,3 +301,12 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     if spec.db_backend != "tinydb":
         raise ValueError(f"Unsupported db_backend: {spec.db_backend}")
     return TinyDbCatalogRepository(root / spec.db_path)
+
+
+def _coerce_artifact_locator(value: object) -> ArtifactLocator:
+    """Coerce a locator value for batch artifact creation."""
+    if isinstance(value, ArtifactLocator):
+        return value
+    if isinstance(value, dict):
+        return ArtifactLocator.from_dict(value)
+    raise TypeError("artifact locator must be an ArtifactLocator or locator dictionary")

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -168,25 +168,27 @@ class Catalog:
         """
         records = [
             self._build_artifact_record(
-                record_type=str(item["record_type"]),
-                locator=_coerce_artifact_locator(item["locator"]),
-                metadata=item.get("metadata"),  # type: ignore[arg-type]
+                record_type=str(validated["record_type"]),
+                locator=_coerce_artifact_locator(validated["locator"]),
+                metadata=validated.get("metadata"),  # type: ignore[arg-type]
                 storage_mode=(
-                    None if item.get("storage_mode") is None else str(item["storage_mode"])
+                    None if validated.get("storage_mode") is None else str(validated["storage_mode"])
                 ),
-                original_path=item.get("original_path"),  # type: ignore[arg-type]
+                original_path=validated.get("original_path"),  # type: ignore[arg-type]
                 original_filename=(
                     None
-                    if item.get("original_filename") is None
-                    else str(item["original_filename"])
+                    if validated.get("original_filename") is None
+                    else str(validated["original_filename"])
                 ),
-                suffixes=item.get("suffixes"),  # type: ignore[arg-type]
-                derived_metadata=item.get("derived_metadata"),  # type: ignore[arg-type]
-                naming_metadata=item.get("naming_metadata"),  # type: ignore[arg-type]
-                record_id=None if item.get("record_id") is None else str(item["record_id"]),
-                time_added=None if item.get("time_added") is None else str(item["time_added"]),
+                suffixes=validated.get("suffixes"),  # type: ignore[arg-type]
+                derived_metadata=validated.get("derived_metadata"),  # type: ignore[arg-type]
+                naming_metadata=validated.get("naming_metadata"),  # type: ignore[arg-type]
+                record_id=None if validated.get("record_id") is None else str(validated["record_id"]),
+                time_added=None if validated.get("time_added") is None else str(validated["time_added"]),
             )
-            for item in artifacts
+            for validated in (
+                _validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)
+            )
         ]
         self.repository.insert_many(records)
         return records
@@ -311,3 +313,16 @@ def _coerce_artifact_locator(value: object) -> ArtifactLocator:
     if isinstance(value, dict):
         return ArtifactLocator.from_dict(value)
     raise TypeError("artifact locator must be an ArtifactLocator or locator dictionary")
+
+
+def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]:
+    """Validate one batch artifact item and return it as a dictionary."""
+    if not isinstance(item, dict):
+        raise TypeError(f"artifact batch item {index} must be a dictionary")
+
+    missing_keys = [key for key in ["record_type", "locator"] if key not in item]
+    if missing_keys:
+        missing = ", ".join(missing_keys)
+        raise ValueError(f"artifact batch item {index} is missing required key(s): {missing}")
+
+    return item

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -140,28 +140,56 @@ class Catalog:
         ingest convenience wrapper that prepares a path-backed locator and then
         delegates here.
         """
-        resolved_record_id = record_id or self._next_record_id()
-        resolved_time_added = time_added or _utc_timestamp()
-        resolved_original_path = None if original_path is None else str(Path(original_path))
-
-        record = CatalogRecord(
-            id=resolved_record_id,
-            catalog=self.spec.catalog_name,
-            time_added=resolved_time_added,
+        record = self._build_artifact_record(
             record_type=record_type,
             locator=locator,
-            stored_abspath=str(locator.as_path()) if locator.as_path() is not None else None,
-            stored_relpath=locator.relative_path,
+            metadata=metadata,
             storage_mode=storage_mode,
-            original_path=resolved_original_path,
+            original_path=original_path,
             original_filename=original_filename,
-            suffixes=[] if suffixes is None else list(suffixes),
-            user_metadata={} if metadata is None else dict(metadata),
-            derived_metadata={} if derived_metadata is None else dict(derived_metadata),
-            naming_metadata={} if naming_metadata is None else dict(naming_metadata),
+            suffixes=suffixes,
+            derived_metadata=derived_metadata,
+            naming_metadata=naming_metadata,
+            record_id=record_id,
+            time_added=time_added,
         )
         self.repository.insert(record)
         return record
+
+    def add_artifacts(
+        self,
+        artifacts: list[dict[str, object]],
+    ) -> list[CatalogRecord]:
+        """Add multiple artifact records.
+
+        Each item should provide the same keyword-style fields accepted by
+        `add_artifact()`. This keeps the public artifact API small while allowing
+        batch-oriented callers to avoid one-at-a-time repository writes.
+        """
+        records = [
+            self._build_artifact_record(
+                record_type=str(item["record_type"]),
+                locator=item["locator"],  # type: ignore[arg-type]
+                metadata=item.get("metadata"),  # type: ignore[arg-type]
+                storage_mode=(
+                    None if item.get("storage_mode") is None else str(item["storage_mode"])
+                ),
+                original_path=item.get("original_path"),  # type: ignore[arg-type]
+                original_filename=(
+                    None
+                    if item.get("original_filename") is None
+                    else str(item["original_filename"])
+                ),
+                suffixes=item.get("suffixes"),  # type: ignore[arg-type]
+                derived_metadata=item.get("derived_metadata"),  # type: ignore[arg-type]
+                naming_metadata=item.get("naming_metadata"),  # type: ignore[arg-type]
+                record_id=None if item.get("record_id") is None else str(item["record_id"]),
+                time_added=None if item.get("time_added") is None else str(item["time_added"]),
+            )
+            for item in artifacts
+        ]
+        self.repository.insert_many(records)
+        return records
 
     def search(
         self,
@@ -218,6 +246,43 @@ class Catalog:
         if record is None:
             return None
         return record.path()
+
+    def _build_artifact_record(
+        self,
+        *,
+        record_type: str,
+        locator: ArtifactLocator,
+        metadata: MetadataDict | None = None,
+        storage_mode: str | None = None,
+        original_path: str | Path | None = None,
+        original_filename: str | None = None,
+        suffixes: list[str] | None = None,
+        derived_metadata: MetadataDict | None = None,
+        naming_metadata: MetadataDict | None = None,
+        record_id: str | None = None,
+        time_added: str | None = None,
+    ) -> CatalogRecord:
+        """Build an artifact record without persisting it."""
+        resolved_record_id = record_id or self._next_record_id()
+        resolved_time_added = time_added or _utc_timestamp()
+        resolved_original_path = None if original_path is None else str(Path(original_path))
+
+        return CatalogRecord(
+            id=resolved_record_id,
+            catalog=self.spec.catalog_name,
+            time_added=resolved_time_added,
+            record_type=record_type,
+            locator=locator,
+            stored_abspath=str(locator.as_path()) if locator.as_path() is not None else None,
+            stored_relpath=locator.relative_path,
+            storage_mode=storage_mode,
+            original_path=resolved_original_path,
+            original_filename=original_filename,
+            suffixes=[] if suffixes is None else list(suffixes),
+            user_metadata={} if metadata is None else dict(metadata),
+            derived_metadata={} if derived_metadata is None else dict(derived_metadata),
+            naming_metadata={} if naming_metadata is None else dict(naming_metadata),
+        )
 
 
 def _utc_timestamp() -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from pathlib import Path
 import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.models import CatalogRecord, MetadataDict
+from ogcat.models import ArtifactLocator, CatalogRecord, MetadataDict
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.repository import CatalogRepository
 from ogcat.search import matches_record
@@ -25,7 +25,7 @@ class Catalog:
     repository: CatalogRepository
 
     @classmethod
-    def create(cls, root: str | Path, spec: CatalogSpec) -> "Catalog":
+    def create(cls, root: str | Path, spec: CatalogSpec) -> Catalog:
         """Create a new catalog directory and write its specification."""
         root_path = Path(root).expanduser().resolve()
         root_path.mkdir(parents=True, exist_ok=True)
@@ -35,7 +35,7 @@ class Catalog:
         return cls(root=root_path, spec=spec, repository=repository)
 
     @classmethod
-    def open(cls, root: str | Path) -> "Catalog":
+    def open(cls, root: str | Path) -> Catalog:
         """Open an existing catalog from disk."""
         root_path = Path(root).expanduser().resolve()
         spec = CatalogSpec.read(root_path / "catalog.json")
@@ -72,8 +72,7 @@ class Catalog:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
 
         record_id = self._next_record_id()
-        timestamp = datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
-        timestamp = timestamp.replace("+00:00", "Z")
+        timestamp = _utc_timestamp()
         date_added = timestamp[:10]
 
         context = build_naming_context(
@@ -98,25 +97,68 @@ class Catalog:
             shutil.move(str(source), str(target))
             storage_mode = "move"
 
+        # NOTE: derived metadata is not used for location and filename creation
         derived_metadata = extract_derived_metadata(target)
+        locator = ArtifactLocator.path(target, relative_path=rel_path)
 
-        record = CatalogRecord(
-            id=record_id,
-            catalog=self.spec.catalog_name,
-            stored_abspath=str(target),
-            stored_relpath=rel_path,
+        return self.add_artifact(
+            record_type="managed_file",
+            locator=locator,
+            metadata=metadata,
             storage_mode=storage_mode,
-            time_added=timestamp,
-            original_path=str(source),
+            original_path=source,
             original_filename=source.name,
             suffixes=source.suffixes,
-            user_metadata=metadata,
             derived_metadata=derived_metadata,
             naming_metadata={
                 "directory_template": self.spec.directory_template,
                 "filename_template": self.spec.filename_template,
                 "resolved_filename": resolved_filename,
             },
+            record_id=record_id,
+            time_added=timestamp,
+        )
+
+    def add_artifact(
+        self,
+        *,
+        record_type: str,
+        locator: ArtifactLocator,
+        metadata: MetadataDict | None = None,
+        storage_mode: str | None = None,
+        original_path: str | Path | None = None,
+        original_filename: str | None = None,
+        suffixes: list[str] | None = None,
+        derived_metadata: MetadataDict | None = None,
+        naming_metadata: MetadataDict | None = None,
+        record_id: str | None = None,
+        time_added: str | None = None,
+    ) -> CatalogRecord:
+        """Add an artifact record without performing any file operation.
+
+        This is the minimal general record API. `add_file()` remains the managed
+        ingest convenience wrapper that prepares a path-backed locator and then
+        delegates here.
+        """
+        resolved_record_id = record_id or self._next_record_id()
+        resolved_time_added = time_added or _utc_timestamp()
+        resolved_original_path = None if original_path is None else str(Path(original_path))
+
+        record = CatalogRecord(
+            id=resolved_record_id,
+            catalog=self.spec.catalog_name,
+            time_added=resolved_time_added,
+            record_type=record_type,
+            locator=locator,
+            stored_abspath=str(locator.as_path()) if locator.as_path() is not None else None,
+            stored_relpath=locator.relative_path,
+            storage_mode=storage_mode,
+            original_path=resolved_original_path,
+            original_filename=original_filename,
+            suffixes=[] if suffixes is None else list(suffixes),
+            user_metadata={} if metadata is None else dict(metadata),
+            derived_metadata={} if derived_metadata is None else dict(derived_metadata),
+            naming_metadata={} if naming_metadata is None else dict(naming_metadata),
         )
         self.repository.insert(record)
         return record
@@ -171,11 +213,17 @@ class Catalog:
         return self.repository.get(record_id)
 
     def path(self, record_id: str) -> Path | None:
-        """Return the stored path for a record, if present."""
+        """Return the stored path for a path-backed record, if present."""
         record = self.get(record_id)
         if record is None:
             return None
-        return Path(record.stored_abspath)
+        return record.path()
+
+
+def _utc_timestamp() -> str:
+    """Return a stable UTC timestamp string for record creation."""
+    timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat()
+    return timestamp.replace("+00:00", "Z")
 
 
 def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -251,7 +251,7 @@ def path(
     record = active_catalog.get(record_id)
     if record is None:
         _fail(f"Record not found: {record_id}")
-    resolved = active_catalog.path(record_id)
+    resolved = record.path()
     if resolved is None:
         _fail(f"Record is not path-backed: {record_id}")
     console.print(str(resolved))

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -178,7 +178,9 @@ def search(
 
     if paths_only:
         for record in results:
-            typer.echo(record.stored_abspath)
+            resolved = record.path()
+            if resolved is not None:
+                typer.echo(str(resolved))
         return
 
     if not results:
@@ -198,7 +200,7 @@ def search(
             str(record.user_metadata.get("title", "")),
             str(record.user_metadata.get("product", "")),
             str(record.user_metadata.get("species", "")),
-            record.stored_abspath,
+            "" if record.path() is None else str(record.path()),
         )
 
     console.print(f"{len(results)} result(s)")

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -15,7 +15,7 @@ from ogcat.catalog import Catalog
 from ogcat.spec import CatalogSpec
 
 app = typer.Typer(
-    help="Lightweight local file catalog.",
+    help="Lightweight artifact catalog with managed file ingest.",
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 console = Console()
@@ -226,9 +226,11 @@ def show(
     table.add_column("value")
     table.add_row("id", record.id)
     table.add_row("catalog", record.catalog)
-    table.add_row("stored path", record.stored_abspath)
-    table.add_row("relative path", record.stored_relpath)
-    table.add_row("storage mode", record.storage_mode)
+    table.add_row("record type", record.record_type)
+    table.add_row("locator", json.dumps(record.locator.to_dict(), sort_keys=True))
+    table.add_row("stored path", str(record.stored_abspath or ""))
+    table.add_row("relative path", str(record.stored_relpath or ""))
+    table.add_row("storage mode", str(record.storage_mode or ""))
     table.add_row("time added", record.time_added)
     table.add_row("original path", str(record.original_path or ""))
     table.add_row("original filename", str(record.original_filename or ""))
@@ -246,9 +248,12 @@ def path(
 ) -> None:
     """Print the stored path for a record."""
     active_catalog = _open_catalog_or_fail(catalog)
+    record = active_catalog.get(record_id)
+    if record is None:
+        _fail(f"Record not found: {record_id}")
     resolved = active_catalog.path(record_id)
     if resolved is None:
-        _fail(f"Record not found: {record_id}")
+        _fail(f"Record is not path-backed: {record_id}")
     console.print(str(resolved))
 
 

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -195,12 +195,13 @@ def search(
     table.add_column("path")
 
     for record in results:
+        resolved_path = record.path()
         table.add_row(
             record.id,
             str(record.user_metadata.get("title", "")),
             str(record.user_metadata.get("product", "")),
             str(record.user_metadata.get("species", "")),
-            "" if record.path() is None else str(record.path()),
+            "" if resolved_path is None else str(resolved_path),
         )
 
     console.print(f"{len(results)} result(s)")

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -69,6 +69,8 @@ class ArtifactLocator:
         """Return the locator as a path when the locator is path-backed."""
         if self.kind != "path":
             return None
+        if not self.value.strip():
+            return None
         return Path(self.value)
 
 
@@ -136,11 +138,12 @@ class CatalogRecord:
             stored_abspath=data.get("stored_abspath"),
             stored_relpath=data.get("stored_relpath"),
         )
+        record_type = data.get("record_type")
         return cls(
             id=str(data["id"]),
             catalog=str(data["catalog"]),
             time_added=str(data["time_added"]),
-            record_type=str(data.get("record_type", "managed_file")),
+            record_type="managed_file" if record_type is None else str(record_type),
             locator=locator,
             stored_abspath=(None if data.get("stored_abspath") is None else str(data["stored_abspath"])),
             stored_relpath=(None if data.get("stored_relpath") is None else str(data["stored_relpath"])),

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import TypeAlias
 
 JsonScalar: TypeAlias = str | int | float | bool | None
@@ -24,7 +25,7 @@ class MetadataFieldDescription:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, JsonValue]) -> "MetadataFieldDescription":
+    def from_dict(cls, data: dict[str, JsonValue]) -> MetadataFieldDescription:
         """Build a field description from a plain dictionary."""
         return cls(
             name=str(data["name"]),
@@ -35,15 +36,54 @@ class MetadataFieldDescription:
 
 
 @dataclass(slots=True)
+class ArtifactLocator:
+    """Minimal locator for a catalogued artifact."""
+
+    kind: str
+    value: str
+    relative_path: str | None = None
+
+    @classmethod
+    def path(cls, path: str | Path, *, relative_path: str | None = None) -> ArtifactLocator:
+        """Build a locator for a local path-backed artifact."""
+        return cls(kind="path", value=str(path), relative_path=relative_path)
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Convert the locator to a plain dictionary."""
+        return {
+            "kind": self.kind,
+            "value": self.value,
+            "relative_path": self.relative_path,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, JsonValue]) -> ArtifactLocator:
+        """Build a locator from a plain dictionary."""
+        return cls(
+            kind=str(data["kind"]),
+            value=str(data["value"]),
+            relative_path=(None if data.get("relative_path") is None else str(data["relative_path"])),
+        )
+
+    def as_path(self) -> Path | None:
+        """Return the locator as a path when the locator is path-backed."""
+        if self.kind != "path":
+            return None
+        return Path(self.value)
+
+
+@dataclass(slots=True)
 class CatalogRecord:
-    """A single catalogued file record."""
+    """A single catalogued artifact record."""
 
     id: str
     catalog: str
-    stored_abspath: str
-    stored_relpath: str
-    storage_mode: str
     time_added: str
+    record_type: str = "managed_file"
+    locator: ArtifactLocator = field(default_factory=lambda: ArtifactLocator(kind="path", value=""))
+    stored_abspath: str | None = None
+    stored_relpath: str | None = None
+    storage_mode: str | None = None
     original_path: str | None = None
     original_filename: str | None = None
     suffixes: list[str] = field(default_factory=list)
@@ -51,11 +91,30 @@ class CatalogRecord:
     derived_metadata: MetadataDict = field(default_factory=dict)
     naming_metadata: MetadataDict = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """Keep compatibility path fields aligned with the locator when possible."""
+        if not self.locator.value and self.stored_abspath is not None:
+            self.locator = ArtifactLocator.path(
+                self.stored_abspath,
+                relative_path=self.stored_relpath,
+            )
+        locator_path = self.locator.as_path()
+        if locator_path is not None and self.stored_abspath is None:
+            self.stored_abspath = str(locator_path)
+        if self.locator.relative_path is not None and self.stored_relpath is None:
+            self.stored_relpath = self.locator.relative_path
+
+    def path(self) -> Path | None:
+        """Return a local path for path-backed records."""
+        return self.locator.as_path()
+
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the record to a plain dictionary."""
         return {
             "id": self.id,
             "catalog": self.catalog,
+            "record_type": self.record_type,
+            "locator": self.locator.to_dict(),
             "stored_abspath": self.stored_abspath,
             "stored_relpath": self.stored_relpath,
             "storage_mode": self.storage_mode,
@@ -69,15 +128,23 @@ class CatalogRecord:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, JsonValue]) -> "CatalogRecord":
+    def from_dict(cls, data: dict[str, JsonValue]) -> CatalogRecord:
         """Build a record from a plain dictionary."""
+        locator_data = data.get("locator")
+        locator = _coerce_locator(
+            locator_data,
+            stored_abspath=data.get("stored_abspath"),
+            stored_relpath=data.get("stored_relpath"),
+        )
         return cls(
             id=str(data["id"]),
             catalog=str(data["catalog"]),
-            stored_abspath=str(data["stored_abspath"]),
-            stored_relpath=str(data["stored_relpath"]),
-            storage_mode=str(data["storage_mode"]),
             time_added=str(data["time_added"]),
+            record_type=str(data.get("record_type", "managed_file")),
+            locator=locator,
+            stored_abspath=(None if data.get("stored_abspath") is None else str(data["stored_abspath"])),
+            stored_relpath=(None if data.get("stored_relpath") is None else str(data["stored_relpath"])),
+            storage_mode=(None if data.get("storage_mode") is None else str(data["storage_mode"])),
             original_path=(None if data.get("original_path") is None else str(data["original_path"])),
             original_filename=(
                 None if data.get("original_filename") is None else str(data["original_filename"])
@@ -87,3 +154,22 @@ class CatalogRecord:
             derived_metadata=dict(data.get("derived_metadata", {})),
             naming_metadata=dict(data.get("naming_metadata", {})),
         )
+
+
+def _coerce_locator(
+    value: JsonValue | None,
+    *,
+    stored_abspath: JsonValue | None,
+    stored_relpath: JsonValue | None,
+) -> ArtifactLocator:
+    """Coerce locator data, including legacy path-only records."""
+    if isinstance(value, ArtifactLocator):
+        return value
+    if isinstance(value, dict):
+        return ArtifactLocator.from_dict(value)
+    if stored_abspath is None:
+        return ArtifactLocator(kind="opaque", value="")
+    return ArtifactLocator.path(
+        str(stored_abspath),
+        relative_path=None if stored_relpath is None else str(stored_relpath),
+    )

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -59,9 +59,14 @@ class ArtifactLocator:
     @classmethod
     def from_dict(cls, data: dict[str, JsonValue]) -> ArtifactLocator:
         """Build a locator from a plain dictionary."""
+        if "kind" not in data:
+            raise ValueError("locator dictionary is missing required key: kind")
+        if "value" not in data:
+            raise ValueError("locator dictionary is missing required key: value")
+        raw_value = data["value"]
         return cls(
             kind=str(data["kind"]),
-            value=str(data["value"]),
+            value="" if raw_value is None else str(raw_value),
             relative_path=(None if data.get("relative_path") is None else str(data["relative_path"])),
         )
 

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -80,7 +80,7 @@ class CatalogRecord:
     catalog: str
     time_added: str
     record_type: str = "managed_file"
-    locator: ArtifactLocator = field(default_factory=lambda: ArtifactLocator(kind="path", value=""))
+    locator: ArtifactLocator = field(default_factory=lambda: ArtifactLocator(kind="opaque", value=""))
     stored_abspath: str | None = None
     stored_relpath: str | None = None
     storage_mode: str | None = None

--- a/src/ogcat/repository.py
+++ b/src/ogcat/repository.py
@@ -10,6 +10,9 @@ from ogcat.models import CatalogRecord
 class CatalogRepository(Protocol):
     """Abstract storage for catalog records."""
 
+    def allocate_record_ids(self, count: int = 1) -> list[str]:
+        """Allocate one or more new record ids."""
+
     def insert(self, record: CatalogRecord) -> None:
         """Insert a new record."""
 

--- a/src/ogcat/repository.py
+++ b/src/ogcat/repository.py
@@ -13,6 +13,9 @@ class CatalogRepository(Protocol):
     def insert(self, record: CatalogRecord) -> None:
         """Insert a new record."""
 
+    def insert_many(self, records: list[CatalogRecord]) -> None:
+        """Insert multiple records."""
+
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
 

--- a/src/ogcat/search.py
+++ b/src/ogcat/search.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import re
-from typing import Any, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ogcat.models import CatalogRecord
-
 
 _RESERVED_FIELDS = {
     "id",
     "catalog",
+    "record_type",
+    "locator",
     "stored_abspath",
     "stored_relpath",
     "storage_mode",

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -1,98 +1,73 @@
-"""TinyDB-backed repository implementation.
-
-This module also includes a small JSON-file fallback so the package remains usable
-in environments where TinyDB is not installed.
-"""
+"""TinyDB-backed repository implementation."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Any
+
+from tinydb import Query, TinyDB
 
 from ogcat.models import CatalogRecord
 
-try:
-    from tinydb import Query, TinyDB  # type: ignore
-except ImportError:  # pragma: no cover
-    Query = None
-    TinyDB = None
-
 
 class TinyDbCatalogRepository:
-    """TinyDB-backed catalog repository with a small JSON fallback."""
+    """TinyDB-backed catalog repository."""
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        if TinyDB is not None:
-            self._db: TinyDB | None = TinyDB(db_path)
-        else:
-            self._db = None
-            if not db_path.exists():
-                db_path.write_text("[]\n", encoding="utf-8")
+        self._db = TinyDB(db_path)
 
-    def _load_json_records(self) -> list[dict[str, Any]]:
-        if self._db is not None:
-            raise RuntimeError("JSON fallback should not be used when TinyDB is available.")
-        return json.loads(self._db_path.read_text(encoding="utf-8"))
-
-    def _write_json_records(self, records: list[dict[str, Any]]) -> None:
-        if self._db is not None:
-            raise RuntimeError("JSON fallback should not be used when TinyDB is available.")
-        self._db_path.write_text(json.dumps(records, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    def allocate_record_ids(self, count: int = 1) -> list[str]:
+        """Allocate one or more new ids aligned with TinyDB doc_ids."""
+        if count < 1:
+            return []
+        start = 1
+        for document in self._db.all():
+            start = max(start, document.doc_id + 1)
+        return [str(number) for number in range(start, start + count)]
 
     def insert(self, record: CatalogRecord) -> None:
         """Insert a new record."""
-        if self._db is not None:
-            self._db.insert(record.to_dict())
-            return
-        records = self._load_json_records()
-        records.append(record.to_dict())
-        self._write_json_records(records)
+        doc_id = self._db.insert(record.to_dict())
+        expected_id = str(doc_id)
+        if record.id != expected_id:
+            raise ValueError(
+                f"Record id {record.id!r} does not match allocated TinyDB doc_id {expected_id!r}"
+            )
 
     def insert_many(self, records: list[CatalogRecord]) -> None:
         """Insert multiple records."""
         if not records:
             return
-        if self._db is not None:
-            self._db.insert_multiple([record.to_dict() for record in records])
-            return
-        existing_records = self._load_json_records()
-        existing_records.extend(record.to_dict() for record in records)
-        self._write_json_records(existing_records)
+        doc_ids = self._db.insert_multiple([record.to_dict() for record in records])
+        expected_ids = [str(doc_id) for doc_id in doc_ids]
+        actual_ids = [record.id for record in records]
+        if actual_ids != expected_ids:
+            raise ValueError(
+                f"Record ids {actual_ids!r} do not match allocated TinyDB doc_ids {expected_ids!r}"
+            )
 
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
-        if self._db is not None:
+        if record_id.isdigit():
+            result = self._db.get(doc_id=int(record_id))
+        else:
             query = Query()
             result = self._db.get(query.id == record_id)
-            if result is None:
-                return None
-            return CatalogRecord.from_dict(result)
-
-        for item in self._load_json_records():
-            if item.get("id") == record_id:
-                return CatalogRecord.from_dict(item)
-        return None
+        if result is None:
+            return None
+        return CatalogRecord.from_dict(result)
 
     def update(self, record: CatalogRecord) -> None:
         """Update an existing record."""
-        if self._db is not None:
+        if record.id.isdigit():
+            updated_doc_ids = self._db.update(record.to_dict(), doc_ids=[int(record.id)])
+        else:
             query = Query()
-            self._db.update(record.to_dict(), query.id == record.id)
-            return
-
-        records = self._load_json_records()
-        for idx, item in enumerate(records):
-            if item.get("id") == record.id:
-                records[idx] = record.to_dict()
-                self._write_json_records(records)
-                return
-        raise KeyError(f"Record not found: {record.id}")
+            updated_doc_ids = self._db.update(record.to_dict(), query.id == record.id)
+        if not updated_doc_ids:
+            raise KeyError(f"Record not found: {record.id}")
 
     def all(self) -> list[CatalogRecord]:
         """Return all records."""
-        if self._db is not None:
-            return [CatalogRecord.from_dict(item) for item in self._db.all()]
-        return [CatalogRecord.from_dict(item) for item in self._load_json_records()]
+        return [CatalogRecord.from_dict(item) for item in self._db.all()]

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -51,6 +51,17 @@ class TinyDbCatalogRepository:
         records.append(record.to_dict())
         self._write_json_records(records)
 
+    def insert_many(self, records: list[CatalogRecord]) -> None:
+        """Insert multiple records."""
+        if not records:
+            return
+        if self._db is not None:
+            self._db.insert_multiple([record.to_dict() for record in records])
+            return
+        existing_records = self._load_json_records()
+        existing_records.extend(record.to_dict() for record in records)
+        self._write_json_records(existing_records)
+
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
         if self._db is not None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -198,7 +198,6 @@ def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
     records = catalog.add_artifacts(
         [
             {
-                "record_id": "rec_000010",
                 "record_type": "external_reference",
                 "locator": ArtifactLocator.path("/tmp/data/first.nc"),
                 "metadata": {"site": "AAA", "month": 1},
@@ -206,7 +205,6 @@ def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
                 "suffixes": [".nc"],
             },
             {
-                "record_id": "rec_000011",
                 "record_type": "external_reference",
                 "locator": ArtifactLocator.path("/tmp/data/second.nc"),
                 "metadata": {"site": "BBB", "month": 2},
@@ -216,10 +214,10 @@ def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
         ]
     )
 
-    assert [record.id for record in records] == ["rec_000010", "rec_000011"]
+    assert [record.id for record in records] == ["1", "2"]
     assert catalog.describe()["record_count"] == 2
-    assert catalog.get("rec_000010") is not None
-    assert catalog.get("rec_000011") is not None
+    assert catalog.get("1") is not None
+    assert catalog.get("2") is not None
 
 
 def test_add_artifacts_accepts_locator_dicts(tmp_path: Path) -> None:
@@ -229,7 +227,6 @@ def test_add_artifacts_accepts_locator_dicts(tmp_path: Path) -> None:
     records = catalog.add_artifacts(
         [
             {
-                "record_id": "rec_000020",
                 "record_type": "external_reference",
                 "locator": {
                     "kind": "path",
@@ -314,5 +311,25 @@ def test_add_artifacts_assigns_sequential_record_ids_when_missing(tmp_path: Path
         ]
     )
 
-    assert first.id == "rec_000001"
-    assert [record.id for record in records] == ["rec_000002", "rec_000003"]
+    assert first.id == "1"
+    assert [record.id for record in records] == ["2", "3"]
+
+def test_add_artifacts_rejects_record_id_in_batch_input(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    try:
+        catalog.add_artifacts(
+            [
+                {
+                    "record_id": "10",
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+                },
+            ]
+        )
+    except ValueError as exc:
+        assert "must not supply record_id" in str(exc)
+        assert "artifact batch item 0" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected record_id rejection for batch input")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -220,3 +220,41 @@ def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
     assert catalog.describe()["record_count"] == 2
     assert catalog.get("rec_000010") is not None
     assert catalog.get("rec_000011") is not None
+
+
+def test_add_artifacts_accepts_locator_dicts(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_id": "rec_000020",
+                "record_type": "external_reference",
+                "locator": {
+                    "kind": "path",
+                    "value": "/tmp/data/third.nc",
+                    "relative_path": None,
+                },
+                "metadata": {"site": "CCC"},
+                "original_filename": "third.nc",
+                "suffixes": [".nc"],
+            }
+        ]
+    )
+
+    assert len(records) == 1
+    assert records[0].locator == ArtifactLocator.path("/tmp/data/third.nc")
+
+
+def test_add_artifact_preserves_non_path_original_path_strings(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        original_path="s3://bucket/source/example.zarr",
+    )
+
+    assert record.original_path == "s3://bucket/source/example.zarr"

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -258,3 +258,16 @@ def test_add_artifact_preserves_non_path_original_path_strings(tmp_path: Path) -
     )
 
     assert record.original_path == "s3://bucket/source/example.zarr"
+
+
+def test_add_artifacts_raises_helpful_error_for_missing_required_keys(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    try:
+        catalog.add_artifacts([{"locator": {"kind": "path", "value": "/tmp/data/file.nc"}}])
+    except ValueError as exc:
+        assert "artifact batch item 0" in str(exc)
+        assert "record_type" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for missing record_type")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ogcat import Catalog, CatalogSpec
+from ogcat import ArtifactLocator, Catalog, CatalogSpec
 
 
 def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
@@ -16,6 +16,8 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
 
     expected = root / "files" / record.time_added[:4] / "example" / "example.nc"
     assert Path(record.stored_abspath) == expected
+    assert record.record_type == "managed_file"
+    assert record.locator == ArtifactLocator.path(expected, relative_path=record.stored_relpath)
     assert expected.exists()
     assert record.original_filename == "example.nc"
     assert record.suffixes == [".nc"]
@@ -170,3 +172,20 @@ def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -
 
     assert Path(first_record.stored_abspath).name == "bundle.tar.gz"
     assert Path(second_record.stored_abspath).name == "bundle_2.tar.gz"
+
+
+def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2"},
+    )
+
+    assert record.record_type == "external_reference"
+    assert record.locator.kind == "uri"
+    assert record.locator.value == "s3://bucket/example.zarr"
+    assert record.stored_abspath is None
+    assert catalog.path(record.id) is None

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -271,3 +271,48 @@ def test_add_artifacts_raises_helpful_error_for_missing_required_keys(tmp_path: 
         assert "record_type" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Expected ValueError for missing record_type")
+
+
+def test_add_artifacts_raises_helpful_error_for_invalid_locator(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    try:
+        catalog.add_artifacts(
+            [
+                {
+                    "record_type": "external_reference",
+                    "locator": {"kind": "path", "relative_path": None},
+                }
+            ]
+        )
+    except Exception as exc:
+        assert "artifact batch item 0" in str(exc)
+        assert "invalid locator" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected locator validation error")
+
+
+def test_add_artifacts_assigns_sequential_record_ids_when_missing(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+    first = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator.path("/tmp/data/existing.nc"),
+    )
+
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+            },
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator.path("/tmp/data/second.nc"),
+            },
+        ]
+    )
+
+    assert first.id == "rec_000001"
+    assert [record.id for record in records] == ["rec_000002", "rec_000003"]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -189,3 +189,34 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
     assert record.locator.value == "s3://bucket/example.zarr"
     assert record.stored_abspath is None
     assert catalog.path(record.id) is None
+
+
+def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_id": "rec_000010",
+                "record_type": "external_reference",
+                "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+                "metadata": {"site": "AAA", "month": 1},
+                "original_filename": "first.nc",
+                "suffixes": [".nc"],
+            },
+            {
+                "record_id": "rec_000011",
+                "record_type": "external_reference",
+                "locator": ArtifactLocator.path("/tmp/data/second.nc"),
+                "metadata": {"site": "BBB", "month": 2},
+                "original_filename": "second.nc",
+                "suffixes": [".nc"],
+            },
+        ]
+    )
+
+    assert [record.id for record in records] == ["rec_000010", "rec_000011"]
+    assert catalog.describe()["record_count"] == 2
+    assert catalog.get("rec_000010") is not None
+    assert catalog.get("rec_000011") is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,8 @@ def test_show_json_output(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["id"] == "rec_000001"
+    assert payload["record_type"] == "managed_file"
+    assert payload["locator"]["kind"] == "path"
     assert payload["user_metadata"]["title"] == "Anthropogenic test flux"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 
 from ogcat import Catalog, CatalogSpec, MetadataFieldDescription
 from ogcat.cli import app
-
+from ogcat.models import ArtifactLocator
 
 runner = CliRunner()
 
@@ -191,3 +191,40 @@ def test_missing_catalog_configuration_returns_helpful_error() -> None:
 
     assert result.exit_code != 0
     assert "Provide --catalog or set OGCAT_CATALOG." in result.stderr
+
+
+def test_search_paths_skips_non_path_backed_records(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    source = tmp_path / "source.nc"
+    source.write_text("dummy", encoding="utf-8")
+    catalog.add_file(source, metadata={"species": "CO2"})
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2"},
+    )
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--paths"],
+    )
+
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert lines[0].endswith("source.nc")
+
+
+def test_search_human_output_uses_empty_path_for_non_path_backed_records(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2", "title": "Remote artifact"},
+    )
+
+    result = runner.invoke(app, ["search", "--catalog", str(catalog.root), "--where", "species=CO2"])
+
+    assert result.exit_code == 0
+    assert "Remote artifact" in result.stdout
+    assert "None" not in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,7 @@ def _create_catalog(tmp_path: Path, *, with_fields: bool = True) -> Catalog:
 
 def test_search_json_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
 
     result = runner.invoke(
         app,
@@ -58,18 +59,19 @@ def test_search_json_output(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert [item["id"] for item in payload] == ["rec_000001"]
+    assert [item["id"] for item in payload] == [record.id]
     assert payload[0]["user_metadata"]["species"] == "CO2"
 
 
 def test_show_json_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
 
-    result = runner.invoke(app, ["show", "rec_000001", "--catalog", str(catalog.root), "--json"])
+    result = runner.invoke(app, ["show", record.id, "--catalog", str(catalog.root), "--json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert payload["id"] == "rec_000001"
+    assert payload["id"] == record.id
     assert payload["record_type"] == "managed_file"
     assert payload["locator"]["kind"] == "path"
     assert payload["user_metadata"]["title"] == "Anthropogenic test flux"
@@ -149,7 +151,7 @@ def test_add_accepts_multiple_metadata_items_after_single_meta_flag(tmp_path: Pa
     )
 
     assert result.exit_code == 0
-    record = Catalog.open(catalog.root).get("rec_000001")
+    record = Catalog.open(catalog.root).get("1")
     assert record is not None
     assert record.user_metadata == {"species": "CO2", "product": "CTE-HR", "version": "v4.2"}
 
@@ -172,7 +174,7 @@ def test_add_accepts_json_object_metadata(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    record = Catalog.open(catalog.root).get("rec_000001")
+    record = Catalog.open(catalog.root).get("1")
     assert record is not None
     assert record.user_metadata == {"species": "CO2", "month": 1}
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from ogcat.models import CatalogRecord
+import json
+from pathlib import Path
+
+from ogcat.models import ArtifactLocator, CatalogRecord
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
 
@@ -11,10 +14,14 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
     record = CatalogRecord(
         id="rec_000001",
         catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        locator=ArtifactLocator.path(
+            "/tmp/catalog/files/example.nc",
+            relative_path="files/example.nc",
+        ),
         stored_abspath="/tmp/catalog/files/example.nc",
         stored_relpath="files/example.nc",
         storage_mode="copy",
-        time_added="2026-04-23T12:00:00Z",
         original_path="/tmp/source/example.nc",
         original_filename="example.nc",
         suffixes=[".nc"],
@@ -32,10 +39,12 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
     updated = CatalogRecord(
         id=record.id,
         catalog=record.catalog,
+        time_added=record.time_added,
+        record_type=record.record_type,
+        locator=record.locator,
         stored_abspath=record.stored_abspath,
         stored_relpath=record.stored_relpath,
         storage_mode=record.storage_mode,
-        time_added=record.time_added,
         original_path=record.original_path,
         original_filename=record.original_filename,
         suffixes=record.suffixes,
@@ -46,3 +55,68 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
     repository.update(updated)
 
     assert repository.get(record.id) == updated
+
+
+def test_record_round_trips_with_non_path_locator(tmp_path: Path) -> None:
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    record = CatalogRecord(
+        id="rec_000002",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        user_metadata={"species": "CO2"},
+    )
+
+    repository.insert(record)
+
+    stored = repository.get(record.id)
+    assert stored == record
+    assert stored is not None
+    assert stored.path() is None
+
+
+def test_from_dict_upgrades_legacy_path_only_records() -> None:
+    record = CatalogRecord.from_dict(
+        {
+            "id": "rec_000003",
+            "catalog": "fluxes",
+            "stored_abspath": "/tmp/catalog/files/example.nc",
+            "stored_relpath": "files/example.nc",
+            "storage_mode": "copy",
+            "time_added": "2026-04-23T12:00:00Z",
+            "original_path": "/tmp/source/example.nc",
+            "original_filename": "example.nc",
+            "suffixes": [".nc"],
+            "user_metadata": {},
+            "derived_metadata": {},
+            "naming_metadata": {},
+        }
+    )
+
+    assert record.record_type == "managed_file"
+    assert record.locator == ArtifactLocator.path(
+        "/tmp/catalog/files/example.nc",
+        relative_path="files/example.nc",
+    )
+    assert record.path() == Path("/tmp/catalog/files/example.nc")
+
+
+def test_record_to_dict_stays_json_serialisable() -> None:
+    record = CatalogRecord(
+        id="rec_000004",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        user_metadata={"species": "CO2"},
+    )
+
+    payload = record.to_dict()
+
+    assert payload["locator"] == {
+        "kind": "uri",
+        "value": "s3://bucket/example.zarr",
+        "relative_path": None,
+    }
+    assert json.loads(json.dumps(payload)) == payload

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -151,3 +151,31 @@ def test_record_without_locator_does_not_resolve_to_current_directory() -> None:
 
     assert record.stored_abspath is None
     assert record.path() is None
+
+
+def test_empty_path_locator_does_not_resolve_to_current_directory() -> None:
+    locator = ArtifactLocator(kind="path", value="  ")
+
+    assert locator.as_path() is None
+
+
+def test_from_dict_defaults_null_record_type_to_managed_file() -> None:
+    record = CatalogRecord.from_dict(
+        {
+            "id": "rec_000100",
+            "catalog": "fluxes",
+            "record_type": None,
+            "stored_abspath": "/tmp/catalog/files/example.nc",
+            "stored_relpath": "files/example.nc",
+            "storage_mode": "copy",
+            "time_added": "2026-04-23T12:00:00Z",
+            "original_path": "/tmp/source/example.nc",
+            "original_filename": "example.nc",
+            "suffixes": [".nc"],
+            "user_metadata": {},
+            "derived_metadata": {},
+            "naming_metadata": {},
+        }
+    )
+
+    assert record.record_type == "managed_file"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -159,6 +159,13 @@ def test_empty_path_locator_does_not_resolve_to_current_directory() -> None:
     assert locator.as_path() is None
 
 
+def test_locator_from_dict_treats_null_value_as_empty() -> None:
+    locator = ArtifactLocator.from_dict({"kind": "path", "value": None, "relative_path": None})
+
+    assert locator.value == ""
+    assert locator.as_path() is None
+
+
 def test_from_dict_defaults_null_record_type_to_managed_file() -> None:
     record = CatalogRecord.from_dict(
         {

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -140,3 +140,14 @@ def test_repository_insert_many(tmp_path: Path) -> None:
     repository.insert_many(records)
 
     assert repository.all() == records
+
+
+def test_record_without_locator_does_not_resolve_to_current_directory() -> None:
+    record = CatalogRecord(
+        id="rec_000099",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+    )
+
+    assert record.stored_abspath is None
+    assert record.path() is None

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -12,7 +12,7 @@ from ogcat.tinydb_repository import TinyDbCatalogRepository
 def test_repository_insert_get_update_and_all(tmp_path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     record = CatalogRecord(
-        id="rec_000001",
+        id="1",
         catalog="fluxes",
         time_added="2026-04-23T12:00:00Z",
         locator=ArtifactLocator.path(
@@ -60,7 +60,7 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
 def test_record_round_trips_with_non_path_locator(tmp_path: Path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     record = CatalogRecord(
-        id="rec_000002",
+        id="1",
         catalog="fluxes",
         time_added="2026-04-23T12:00:00Z",
         record_type="external_reference",
@@ -126,7 +126,7 @@ def test_repository_insert_many(tmp_path: Path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     records = [
         CatalogRecord(
-            id="rec_000010",
+            id=str(index + 1),
             catalog="fluxes",
             time_added="2026-04-23T12:00:00Z",
             record_type="external_reference",
@@ -140,6 +140,22 @@ def test_repository_insert_many(tmp_path: Path) -> None:
     repository.insert_many(records)
 
     assert repository.all() == records
+
+
+def test_repository_allocate_record_ids(tmp_path: Path) -> None:
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    assert repository.allocate_record_ids(2) == ["1", "2"]
+
+    repository.insert(
+        CatalogRecord(
+            id="1",
+            catalog="fluxes",
+            time_added="2026-04-23T12:00:00Z",
+            locator=ArtifactLocator.path("/tmp/catalog/files/example.nc"),
+        )
+    )
+
+    assert repository.allocate_record_ids(2) == ["2", "3"]
 
 
 def test_record_without_locator_does_not_resolve_to_current_directory() -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -120,3 +120,23 @@ def test_record_to_dict_stays_json_serialisable() -> None:
         "relative_path": None,
     }
     assert json.loads(json.dumps(payload)) == payload
+
+
+def test_repository_insert_many(tmp_path: Path) -> None:
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    records = [
+        CatalogRecord(
+            id="rec_000010",
+            catalog="fluxes",
+            time_added="2026-04-23T12:00:00Z",
+            record_type="external_reference",
+            locator=ArtifactLocator.path(f"/tmp/catalog/files/example-{index}.nc"),
+            original_filename=f"example-{index}.nc",
+            suffixes=[".nc"],
+        )
+        for index in range(3)
+    ]
+
+    repository.insert_many(records)
+
+    assert repository.all() == records


### PR DESCRIPTION
To generalise storage beyond moving or copying files on a local filesystem, a `ArtifactLocator` class has been added. As a special case, it handles filepaths. `Catalog.add_file` is now written in terms of `Catalog.add_artifact`.

An example script that creates a catalog for the NAME footprints on Blue Pebble was added.