### PR TITLE
Implement repository-owned IDs and search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install package
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -e ".[dev]"
+
+      - name: Check formatting
+        run: .venv/bin/ruff format --check .
+
+      - name: Lint
+        run: .venv/bin/ruff check .
+
+      - name: Test
+        run: .venv/bin/pytest
+
+      - name: Type check
+        run: .venv/bin/pyright

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -168,11 +168,7 @@ def parse_footprint_path(path: Path, *, default_model: str = "NAME") -> Footprin
     month = int(match.group("month"))
     model = (match.group("model") or default_model).upper()
     met_model = match.group("met_model")
-    domain = (
-        match.group("domain")
-        or match.group("domain_last")
-        or match.group("domain_only")
-    )
+    domain = match.group("domain") or match.group("domain_last") or match.group("domain_only")
     species = match.group("species") or match.group("species_first")
 
     if species is None and path.parent.name != path.parent.name.upper():
@@ -256,9 +252,7 @@ def build_catalog(
     if (catalog_root / "catalog.json").exists():
         catalog = Catalog.open(catalog_root)
         if not append and catalog.describe()["record_count"] != 0:
-            raise ValueError(
-                "Catalog already exists and is not empty. Use --append to add more records."
-            )
+            raise ValueError("Catalog already exists and is not empty. Use --append to add more records.")
     else:
         spec = CatalogSpec(
             catalog_name=catalog_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,5 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 include = ["src", "tests"]
 pythonVersion = "3.11"
 typeCheckingMode = "basic"
+venvPath = "."
+venv = ".venv"

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -116,7 +116,9 @@ class Catalog:
             self.repository.update(record)
             return record
         except Exception:
-            with suppress(Exception):
+            with suppress(FileNotFoundError):
+                target.unlink()
+            with suppress(KeyError):
                 self.repository.delete(record_id)
             raise
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import shutil
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.models import ArtifactLocator, CatalogRecord, MetadataDict
+from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.repository import CatalogRepository
-from ogcat.search import matches_record
 from ogcat.spec import CatalogSpec
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
@@ -50,17 +50,25 @@ class Catalog:
     ) -> CatalogRecord:
         """Add a file to the catalog using managed copy or move."""
         source = Path(path).expanduser().resolve()
-        if not source.is_file():
-            raise FileNotFoundError(f"Source file does not exist: {source}")
-
         metadata = metadata or {}
         chosen_operation = operation or self.spec.default_operation
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
 
-        record_id = self.repository.allocate_record_ids(1)[0]
         timestamp = _utc_timestamp()
         date_added = timestamp[:10]
+        draft_record = self._build_artifact_record(
+            record_type="managed_file",
+            locator=ArtifactLocator(kind="opaque", value=""),
+            metadata=metadata,
+            storage_mode=chosen_operation,
+            original_path=source,
+            original_filename=source.name,
+            suffixes=source.suffixes,
+            time_added=timestamp,
+        )
+        persisted_record = self.repository.insert(draft_record)
+        record_id = _require_record_id(persisted_record)
 
         context = build_naming_context(
             record_id=record_id,
@@ -77,35 +85,40 @@ class Catalog:
         )
         target.parent.mkdir(parents=True, exist_ok=True)
 
-        if chosen_operation == "copy":
-            shutil.copy2(source, target)
-            storage_mode = "copy"
-        else:
-            shutil.move(str(source), str(target))
-            storage_mode = "move"
+        try:
+            if chosen_operation == "copy":
+                shutil.copy2(source, target)
+                storage_mode = "copy"
+            else:
+                shutil.move(str(source), str(target))
+                storage_mode = "move"
 
-        # NOTE: derived metadata is not used for location and filename creation
-        derived_metadata = extract_derived_metadata(target)
-        locator = ArtifactLocator.path(target, relative_path=rel_path)
-        record = self._build_artifact_record(
-            record_id=record_id,
-            record_type="managed_file",
-            locator=locator,
-            metadata=metadata,
-            storage_mode=storage_mode,
-            original_path=source,
-            original_filename=source.name,
-            suffixes=source.suffixes,
-            derived_metadata=derived_metadata,
-            naming_metadata={
-                "directory_template": self.spec.directory_template,
-                "filename_template": self.spec.filename_template,
-                "resolved_filename": resolved_filename,
-            },
-            time_added=timestamp,
-        )
-        self.repository.insert(record)
-        return record
+            # NOTE: derived metadata is not used for location and filename creation
+            derived_metadata = extract_derived_metadata(target)
+            locator = ArtifactLocator.path(target, relative_path=rel_path)
+            record = self._build_artifact_record(
+                record_id=record_id,
+                record_type="managed_file",
+                locator=locator,
+                metadata=metadata,
+                storage_mode=storage_mode,
+                original_path=source,
+                original_filename=source.name,
+                suffixes=source.suffixes,
+                derived_metadata=derived_metadata,
+                naming_metadata={
+                    "directory_template": self.spec.directory_template,
+                    "filename_template": self.spec.filename_template,
+                    "resolved_filename": resolved_filename,
+                },
+                time_added=timestamp,
+            )
+            self.repository.update(record)
+            return record
+        except Exception:
+            with suppress(Exception):
+                self.repository.delete(record_id)
+            raise
 
     def add_artifact(
         self,
@@ -128,7 +141,6 @@ class Catalog:
         delegates here.
         """
         record = self._build_artifact_record(
-            record_id=self.repository.allocate_record_ids(1)[0],
             record_type=record_type,
             locator=locator,
             metadata=metadata,
@@ -140,8 +152,7 @@ class Catalog:
             naming_metadata=naming_metadata,
             time_added=time_added,
         )
-        self.repository.insert(record)
-        return record
+        return self.repository.insert(record)
 
     def add_artifacts(
         self,
@@ -153,17 +164,10 @@ class Catalog:
         `add_artifact()`. This keeps the public artifact API small while allowing
         batch-oriented callers to avoid one-at-a-time repository writes.
         """
-        validated_items = [
-            _validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)
-        ]
-        allocated_record_ids = self.repository.allocate_record_ids(len(validated_items))
+        validated_items = [_validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)]
 
         records: list[CatalogRecord] = []
-        for record_id, (index, validated) in zip(
-            allocated_record_ids,
-            enumerate(validated_items),
-            strict=True,
-        ):
+        for index, validated in enumerate(validated_items):
             try:
                 locator = _coerce_artifact_locator(validated["locator"])
             except TypeError as exc:
@@ -173,14 +177,11 @@ class Catalog:
 
             records.append(
                 self._build_artifact_record(
-                    record_id=record_id,
                     record_type=str(validated["record_type"]),
                     locator=locator,
                     metadata=validated.get("metadata"),  # type: ignore[arg-type]
                     storage_mode=(
-                        None
-                        if validated.get("storage_mode") is None
-                        else str(validated["storage_mode"])
+                        None if validated.get("storage_mode") is None else str(validated["storage_mode"])
                     ),
                     original_path=validated.get("original_path"),  # type: ignore[arg-type]
                     original_filename=(
@@ -196,8 +197,7 @@ class Catalog:
                     ),
                 )
             )
-        self.repository.insert_many(records)
-        return records
+        return self.repository.insert_many(records)
 
     def search(
         self,
@@ -208,19 +208,13 @@ class Catalog:
         ignore_case: bool = False,
     ) -> list[CatalogRecord]:
         """Search catalog records using equality, substring, and regex filters."""
-        records = self.repository.all()
-        return [
-            record
-            for record in records
-            if matches_record(
-                record,
-                where=where,
-                contains=contains,
-                regex=regex,
-                ignore_case=ignore_case,
-                resolution_order=self.spec.field_resolution_order,
-            )
-        ]
+        return self.repository.search(
+            where=where,
+            contains=contains,
+            regex=regex,
+            ignore_case=ignore_case,
+            resolution_order=self.spec.field_resolution_order,
+        )
 
     def describe(self) -> dict[str, object]:
         """Return a simple serialisable summary of the catalog."""
@@ -240,7 +234,7 @@ class Catalog:
             "has_metadata_fields": bool(self.spec.metadata_fields),
         }
 
-    def list_metadata_fields(self) -> list[dict[str, object]]:
+    def list_metadata_fields(self) -> list[dict[str, JsonValue]]:
         """Return serialisable metadata field descriptions."""
         return [field_description.to_dict() for field_description in self.spec.metadata_fields]
 
@@ -258,7 +252,7 @@ class Catalog:
     def _build_artifact_record(
         self,
         *,
-        record_id: str,
+        record_id: str | None = None,
         record_type: str,
         locator: ArtifactLocator,
         metadata: MetadataDict | None = None,
@@ -329,7 +323,16 @@ def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]
     if missing_keys:
         missing = ", ".join(missing_keys)
         raise ValueError(f"artifact batch item {index} is missing required key(s): {missing}")
-    if "record_id" in item:
-        raise ValueError(f"artifact batch item {index} must not supply record_id")
+    forbidden_id_keys = [key for key in ["record_id", "id"] if key in item]
+    if forbidden_id_keys:
+        forbidden = ", ".join(forbidden_id_keys)
+        raise ValueError(f"artifact batch item {index} must not supply {forbidden}")
 
     return item
+
+
+def _require_record_id(record: CatalogRecord) -> str:
+    """Return a persisted record id."""
+    if record.id is None:
+        raise RuntimeError("Repository returned a persisted record without an id.")
+    return record.id

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -116,9 +116,10 @@ class Catalog:
             self.repository.update(record)
             return record
         except Exception:
-            with suppress(FileNotFoundError):
-                target.unlink()
-            with suppress(KeyError):
+            if chosen_operation == "copy":
+                with suppress(Exception):
+                    target.unlink()
+            with suppress(Exception):
                 self.repository.delete(record_id)
             raise
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -70,22 +70,23 @@ class Catalog:
         persisted_record = self.repository.insert(draft_record)
         record_id = _require_record_id(persisted_record)
 
-        context = build_naming_context(
-            record_id=record_id,
-            original_path=source,
-            metadata=metadata,
-            date_added=date_added,
-        )
-        files_root = self.root / self.spec.files_root
-        target, rel_path, resolved_filename = render_storage_location(
-            files_root=files_root,
-            directory_template=self.spec.directory_template,
-            filename_template=self.spec.filename_template,
-            context=context,
-        )
-        target.parent.mkdir(parents=True, exist_ok=True)
-
+        target: Path | None = None
         try:
+            context = build_naming_context(
+                record_id=record_id,
+                original_path=source,
+                metadata=metadata,
+                date_added=date_added,
+            )
+            files_root = self.root / self.spec.files_root
+            target, rel_path, resolved_filename = render_storage_location(
+                files_root=files_root,
+                directory_template=self.spec.directory_template,
+                filename_template=self.spec.filename_template,
+                context=context,
+            )
+            target.parent.mkdir(parents=True, exist_ok=True)
+
             if chosen_operation == "copy":
                 shutil.copy2(source, target)
                 storage_mode = "copy"
@@ -116,7 +117,7 @@ class Catalog:
             self.repository.update(record)
             return record
         except Exception:
-            if chosen_operation == "copy":
+            if chosen_operation == "copy" and target is not None:
                 with suppress(Exception):
                     target.unlink()
             with suppress(Exception):

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, NoReturn
 
 import typer
 from rich.console import Console
@@ -32,7 +32,7 @@ def _resolve_catalog_path(catalog: Path | None) -> Path:
     raise typer.BadParameter("Provide --catalog or set OGCAT_CATALOG.")
 
 
-def _fail(message: str, *, code: int = 1) -> None:
+def _fail(message: str, *, code: int = 1) -> NoReturn:
     """Print a consistent error message and exit."""
     error_console.print(f"Error: {message}")
     raise typer.Exit(code=code)
@@ -107,8 +107,8 @@ def _parse_key_value_options(items: list[str]) -> dict[str, str]:
 
 @app.command()
 def init(
-    root: Path = typer.Argument(..., help="Catalog root directory."),
-    name: str = typer.Option(..., "--name", help="Catalog name."),
+    root: Annotated[Path, typer.Argument(help="Catalog root directory.")],
+    name: Annotated[str, typer.Option("--name", help="Catalog name.")],
 ) -> None:
     """Create a new catalog."""
     spec = CatalogSpec(catalog_name=name)
@@ -122,48 +122,70 @@ def init(
 )
 def add_command(
     ctx: typer.Context,
-    path: Path = typer.Argument(..., help="Source file to add."),
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
-    meta: list[str] = typer.Option(
-        [],
-        "--meta",
-        help="Metadata item KEY=VALUE. Repeatable. Additional KEY=VALUE items may follow a single --meta.",
-    ),
-    operation: str | None = typer.Option(None, "--operation", help="copy or move."),
+    path: Annotated[Path, typer.Argument(help="Source file to add.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    meta: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--meta",
+            help=(
+                "Metadata item KEY=VALUE. Repeatable. Additional KEY=VALUE items may follow a single --meta."
+            ),
+        ),
+    ] = None,
+    operation: Annotated[str | None, typer.Option("--operation", help="copy or move.")] = None,
 ) -> None:
     """Add a file to the catalog."""
     extra_meta_items = list(ctx.args)
-    if extra_meta_items and not meta:
-        raise typer.BadParameter(
-            "Unexpected extra arguments. Use --meta KEY=VALUE to supply metadata."
-        )
+    meta_items = [] if meta is None else meta
+    if extra_meta_items and not meta_items:
+        raise typer.BadParameter("Unexpected extra arguments. Use --meta KEY=VALUE to supply metadata.")
 
     active_catalog = _open_catalog_or_fail(catalog)
-    metadata = _parse_meta_items([*meta, *extra_meta_items])
+    metadata = _parse_meta_items([*meta_items, *extra_meta_items])
     record = active_catalog.add_file(path, metadata=metadata, operation=operation)
     console.print(f"Added {record.id}: {record.stored_abspath}")
 
 
 @app.command()
 def search(
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
-    where: list[str] = typer.Option([], "--where", help="Equality filter KEY=VALUE. Repeatable."),
-    contains: list[str] = typer.Option(
-        [], "--contains", help="Substring filter KEY=VALUE. Repeatable."
-    ),
-    regex: list[str] = typer.Option([], "--regex", help="Regex filter KEY=VALUE. Repeatable."),
-    ignore_case: bool = typer.Option(False, "--ignore-case", help="Case-insensitive matching."),
-    json_mode: bool = typer.Option(False, "--json", help="Print matching records as JSON."),
-    ids_only: bool = typer.Option(False, "--ids", help="Print only matching record ids."),
-    paths_only: bool = typer.Option(False, "--paths", help="Print only matching stored paths."),
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    where: Annotated[
+        list[str] | None,
+        typer.Option("--where", help="Equality filter KEY=VALUE. Repeatable."),
+    ] = None,
+    contains: Annotated[
+        list[str] | None,
+        typer.Option("--contains", help="Substring filter KEY=VALUE. Repeatable."),
+    ] = None,
+    regex: Annotated[
+        list[str] | None,
+        typer.Option("--regex", help="Regex filter KEY=VALUE. Repeatable."),
+    ] = None,
+    ignore_case: Annotated[
+        bool,
+        typer.Option("--ignore-case", help="Case-insensitive matching."),
+    ] = False,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print matching records as JSON."),
+    ] = False,
+    ids_only: Annotated[
+        bool,
+        typer.Option("--ids", help="Print only matching record ids."),
+    ] = False,
+    paths_only: Annotated[
+        bool,
+        typer.Option("--paths", help="Print only matching stored paths."),
+    ] = False,
 ) -> None:
     """Search records in a catalog."""
     _validate_output_flags(json_mode=json_mode, ids_only=ids_only, paths_only=paths_only)
     active_catalog = _open_catalog_or_fail(catalog)
     results = active_catalog.search(
-        where=_parse_meta_items(where),
-        contains=_parse_key_value_options(contains),
-        regex=_parse_key_value_options(regex),
+        where=_parse_meta_items([] if where is None else where),
+        contains=_parse_key_value_options([] if contains is None else contains),
+        regex=_parse_key_value_options([] if regex is None else regex),
         ignore_case=ignore_case,
     )
 
@@ -210,9 +232,12 @@ def search(
 
 @app.command()
 def show(
-    record_id: str = typer.Argument(..., help="Record id."),
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
-    json_mode: bool = typer.Option(False, "--json", help="Print the record as JSON."),
+    record_id: Annotated[str, typer.Argument(help="Record id.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print the record as JSON."),
+    ] = False,
 ) -> None:
     """Show a single record."""
     active_catalog = _open_catalog_or_fail(catalog)
@@ -246,8 +271,8 @@ def show(
 
 @app.command()
 def path(
-    record_id: str = typer.Argument(..., help="Record id."),
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
+    record_id: Annotated[str, typer.Argument(help="Record id.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
 ) -> None:
     """Print the stored path for a record."""
     active_catalog = _open_catalog_or_fail(catalog)
@@ -262,8 +287,11 @@ def path(
 
 @app.command()
 def info(
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
-    json_mode: bool = typer.Option(False, "--json", help="Print catalog info as JSON."),
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print catalog info as JSON."),
+    ] = False,
 ) -> None:
     """Show a curated catalog overview."""
     active_catalog = _open_catalog_or_fail(catalog)
@@ -284,9 +312,12 @@ def info(
     table.add_row("default operation", str(description["default_operation"]))
     table.add_row("directory template", str(description["directory_template"]))
     table.add_row("filename template", str(description["filename_template"]))
+    field_resolution_order = description["field_resolution_order"]
+    if not isinstance(field_resolution_order, list):
+        field_resolution_order = []
     table.add_row(
         "field resolution order",
-        " -> ".join(str(item) for item in description["field_resolution_order"]),
+        " -> ".join(str(item) for item in field_resolution_order),
     )
     table.add_row("record count", str(description["record_count"]))
     table.add_row("metadata fields present", "yes" if description["has_metadata_fields"] else "no")
@@ -295,8 +326,11 @@ def info(
 
 @app.command()
 def fields(
-    catalog: Path | None = typer.Option(None, "--catalog", help="Catalog root."),
-    json_mode: bool = typer.Option(False, "--json", help="Print metadata field descriptions as JSON."),
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print metadata field descriptions as JSON."),
+    ] = False,
 ) -> None:
     """List important metadata fields from the catalog spec."""
     active_catalog = _open_catalog_or_fail(catalog)

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -22,6 +22,12 @@ console = Console()
 error_console = Console(stderr=True)
 
 
+def _fail(message: str, *, code: int = 1) -> NoReturn:
+    """Print a consistent error message and exit."""
+    error_console.print(f"Error: {message}")
+    raise typer.Exit(code=code)
+
+
 def _resolve_catalog_path(catalog: Path | None) -> Path:
     """Resolve the active catalog path from CLI option or environment."""
     if catalog is not None:
@@ -29,13 +35,7 @@ def _resolve_catalog_path(catalog: Path | None) -> Path:
     env_value = os.environ.get("OGCAT_CATALOG")
     if env_value:
         return Path(env_value)
-    raise typer.BadParameter("Provide --catalog or set OGCAT_CATALOG.")
-
-
-def _fail(message: str, *, code: int = 1) -> NoReturn:
-    """Print a consistent error message and exit."""
-    error_console.print(f"Error: {message}")
-    raise typer.Exit(code=code)
+    _fail("Provide --catalog or set OGCAT_CATALOG.")
 
 
 def _open_catalog_or_fail(catalog: Path | None) -> Catalog:

--- a/src/ogcat/extractors/__init__.py
+++ b/src/ogcat/extractors/__init__.py
@@ -12,13 +12,18 @@ from ogcat.models import JsonValue, MetadataDict
 class DerivedMetadataExtractor(Protocol):
     """Simple interface for optional file metadata extractors."""
 
-    name: str
+    @property
+    def name(self) -> str:
+        """Extractor name used as the derived metadata key."""
+        ...
 
     def can_extract(self, path: Path) -> bool:
         """Return whether this extractor should run for the given file."""
+        ...
 
     def extract(self, path: Path) -> JsonValue | None:
         """Return extracted metadata for this file, or ``None`` if unavailable."""
+        ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ogcat/extractors/netcdf.py
+++ b/src/ogcat/extractors/netcdf.py
@@ -7,8 +7,8 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any
 
-from ogcat.models import JsonValue
 from ogcat.extractors import SuffixExtractor
+from ogcat.models import JsonValue
 
 _SELECTED_ATTRS = (
     "title",

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -147,8 +147,9 @@ class CatalogRecord:
             stored_relpath=data.get("stored_relpath"),
         )
         record_type = data.get("record_type")
+        raw_id = data.get("id")
         return cls(
-            id=str(data["id"]),
+            id=None if raw_id is None else str(raw_id),
             catalog=str(data["catalog"]),
             time_added=str(data["time_added"]),
             record_type="managed_file" if record_type is None else str(record_type),

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
@@ -83,9 +83,9 @@ class ArtifactLocator:
 class CatalogRecord:
     """A single catalogued artifact record."""
 
-    id: str
     catalog: str
     time_added: str
+    id: str | None = None
     record_type: str = "managed_file"
     locator: ArtifactLocator = field(default_factory=lambda: ArtifactLocator(kind="opaque", value=""))
     stored_abspath: str | None = None
@@ -117,22 +117,25 @@ class CatalogRecord:
 
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the record to a plain dictionary."""
-        return {
-            "id": self.id,
-            "catalog": self.catalog,
-            "record_type": self.record_type,
-            "locator": self.locator.to_dict(),
-            "stored_abspath": self.stored_abspath,
-            "stored_relpath": self.stored_relpath,
-            "storage_mode": self.storage_mode,
-            "time_added": self.time_added,
-            "original_path": self.original_path,
-            "original_filename": self.original_filename,
-            "suffixes": self.suffixes,
-            "user_metadata": self.user_metadata,
-            "derived_metadata": self.derived_metadata,
-            "naming_metadata": self.naming_metadata,
-        }
+        return cast(
+            dict[str, JsonValue],
+            {
+                "id": self.id,
+                "catalog": self.catalog,
+                "record_type": self.record_type,
+                "locator": self.locator.to_dict(),
+                "stored_abspath": self.stored_abspath,
+                "stored_relpath": self.stored_relpath,
+                "storage_mode": self.storage_mode,
+                "time_added": self.time_added,
+                "original_path": self.original_path,
+                "original_filename": self.original_filename,
+                "suffixes": self.suffixes,
+                "user_metadata": self.user_metadata,
+                "derived_metadata": self.derived_metadata,
+                "naming_metadata": self.naming_metadata,
+            },
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, JsonValue]) -> CatalogRecord:
@@ -157,10 +160,10 @@ class CatalogRecord:
             original_filename=(
                 None if data.get("original_filename") is None else str(data["original_filename"])
             ),
-            suffixes=[str(x) for x in data.get("suffixes", [])],
-            user_metadata=dict(data.get("user_metadata", {})),
-            derived_metadata=dict(data.get("derived_metadata", {})),
-            naming_metadata=dict(data.get("naming_metadata", {})),
+            suffixes=_coerce_string_list(data.get("suffixes", [])),
+            user_metadata=_coerce_metadata_dict(data.get("user_metadata", {})),
+            derived_metadata=_coerce_metadata_dict(data.get("derived_metadata", {})),
+            naming_metadata=_coerce_metadata_dict(data.get("naming_metadata", {})),
         )
 
 
@@ -181,3 +184,17 @@ def _coerce_locator(
         str(stored_abspath),
         relative_path=None if stored_relpath is None else str(stored_relpath),
     )
+
+
+def _coerce_string_list(value: JsonValue) -> list[str]:
+    """Coerce a JSON list value to a list of strings."""
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _coerce_metadata_dict(value: JsonValue) -> MetadataDict:
+    """Coerce a JSON object value to metadata."""
+    if not isinstance(value, dict):
+        return {}
+    return dict(value)

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
-
 
 _TEMPLATE_PATTERN = re.compile(r"\{([^{}]+)\}")
 _SLUG_SEPARATOR_PATTERN = re.compile(r"[\s_]+")
@@ -118,7 +118,7 @@ def build_naming_context(
     *,
     record_id: str,
     original_path: Path,
-    metadata: dict[str, object],
+    metadata: Mapping[str, object],
     date_added: str,
 ) -> dict[str, object]:
     """Build a simple naming context for template rendering."""
@@ -154,12 +154,19 @@ def _derive_year_month_or_original_stem(*, year: object, month: object, original
     """Return a compact year-month key when available, otherwise the original stem."""
     try:
         if year is not None and month is not None:
-            return f"{int(year):04d}{int(month):02d}"
+            return f"{_coerce_int(year):04d}{_coerce_int(month):02d}"
         if year is not None:
-            return f"{int(year):04d}"
+            return f"{_coerce_int(year):04d}"
     except (TypeError, ValueError):
         return original_stem
     return original_stem
+
+
+def _coerce_int(value: object) -> int:
+    """Coerce template metadata values that are intended to be integer-like."""
+    if isinstance(value, int | float | str | bytes | bytearray):
+        return int(value)
+    raise TypeError(f"Expected an integer-like value, got {type(value).__name__}")
 
 
 def render_storage_location(

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -164,7 +164,15 @@ def _derive_year_month_or_original_stem(*, year: object, month: object, original
 
 def _coerce_int(value: object) -> int:
     """Coerce template metadata values that are intended to be integer-like."""
-    if isinstance(value, int | float | str | bytes | bytearray):
+    if isinstance(value, bool):
+        raise TypeError("Boolean values are not integer-like metadata values")
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value)
+        raise ValueError(f"Expected an integer-like float, got {value!r}")
+    if isinstance(value, str | bytes | bytearray):
         return int(value)
     raise TypeError(f"Expected an integer-like value, got {type(value).__name__}")
 

--- a/src/ogcat/repository.py
+++ b/src/ogcat/repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol
 
 from ogcat.models import CatalogRecord
@@ -10,20 +11,38 @@ from ogcat.models import CatalogRecord
 class CatalogRepository(Protocol):
     """Abstract storage for catalog records."""
 
-    def allocate_record_ids(self, count: int = 1) -> list[str]:
-        """Allocate one or more new record ids."""
+    def insert(self, record: CatalogRecord) -> CatalogRecord:
+        """Insert a new record and return it with its repository-assigned id."""
+        ...
 
-    def insert(self, record: CatalogRecord) -> None:
-        """Insert a new record."""
-
-    def insert_many(self, records: list[CatalogRecord]) -> None:
-        """Insert multiple records."""
+    def insert_many(self, records: list[CatalogRecord]) -> list[CatalogRecord]:
+        """Insert multiple records and return them with repository-assigned ids."""
+        ...
 
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
+        ...
 
     def update(self, record: CatalogRecord) -> None:
         """Update an existing record."""
+        ...
+
+    def delete(self, record_id: str) -> None:
+        """Delete an existing record."""
+        ...
+
+    def search(
+        self,
+        *,
+        where: dict[str, object] | None = None,
+        contains: dict[str, str] | None = None,
+        regex: dict[str, str] | None = None,
+        ignore_case: bool = False,
+        resolution_order: Sequence[str] | None = None,
+    ) -> list[CatalogRecord]:
+        """Search records."""
+        ...
 
     def all(self) -> list[CatalogRecord]:
         """Return all records."""
+        ...

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -45,7 +45,7 @@ class CatalogSpec:
         """Build a spec from a dictionary."""
         metadata_fields = [
             _coerce_metadata_field_description(item)
-            for item in _coerce_object_list(data.get("metadata_fields", []))
+            for item in _coerce_object_list(data.get("metadata_fields"), field_name="metadata_fields")
         ]
         return cls(
             catalog_name=str(data["catalog_name"]),
@@ -58,7 +58,11 @@ class CatalogSpec:
             ),
             default_operation=data.get("default_operation", "copy"),  # type: ignore[arg-type]
             field_resolution_order=[
-                str(item) for item in _coerce_object_list(data.get("field_resolution_order", []))
+                str(item)
+                for item in _coerce_object_list(
+                    data.get("field_resolution_order"),
+                    field_name="field_resolution_order",
+                )
             ]
             or ["top_level", "user_metadata", "derived_metadata"],
             metadata_fields=metadata_fields,
@@ -84,8 +88,10 @@ def _coerce_metadata_field_description(value: object) -> MetadataFieldDescriptio
     return MetadataFieldDescription.from_dict(value)  # type: ignore[arg-type]
 
 
-def _coerce_object_list(value: object) -> list[object]:
+def _coerce_object_list(value: object, *, field_name: str) -> list[object]:
     """Coerce a JSON-like list value to a plain object list."""
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise TypeError(f"{field_name} must be a list")
     return value

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
-import json
 from typing import Literal
 
 from ogcat.models import MetadataFieldDescription
@@ -41,11 +41,11 @@ class CatalogSpec:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, object]) -> "CatalogSpec":
+    def from_dict(cls, data: dict[str, object]) -> CatalogSpec:
         """Build a spec from a dictionary."""
         metadata_fields = [
             _coerce_metadata_field_description(item)
-            for item in data.get("metadata_fields", [])
+            for item in _coerce_object_list(data.get("metadata_fields", []))
         ]
         return cls(
             catalog_name=str(data["catalog_name"]),
@@ -57,7 +57,9 @@ class CatalogSpec:
                 data.get("filename_template", "{title_slug|original_stem}{original_suffix}")
             ),
             default_operation=data.get("default_operation", "copy"),  # type: ignore[arg-type]
-            field_resolution_order=[str(item) for item in data.get("field_resolution_order", [])]
+            field_resolution_order=[
+                str(item) for item in _coerce_object_list(data.get("field_resolution_order", []))
+            ]
             or ["top_level", "user_metadata", "derived_metadata"],
             metadata_fields=metadata_fields,
         )
@@ -67,7 +69,7 @@ class CatalogSpec:
         path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     @classmethod
-    def read(cls, path: Path) -> "CatalogSpec":
+    def read(cls, path: Path) -> CatalogSpec:
         """Read a spec JSON file from disk."""
         data = json.loads(path.read_text(encoding="utf-8"))
         return cls.from_dict(data)
@@ -80,3 +82,10 @@ def _coerce_metadata_field_description(value: object) -> MetadataFieldDescriptio
     if not isinstance(value, dict):
         raise TypeError("metadata_fields entries must be dictionaries")
     return MetadataFieldDescription.from_dict(value)  # type: ignore[arg-type]
+
+
+def _coerce_object_list(value: object) -> list[object]:
+    """Coerce a JSON-like list value to a plain object list."""
+    if not isinstance(value, list):
+        return []
+    return value

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
+from typing import cast
 
 from tinydb import Query, TinyDB
 
-from ogcat.models import CatalogRecord
+from ogcat.models import CatalogRecord, JsonValue
+from ogcat.search import matches_record
 
 
 class TinyDbCatalogRepository:
@@ -17,35 +21,33 @@ class TinyDbCatalogRepository:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         self._db = TinyDB(db_path)
 
-    def allocate_record_ids(self, count: int = 1) -> list[str]:
-        """Allocate one or more new ids aligned with TinyDB doc_ids."""
-        if count < 1:
-            return []
-        start = 1
-        for document in self._db.all():
-            start = max(start, document.doc_id + 1)
-        return [str(number) for number in range(start, start + count)]
+    def insert(self, record: CatalogRecord) -> CatalogRecord:
+        """Insert a new record and return it with its TinyDB doc_id."""
+        payload = record.to_dict()
+        payload.pop("id", None)
+        doc_id = self._db.insert(payload)
+        persisted = replace(record, id=str(doc_id))
+        self._db.update(persisted.to_dict(), doc_ids=[doc_id])
+        return persisted
 
-    def insert(self, record: CatalogRecord) -> None:
-        """Insert a new record."""
-        doc_id = self._db.insert(record.to_dict())
-        expected_id = str(doc_id)
-        if record.id != expected_id:
-            raise ValueError(
-                f"Record id {record.id!r} does not match allocated TinyDB doc_id {expected_id!r}"
-            )
-
-    def insert_many(self, records: list[CatalogRecord]) -> None:
-        """Insert multiple records."""
+    def insert_many(self, records: list[CatalogRecord]) -> list[CatalogRecord]:
+        """Insert multiple records and return them with their TinyDB doc_ids."""
         if not records:
-            return
-        doc_ids = self._db.insert_multiple([record.to_dict() for record in records])
-        expected_ids = [str(doc_id) for doc_id in doc_ids]
-        actual_ids = [record.id for record in records]
-        if actual_ids != expected_ids:
-            raise ValueError(
-                f"Record ids {actual_ids!r} do not match allocated TinyDB doc_ids {expected_ids!r}"
-            )
+            return []
+        persisted_records: list[CatalogRecord] = []
+        inserted_doc_ids: list[int] = []
+        try:
+            for record in records:
+                persisted = self.insert(record)
+                if persisted.id is None:
+                    raise RuntimeError("Repository inserted a record without assigning an id.")
+                persisted_records.append(persisted)
+                inserted_doc_ids.append(int(persisted.id))
+        except Exception:
+            if inserted_doc_ids:
+                self._db.remove(doc_ids=inserted_doc_ids)
+            raise
+        return persisted_records
 
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
@@ -56,10 +58,12 @@ class TinyDbCatalogRepository:
             result = self._db.get(query.id == record_id)
         if result is None:
             return None
-        return CatalogRecord.from_dict(result)
+        return CatalogRecord.from_dict(cast(dict[str, JsonValue], result))
 
     def update(self, record: CatalogRecord) -> None:
         """Update an existing record."""
+        if record.id is None:
+            raise ValueError("Cannot update a record without an id.")
         if record.id.isdigit():
             updated_doc_ids = self._db.update(record.to_dict(), doc_ids=[int(record.id)])
         else:
@@ -67,6 +71,39 @@ class TinyDbCatalogRepository:
             updated_doc_ids = self._db.update(record.to_dict(), query.id == record.id)
         if not updated_doc_ids:
             raise KeyError(f"Record not found: {record.id}")
+
+    def delete(self, record_id: str) -> None:
+        """Delete an existing record."""
+        if record_id.isdigit():
+            removed_doc_ids = self._db.remove(doc_ids=[int(record_id)])
+        else:
+            query = Query()
+            removed_doc_ids = self._db.remove(query.id == record_id)
+        if not removed_doc_ids:
+            raise KeyError(f"Record not found: {record_id}")
+
+    def search(
+        self,
+        *,
+        where: dict[str, object] | None = None,
+        contains: dict[str, str] | None = None,
+        regex: dict[str, str] | None = None,
+        ignore_case: bool = False,
+        resolution_order: Sequence[str] | None = None,
+    ) -> list[CatalogRecord]:
+        """Search records."""
+        return [
+            record
+            for record in self.all()
+            if matches_record(
+                record,
+                where=where,
+                contains=contains,
+                regex=regex,
+                ignore_case=ignore_case,
+                resolution_order=resolution_order,
+            )
+        ]
 
     def all(self) -> list[CatalogRecord]:
         """Return all records."""

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -26,32 +26,19 @@ class TinyDbCatalogRepository:
         payload = record.to_dict()
         payload.pop("id", None)
         doc_id = self._db.insert(payload)
-        persisted = replace(record, id=str(doc_id))
-        try:
-            self._db.update(persisted.to_dict(), doc_ids=[doc_id])
-        except Exception:
-            self._db.remove(doc_ids=[doc_id])
-            raise
-        return persisted
+        return replace(record, id=str(doc_id))
 
     def insert_many(self, records: list[CatalogRecord]) -> list[CatalogRecord]:
         """Insert multiple records and return them with their TinyDB doc_ids."""
         if not records:
             return []
-        persisted_records: list[CatalogRecord] = []
-        inserted_doc_ids: list[int] = []
-        try:
-            for record in records:
-                persisted = self.insert(record)
-                if persisted.id is None:
-                    raise RuntimeError("Repository inserted a record without assigning an id.")
-                persisted_records.append(persisted)
-                inserted_doc_ids.append(int(persisted.id))
-        except Exception:
-            if inserted_doc_ids:
-                self._db.remove(doc_ids=inserted_doc_ids)
-            raise
-        return persisted_records
+        payloads = []
+        for record in records:
+            payload = record.to_dict()
+            payload.pop("id", None)
+            payloads.append(payload)
+        doc_ids = self._db.insert_multiple(payloads)
+        return [replace(record, id=str(doc_id)) for record, doc_id in zip(records, doc_ids, strict=True)]
 
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from tinydb import Query, TinyDB
 
@@ -27,7 +27,11 @@ class TinyDbCatalogRepository:
         payload.pop("id", None)
         doc_id = self._db.insert(payload)
         persisted = replace(record, id=str(doc_id))
-        self._db.update(persisted.to_dict(), doc_ids=[doc_id])
+        try:
+            self._db.update(persisted.to_dict(), doc_ids=[doc_id])
+        except Exception:
+            self._db.remove(doc_ids=[doc_id])
+            raise
         return persisted
 
     def insert_many(self, records: list[CatalogRecord]) -> list[CatalogRecord]:
@@ -58,7 +62,7 @@ class TinyDbCatalogRepository:
             result = self._db.get(query.id == record_id)
         if result is None:
             return None
-        return CatalogRecord.from_dict(cast(dict[str, JsonValue], result))
+        return self._record_from_document(result)
 
     def update(self, record: CatalogRecord) -> None:
         """Update an existing record."""
@@ -107,4 +111,11 @@ class TinyDbCatalogRepository:
 
     def all(self) -> list[CatalogRecord]:
         """Return all records."""
-        return [CatalogRecord.from_dict(item) for item in self._db.all()]
+        return [self._record_from_document(item) for item in self._db.all()]
+
+    def _record_from_document(self, document: Any) -> CatalogRecord:
+        """Build a record, recovering the id from TinyDB doc_id when needed."""
+        data = dict(cast(dict[str, JsonValue], document))
+        if data.get("id") is None:
+            data["id"] = str(document.doc_id)
+        return CatalogRecord.from_dict(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 SRC_PATH = Path(__file__).resolve().parents[1] / "src"
 
 if str(SRC_PATH) not in sys.path:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -219,6 +219,31 @@ def test_add_file_rolls_back_record_when_copy_fails(tmp_path: Path) -> None:
     assert catalog.repository.all() == []
 
 
+def test_add_file_rolls_back_record_when_naming_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "broken.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_render_storage_location(*args: object, **kwargs: object) -> None:
+        raise ValueError("simulated naming failure")
+
+    monkeypatch.setattr("ogcat.catalog.render_storage_location", fail_render_storage_location)
+
+    with pytest.raises(ValueError, match="simulated naming failure"):
+        catalog.add_file(source)
+
+    assert catalog.describe()["record_count"] == 0
+    assert catalog.repository.all() == []
+    assert list((root / "files").rglob("*.nc")) == []
+
+
 def test_add_file_removes_partial_target_when_copy_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -89,6 +89,26 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
     assert record.storage_mode == "copy"
 
 
+def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "floatyear.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="fluxes",
+            filename_template="{year_month_or_original_stem}{original_suffix}",
+        ),
+    )
+
+    record = catalog.add_file(source, metadata={"year": 2024.9, "month": 1})
+
+    assert _stored_path(record).name == "floatyear.nc"
+
+
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()
@@ -222,6 +242,33 @@ def test_add_file_removes_partial_target_when_copy_fails(
 
     assert catalog.describe()["record_count"] == 0
     assert list((root / "files").rglob("*.nc")) == []
+
+
+def test_add_file_does_not_delete_moved_file_when_record_update_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "moved.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_update(record: CatalogRecord) -> None:
+        raise OSError("simulated update failure")
+
+    monkeypatch.setattr(catalog.repository, "update", fail_update)
+
+    with pytest.raises(OSError, match="simulated update failure"):
+        catalog.add_file(source, operation="move")
+
+    moved_files = list((root / "files").rglob("moved.nc"))
+    assert len(moved_files) == 1
+    assert moved_files[0].read_text(encoding="utf-8") == "dummy"
+    assert not source.exists()
+    assert catalog.describe()["record_count"] == 0
 
 
 def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -196,6 +197,31 @@ def test_add_file_rolls_back_record_when_copy_fails(tmp_path: Path) -> None:
 
     assert catalog.describe()["record_count"] == 0
     assert catalog.repository.all() == []
+
+
+def test_add_file_removes_partial_target_when_copy_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "partial.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_copy(source_path: Path, target_path: Path, *args: Any, **kwargs: Any) -> None:
+        target_path.write_text("partial", encoding="utf-8")
+        raise OSError("simulated copy failure")
+
+    monkeypatch.setattr("ogcat.catalog.shutil.copy2", fail_copy)
+
+    with pytest.raises(OSError, match="simulated copy failure"):
+        catalog.add_file(source)
+
+    assert catalog.describe()["record_count"] == 0
+    assert list((root / "files").rglob("*.nc")) == []
 
 
 def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 
+import pytest
+
 from ogcat import ArtifactLocator, Catalog, CatalogSpec
+from ogcat.models import CatalogRecord
+
+
+def _record_id(record: CatalogRecord) -> str:
+    assert record.id is not None
+    return record.id
+
+
+def _stored_path(record: CatalogRecord) -> Path:
+    assert record.stored_abspath is not None
+    return Path(record.stored_abspath)
 
 
 def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
@@ -15,7 +28,7 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     record = catalog.add_file(source)
 
     expected = root / "files" / record.time_added[:4] / "example" / "example.nc"
-    assert Path(record.stored_abspath) == expected
+    assert _stored_path(record) == expected
     assert record.record_type == "managed_file"
     assert record.locator == ArtifactLocator.path(expected, relative_path=record.stored_relpath)
     assert expected.exists()
@@ -69,7 +82,7 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
         / "anthropogenic"
         / "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc"
     )
-    assert Path(record.stored_abspath) == expected
+    assert _stored_path(record) == expected
     assert expected.exists()
     assert record.original_filename == "anthropogenic.202401.nc"
     assert record.storage_mode == "copy"
@@ -87,7 +100,7 @@ def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> 
     record = catalog.add_file(source)
 
     expected = root / "files" / record.time_added[:4] / "anthropogenic.202401" / "anthropogenic.202401.nc"
-    assert Path(record.stored_abspath) == expected
+    assert _stored_path(record) == expected
     assert record.original_filename == "anthropogenic.202401.nc"
     assert record.suffixes == [".202401", ".nc"]
 
@@ -104,7 +117,7 @@ def test_add_file_preserves_compressed_suffixes(tmp_path: Path) -> None:
     record = catalog.add_file(source)
 
     expected = root / "files" / record.time_added[:4] / "archive" / "archive.tar.gz"
-    assert Path(record.stored_abspath) == expected
+    assert _stored_path(record) == expected
     assert record.original_filename == "archive.tar.gz"
     assert record.suffixes == [".tar", ".gz"]
 
@@ -145,8 +158,8 @@ def test_add_file_appends_numeric_suffix_on_collision(tmp_path: Path) -> None:
     first_record = catalog.add_file(first, metadata=metadata)
     second_record = catalog.add_file(second, metadata=metadata)
 
-    assert Path(first_record.stored_abspath).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc"
-    assert Path(second_record.stored_abspath).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401_2.nc"
+    assert _stored_path(first_record).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc"
+    assert _stored_path(second_record).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401_2.nc"
 
 
 def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -> None:
@@ -170,8 +183,19 @@ def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -
     first_record = catalog.add_file(first)
     second_record = catalog.add_file(second)
 
-    assert Path(first_record.stored_abspath).name == "bundle.tar.gz"
-    assert Path(second_record.stored_abspath).name == "bundle_2.tar.gz"
+    assert _stored_path(first_record).name == "bundle.tar.gz"
+    assert _stored_path(second_record).name == "bundle_2.tar.gz"
+
+
+def test_add_file_rolls_back_record_when_copy_fails(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(FileNotFoundError):
+        catalog.add_file(tmp_path / "source" / "missing.nc")
+
+    assert catalog.describe()["record_count"] == 0
+    assert catalog.repository.all() == []
 
 
 def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
@@ -188,7 +212,7 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
     assert record.locator.kind == "uri"
     assert record.locator.value == "s3://bucket/example.zarr"
     assert record.stored_abspath is None
-    assert catalog.path(record.id) is None
+    assert catalog.path(_record_id(record)) is None
 
 
 def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
@@ -314,7 +338,9 @@ def test_add_artifacts_assigns_sequential_record_ids_when_missing(tmp_path: Path
     assert first.id == "1"
     assert [record.id for record in records] == ["2", "3"]
 
-def test_add_artifacts_rejects_record_id_in_batch_input(tmp_path: Path) -> None:
+
+@pytest.mark.parametrize("id_key", ["record_id", "id"])
+def test_add_artifacts_rejects_id_fields_in_batch_input(tmp_path: Path, id_key: str) -> None:
     root = tmp_path / "catalog"
     catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
 
@@ -322,14 +348,14 @@ def test_add_artifacts_rejects_record_id_in_batch_input(tmp_path: Path) -> None:
         catalog.add_artifacts(
             [
                 {
-                    "record_id": "10",
+                    id_key: "10",
                     "record_type": "external_reference",
                     "locator": ArtifactLocator.path("/tmp/data/first.nc"),
                 },
             ]
         )
     except ValueError as exc:
-        assert "must not supply record_id" in str(exc)
+        assert f"must not supply {id_key}" in str(exc)
         assert "artifact batch item 0" in str(exc)
     else:  # pragma: no cover
-        raise AssertionError("Expected record_id rejection for batch input")
+        raise AssertionError("Expected id rejection for batch input")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,9 +7,14 @@ from typer.testing import CliRunner
 
 from ogcat import Catalog, CatalogSpec, MetadataFieldDescription
 from ogcat.cli import app
-from ogcat.models import ArtifactLocator
+from ogcat.models import ArtifactLocator, CatalogRecord
 
 runner = CliRunner()
+
+
+def _record_id(record: CatalogRecord) -> str:
+    assert record.id is not None
+    return record.id
 
 
 def _create_catalog(tmp_path: Path, *, with_fields: bool = True) -> Catalog:
@@ -59,7 +64,7 @@ def test_search_json_output(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert [item["id"] for item in payload] == [record.id]
+    assert [item["id"] for item in payload] == [_record_id(record)]
     assert payload[0]["user_metadata"]["species"] == "CO2"
 
 
@@ -67,11 +72,11 @@ def test_show_json_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
     record = catalog.search()[0]
 
-    result = runner.invoke(app, ["show", record.id, "--catalog", str(catalog.root), "--json"])
+    result = runner.invoke(app, ["show", _record_id(record), "--catalog", str(catalog.root), "--json"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
-    assert payload["id"] == record.id
+    assert payload["id"] == _record_id(record)
     assert payload["record_type"] == "managed_file"
     assert payload["locator"]["kind"] == "path"
     assert payload["user_metadata"]["title"] == "Anthropogenic test flux"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,6 +60,16 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
     assert reloaded == spec
 
 
+def test_catalog_spec_rejects_malformed_list_fields() -> None:
+    for field_name in ["metadata_fields", "field_resolution_order"]:
+        try:
+            CatalogSpec.from_dict({"catalog_name": "fluxes", field_name: "not-a-list"})
+        except TypeError as exc:
+            assert f"{field_name} must be a list" in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError(f"Expected malformed {field_name} to be rejected")
+
+
 def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tmp_path: Path) -> None:
     root = tmp_path / "fluxes"
     spec = CatalogSpec(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
 from ogcat import Catalog, CatalogSpec, MetadataFieldDescription
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 from pathlib import Path
-from typing import Any
-
-import pytest
 
 from ogcat.models import ArtifactLocator, CatalogRecord
 from ogcat.tinydb_repository import TinyDbCatalogRepository
@@ -180,31 +177,6 @@ def test_repository_delete(tmp_path: Path) -> None:
 
     assert persisted.id == "1"
     repository.delete("1")
-
-    assert repository.all() == []
-
-
-def test_repository_removes_inserted_document_when_id_update_fails(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    repository = TinyDbCatalogRepository(tmp_path / "db.json")
-    original_update = repository._db.update
-
-    def fail_update(*args: Any, **kwargs: Any) -> list[int]:
-        if kwargs.get("doc_ids") == [1]:
-            raise OSError("simulated update failure")
-        return original_update(*args, **kwargs)
-
-    monkeypatch.setattr(repository._db, "update", fail_update)
-
-    with pytest.raises(OSError, match="simulated update failure"):
-        repository.insert(
-            CatalogRecord(
-                catalog="fluxes",
-                time_added="2026-04-23T12:00:00Z",
-            )
-        )
 
     assert repository.all() == []
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from ogcat.models import ArtifactLocator, CatalogRecord
 from ogcat.tinydb_repository import TinyDbCatalogRepository
@@ -105,6 +108,25 @@ def test_from_dict_upgrades_legacy_path_only_records() -> None:
     assert record.path() == Path("/tmp/catalog/files/example.nc")
 
 
+def test_from_dict_tolerates_missing_or_null_id_for_draft_records() -> None:
+    missing_id_record = CatalogRecord.from_dict(
+        {
+            "catalog": "fluxes",
+            "time_added": "2026-04-23T12:00:00Z",
+        }
+    )
+    null_id_record = CatalogRecord.from_dict(
+        {
+            "id": None,
+            "catalog": "fluxes",
+            "time_added": "2026-04-23T12:00:00Z",
+        }
+    )
+
+    assert missing_id_record.id is None
+    assert null_id_record.id is None
+
+
 def test_record_to_dict_stays_json_serialisable() -> None:
     record = CatalogRecord(
         id="rec_000004",
@@ -160,6 +182,48 @@ def test_repository_delete(tmp_path: Path) -> None:
     repository.delete("1")
 
     assert repository.all() == []
+
+
+def test_repository_removes_inserted_document_when_id_update_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    original_update = repository._db.update
+
+    def fail_update(*args: Any, **kwargs: Any) -> list[int]:
+        if kwargs.get("doc_ids") == [1]:
+            raise OSError("simulated update failure")
+        return original_update(*args, **kwargs)
+
+    monkeypatch.setattr(repository._db, "update", fail_update)
+
+    with pytest.raises(OSError, match="simulated update failure"):
+        repository.insert(
+            CatalogRecord(
+                catalog="fluxes",
+                time_added="2026-04-23T12:00:00Z",
+            )
+        )
+
+    assert repository.all() == []
+
+
+def test_repository_recovers_missing_document_id_from_tinydb_doc_id(tmp_path: Path) -> None:
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    repository._db.insert(
+        {
+            "catalog": "fluxes",
+            "time_added": "2026-04-23T12:00:00Z",
+            "record_type": "external_reference",
+        }
+    )
+
+    stored = repository.get("1")
+
+    assert stored is not None
+    assert stored.id == "1"
+    assert [record.id for record in repository.all()] == ["1"]
 
 
 def test_record_without_locator_does_not_resolve_to_current_directory() -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from ogcat.models import ArtifactLocator, CatalogRecord
@@ -12,7 +13,6 @@ from ogcat.tinydb_repository import TinyDbCatalogRepository
 def test_repository_insert_get_update_and_all(tmp_path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     record = CatalogRecord(
-        id="1",
         catalog="fluxes",
         time_added="2026-04-23T12:00:00Z",
         locator=ArtifactLocator.path(
@@ -30,14 +30,16 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
         naming_metadata={"resolved_filename": "example.nc"},
     )
 
-    repository.insert(record)
+    persisted = repository.insert(record)
+    expected = replace(record, id="1")
 
-    stored = repository.get(record.id)
-    assert stored == record
-    assert repository.all() == [record]
+    assert persisted == expected
+    stored = repository.get("1")
+    assert stored == expected
+    assert repository.all() == [expected]
 
     updated = CatalogRecord(
-        id=record.id,
+        id=persisted.id,
         catalog=record.catalog,
         time_added=record.time_added,
         record_type=record.record_type,
@@ -54,13 +56,12 @@ def test_repository_insert_get_update_and_all(tmp_path) -> None:
     )
     repository.update(updated)
 
-    assert repository.get(record.id) == updated
+    assert repository.get("1") == updated
 
 
 def test_record_round_trips_with_non_path_locator(tmp_path: Path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     record = CatalogRecord(
-        id="1",
         catalog="fluxes",
         time_added="2026-04-23T12:00:00Z",
         record_type="external_reference",
@@ -68,10 +69,12 @@ def test_record_round_trips_with_non_path_locator(tmp_path: Path) -> None:
         user_metadata={"species": "CO2"},
     )
 
-    repository.insert(record)
+    persisted = repository.insert(record)
+    expected = replace(record, id="1")
 
-    stored = repository.get(record.id)
-    assert stored == record
+    assert persisted == expected
+    stored = repository.get("1")
+    assert stored == expected
     assert stored is not None
     assert stored.path() is None
 
@@ -126,7 +129,6 @@ def test_repository_insert_many(tmp_path: Path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
     records = [
         CatalogRecord(
-            id=str(index + 1),
             catalog="fluxes",
             time_added="2026-04-23T12:00:00Z",
             record_type="external_reference",
@@ -137,25 +139,27 @@ def test_repository_insert_many(tmp_path: Path) -> None:
         for index in range(3)
     ]
 
-    repository.insert_many(records)
+    persisted = repository.insert_many(records)
+    expected = [replace(record, id=str(index + 1)) for index, record in enumerate(records)]
 
-    assert repository.all() == records
+    assert persisted == expected
+    assert repository.all() == expected
 
 
-def test_repository_allocate_record_ids(tmp_path: Path) -> None:
+def test_repository_delete(tmp_path: Path) -> None:
     repository = TinyDbCatalogRepository(tmp_path / "db.json")
-    assert repository.allocate_record_ids(2) == ["1", "2"]
-
-    repository.insert(
+    persisted = repository.insert(
         CatalogRecord(
-            id="1",
             catalog="fluxes",
             time_added="2026-04-23T12:00:00Z",
             locator=ArtifactLocator.path("/tmp/catalog/files/example.nc"),
         )
     )
 
-    assert repository.allocate_record_ids(2) == ["2", "3"]
+    assert persisted.id == "1"
+    repository.delete("1")
+
+    assert repository.all() == []
 
 
 def test_record_without_locator_does_not_resolve_to_current_directory() -> None:


### PR DESCRIPTION
## Summary
- Make catalog record IDs repository-assigned and optional before persistence
- Move search behind the repository interface and implement it in TinyDB
- Update file ingest to insert metadata first, then roll back on file-copy failure
- Add coverage for rollback behavior and batch ID validation
- Tidy the CLI and typing so `ruff` and `pyright` pass cleanly

## Testing
- `ruff format .`
- `ruff check .`
- `pytest`
- `pyright`