### PR TITLE
Add typed record schemas for catalog records

### DIFF
--- a/MVP_SPEC.md
+++ b/MVP_SPEC.md
@@ -38,23 +38,22 @@ Fields:
 - `db_backend: str = "tinydb"`
 - `db_path: str = "db.json"`
 - `files_root: str = "files"`
-- `directory_template: str`
-- `filename_template: str`
 - `default_operation: Literal["copy", "move"] = "copy"`
 - `field_resolution_order: list[str] = ["top_level", "user_metadata", "derived_metadata"]`
-- `metadata_fields: list[MetadataFieldDescription] = []`
+- `default_schema: RecordSchema`
+- `record_schemas: dict[str, RecordSchema] = {}`
 
-Recommended defaults:
+Default schema naming templates:
 - `directory_template = "{year_added}/{original_stem}"`
 - `filename_template = "{title_slug|original_stem}{original_suffix}"`
 
-`metadata_fields` is descriptive only for now. Each entry is JSON-serialisable and human-readable:
+Each schema can define `metadata_fields`. Each entry is JSON-serialisable and human-readable:
 - `name: str`
 - `description: str`
 - `example: JSON value | null = null`
 - `required: bool = false`
 
-Flux-specific templates remain valid example templates:
+Flux-specific schemas remain valid examples:
 - `directory_template = "{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/{version|unversioned}/{flux_type|misc}"`
 - `filename_template = "{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}{original_suffix}"`
 
@@ -93,7 +92,7 @@ Metadata is split into:
 - `user_metadata`, and
 - `derived_metadata`.
 
-Catalog specifications may also describe important metadata through `metadata_fields`,
+Catalog schemas may also describe important metadata through `metadata_fields`,
 but this is not yet used for strict validation.
 
 Only JSON-serialisable values are supported.
@@ -201,12 +200,14 @@ Example:
 
 ```python
 from pathlib import Path
-from ogcat import Catalog, CatalogSpec
+from ogcat import Catalog, CatalogSpec, RecordSchema
 
 spec = CatalogSpec(
     catalog_name="fluxes",
-    directory_template="{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/{version|unversioned}/{flux_type|misc}",
-    filename_template="{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}{original_suffix}",
+    default_schema=RecordSchema(
+        directory_template="{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/{version|unversioned}/{flux_type|misc}",
+        filename_template="{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}{original_suffix}",
+    ),
 )
 
 catalog = Catalog.create("/tmp/fluxes", spec)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ adding files by copy or move, listing metadata field descriptions, and locating 
 ## Non-goals
 
 - domain-specific validation or workflow logic
-- strict typed schemas for records or metadata
+- domain-specific built-in schemas
 - in-place indexing of arbitrary existing directories
 - reader or manager APIs beyond the current small extractor layer
 - promising richer catalog backends or integrations that do not exist yet
@@ -29,7 +29,8 @@ adding files by copy or move, listing metadata field descriptions, and locating 
 
 `ogcat` is organised around a small catalog specification and a narrow catalog API.
 
-- Catalog spec: `catalog.json` stores the catalog name, storage layout templates, default ingest mode, field resolution order, and descriptive metadata field definitions.
+- Catalog spec: `catalog.json` stores the catalog name, default ingest mode, field resolution
+  order, and a default record schema with optional named schemas.
 - Repository abstraction: catalog records are stored through a repository protocol so the rest of the package does not depend directly on TinyDB details.
 - Records: each record stores reserved top-level fields plus `user_metadata`, `derived_metadata`,
   and `naming_metadata`. Records now also carry a small `record_type` and `locator` so the model
@@ -49,7 +50,7 @@ Each catalog root is self-describing:
   files/
 ```
 
-- `catalog.json`: catalog specification and descriptive metadata field definitions
+- `catalog.json`: catalog specification, default schema, and optional named record schemas
 - `db.json`: TinyDB-backed record store
 - `files/`: managed storage root for ingested files
 
@@ -176,7 +177,8 @@ For compatibility, managed local files still keep `stored_abspath` and `stored_r
 fields remain the simple path-facing surface for today's workflows while the locator model opens a
 path toward external references, directory-like stores, and future transform targets.
 
-`catalog.json` stores the naming templates and descriptive metadata field definitions so a catalog remains understandable without additional application state. `metadata_fields` are descriptive only today; they are not enforced as typed schemas.
+`catalog.json` stores a broad `default_schema` plus optional named `record_schemas`, so a catalog
+can document expected metadata and naming behavior without adding domain-specific framework code.
 
 ## Current Limitations
 
@@ -184,7 +186,7 @@ path toward external references, directory-like stores, and future transform tar
 - non-file record types are only partially modelled so far; readers, managers, and richer URI
   handling are still future work
 - derived metadata extraction is intentionally small and currently focused on optional netCDF summaries
-- there are no typed per-record schemas, readers, or manager bindings yet
+- reader and manager bindings are not implemented yet
 - richer readers, managers, and import workflows are future work
 
 ## Roadmap
@@ -193,7 +195,7 @@ The current direction is:
 
 - today: spec-driven file catalog with metadata, naming, and search
 - next: generalise from managed files to catalogued artefacts with clearer record typing and locator handling
-- later: typed schemas, reader hooks, manager bindings, and scan or import workflows
+- later: reader hooks, manager bindings, and scan or import workflows
 
 See [docs/architecture.md](docs/architecture.md),
 [docs/design-note-artifact-locators.md](docs/design-note-artifact-locators.md),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,15 +66,17 @@ This is not a claim that multiple backends already exist. It only means the pack
 
 ## Why Templates and Metadata Live in `catalog.json`
 
-The naming templates, default operation, field resolution order, and descriptive metadata field definitions are stored in `catalog.json` so a catalog remains self-describing on disk.
+The default schema, optional named record schemas, default operation, and field resolution order
+are stored in `catalog.json` so a catalog remains self-describing on disk.
 
 That choice has a few practical benefits:
 
 - a catalog can be opened without separate application configuration
 - stored records can be interpreted in the context of the catalog that produced them
-- metadata field descriptions travel with the catalog instead of being hard-coded elsewhere
+- schema-level metadata field descriptions travel with the catalog instead of being hard-coded elsewhere
 
-`metadata_fields` are descriptive only today. They document important fields and examples, but they are not enforced as strict schemas.
+Schemas are intentionally lightweight. Required metadata fields are checked at ingest, but there
+is no deep type validation or domain-specific schema language in the catalog core.
 
 ## User Metadata and Derived Metadata
 
@@ -100,7 +102,7 @@ The present architecture is intentionally constrained.
 
 - richer locator handling is still future work; today the generalisation is intentionally minimal
 - TinyDB is the only supported backend
-- metadata field descriptions are not typed schemas and are not validated on ingest
+- metadata validation is intentionally shallow and limited to required-field presence
 - search supports exact equality, contains, and regex matching only
 - there are no reader hooks, manager APIs, or import or scan workflows yet
 - extractor support is limited and should not be described as a general reader framework

--- a/docs/design-note-record-schemas.md
+++ b/docs/design-note-record-schemas.md
@@ -6,11 +6,10 @@
 metadata fields, a directory template, a filename template, and a short
 description.
 
-Backward compatibility is preserved by keeping the older top-level
-`metadata_fields`, `directory_template`, and `filename_template` fields on
-`CatalogSpec`. When older `catalog.json` files are read, those fields are used to
-construct the effective default schema. When a newer default schema is supplied,
-the legacy attributes remain available as compatibility accessors.
+`default_schema` is the source of truth for broad catalog behavior. Earlier MVP
+top-level fields such as `metadata_fields`, `directory_template`, and
+`filename_template` were removed before any real catalog migration burden existed,
+which keeps `CatalogSpec` smaller and avoids parallel compatibility state.
 
 For this first pass, record type and schema name are the same concept only where
 a named schema exists. `Catalog.add_file(..., record_type="flux")` selects the

--- a/docs/design-note-record-schemas.md
+++ b/docs/design-note-record-schemas.md
@@ -6,6 +6,10 @@
 metadata fields, a directory template, a filename template, and a short
 description.
 
+Metadata field descriptions can also carry lightweight type names. These are
+serialised as human-readable schema hints for now; they are not enforced by the
+catalog core.
+
 `default_schema` is the source of truth for broad catalog behavior. Earlier MVP
 top-level fields such as `metadata_fields`, `directory_template`, and
 `filename_template` were removed before any real catalog migration burden existed,

--- a/docs/design-note-record-schemas.md
+++ b/docs/design-note-record-schemas.md
@@ -1,0 +1,24 @@
+# Typed Record Schemas
+
+`ogcat` keeps schemas deliberately small. A catalog has one explicit
+`default_schema` for broad, heterogeneous ingest and an optional
+`record_schemas` mapping keyed by record type. Each `RecordSchema` can describe
+metadata fields, a directory template, a filename template, and a short
+description.
+
+Backward compatibility is preserved by keeping the older top-level
+`metadata_fields`, `directory_template`, and `filename_template` fields on
+`CatalogSpec`. When older `catalog.json` files are read, those fields are used to
+construct the effective default schema. When a newer default schema is supplied,
+the legacy attributes remain available as compatibility accessors.
+
+For this first pass, record type and schema name are the same concept only where
+a named schema exists. `Catalog.add_file(..., record_type="flux")` selects the
+`flux` schema and raises a clear error if that named schema is missing. Generic
+artifact records can still use arbitrary record types; they fall back to the
+default schema unless a matching named schema is present.
+
+Validation is intentionally shallow. Required metadata fields are checked for
+presence when a record is added, but field types, coercion, plugin hooks,
+extractor bindings, readers, managers, and automatic dispatch are left for later
+layers.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,9 +25,11 @@ Today each record assumes a stored file path. A next step would be to separate "
 
 ### Typed or Per-Record Schemas
 
-Future work: add optional typed schemas for record classes or catalog-defined record groups.
+Current direction: keep a broad `default_schema` plus optional named schemas for record types.
 
-Today `metadata_fields` in `catalog.json` are descriptive only. A likely next step is to support stricter schema definitions where needed, while keeping unstructured metadata possible for lightweight use cases. This should be additive and should not force domain-specific validation into the core package.
+Schemas remain lightweight: they describe expected metadata fields and naming templates, and only
+required-field presence is validated at ingest. Rich type validation, automatic dispatch, and
+domain-specific built-in schemas remain out of scope for the catalog core.
 
 ### Reader Hooks
 
@@ -52,7 +54,7 @@ The current implementation assumes managed ingest into the catalog's own `files/
 Later work may include:
 
 - broader artefact support beyond managed files
-- typed schemas associated with record types
+- richer schema behavior where it stays lightweight
 - reader and manager integration points
 - scan or import workflows for existing datasets
 

--- a/examples/catalog_acrg_name_footprints.py
+++ b/examples/catalog_acrg_name_footprints.py
@@ -49,7 +49,7 @@ from pathlib import Path
 
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
 
-from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 
 FOOTPRINT_FILE_RE = re.compile(
     r"^(?P<site>[A-Za-z0-9]+)[-_](?P<inlet>\d{1,4}m)agl"
@@ -256,7 +256,7 @@ def build_catalog(
     else:
         spec = CatalogSpec(
             catalog_name=catalog_name,
-            metadata_fields=_metadata_fields(),
+            default_schema=RecordSchema(metadata_fields=_metadata_fields()),
         )
         catalog = Catalog.create(catalog_root, spec)
 

--- a/examples/catalog_openghg_default_schemas.py
+++ b/examples/catalog_openghg_default_schemas.py
@@ -1,0 +1,394 @@
+"""Create an ogcat catalog with schemas matching OpenGHG metadata defaults.
+
+This example mirrors the default object-store metadata configuration used by
+OpenGHG for the data types listed below:
+
+- ``boundary_conditions``
+- ``column``
+- ``eulerian_model``
+- ``flux``
+- ``flux_timeseries``
+- ``footprints``
+- ``site_met``
+- ``surface``
+
+The example does not import OpenGHG or run OpenGHG standardisation. It only shows
+how the same broad metadata expectations can be represented in an ``ogcat``
+catalog. The generated schema records OpenGHG type names such as ``species``,
+``height``, and ``timestamp`` for documentation and future validation work, but
+`ogcat` validates required metadata field presence only today.
+
+Command-line usage:
+
+```bash
+python examples/catalog_openghg_default_schemas.py /tmp/openghg-ogcat
+ogcat info --catalog /tmp/openghg-ogcat
+ogcat fields --catalog /tmp/openghg-ogcat --record-type surface
+```
+
+Python usage:
+
+```python
+from pathlib import Path
+
+from examples.catalog_openghg_default_schemas import create_openghg_catalog
+
+catalog = create_openghg_catalog("/tmp/openghg-ogcat")
+
+# In OpenGHG, the store argument chooses the object store target:
+#
+# standardise_surface(
+#     filepath=hfd_path,
+#     site="hfd",
+#     instrument="picarro",
+#     network="DECC",
+#     source_format="CRDS",
+#     store="user",
+# )
+#
+# In this ogcat example, choosing the catalog root is analogous to choosing the
+# target store. The record type selects the OpenGHG-style metadata schema.
+surface_record = catalog.add_file(
+    Path("hfd.picarro.1minute.100m.min.dat"),
+    record_type="surface",
+    metadata={
+        "species": "co2",
+        "site": "hfd",
+        "inlet": "100m",
+        "instrument": "picarro",
+        "network": "DECC",
+        "platform": "surface",
+        "data_level": "raw",
+        "data_sublevel": "none",
+        "dataset_source": "openghg",
+        "data_source": "CRDS",
+        "sampling_period": "1minute",
+        "source_format": "CRDS",
+    },
+)
+
+flux_record = catalog.add_file(
+    Path("co2-gpp-cardamom_EUROPE_2012.nc"),
+    record_type="flux",
+    metadata={
+        "species": "co2",
+        "source": "gpp-cardamom",
+        "domain": "europe",
+    },
+)
+
+footprint_record = catalog.add_file(
+    Path("footprint_test.nc"),
+    record_type="footprints",
+    metadata={
+        "model": "test_model",
+        "domain": "europe",
+        "inlet": "10m",
+        "time_resolved": True,
+        "high_spatial_resolution": True,
+        "short_lifetime": False,
+        "species": "inert",
+        "met_model": "ukv",
+    },
+)
+```
+
+OpenGHG standardisation often derives or normalises metadata before data reaches
+the object store. This example is intentionally simpler: callers provide the
+metadata explicitly, and `ogcat` checks only that required keys are present.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
+from ogcat.models import JsonValue
+
+OpenGhgMetadataDefaults = dict[str, dict[str, dict[str, dict[str, list[str]]]]]
+
+OPENGHG_METADATA_DEFAULTS: OpenGhgMetadataDefaults = {
+    "boundary_conditions": {
+        "required": {
+            "species": {"type": ["str"]},
+            "bc_input": {"type": ["str"]},
+            "domain": {"type": ["str"]},
+        },
+        "optional": {},
+    },
+    "eulerian_model": {
+        "required": {
+            "model": {"type": ["str"]},
+            "species": {"type": ["str"]},
+            "date": {"type": ["timestamp"]},
+        },
+        "optional": {},
+    },
+    "column": {
+        "required": {
+            "species": {"type": ["species"]},
+            "platform": {"type": ["platform"]},
+        },
+        "optional": {
+            "satellite": {"type": ["str"]},
+            "selection": {"type": ["str"]},
+            "domain": {"type": ["str"]},
+            "site": {"type": ["str"]},
+            "network": {"type": ["str"]},
+            "obs_region": {"type": ["str"]},
+        },
+    },
+    "footprints": {
+        "required": {
+            "model": {"type": ["str"]},
+            "domain": {"type": ["str"]},
+            "inlet": {"type": ["height"]},
+            "time_resolved": {"type": ["bool"]},
+            "high_spatial_resolution": {"type": ["bool"]},
+            "short_lifetime": {"type": ["bool"]},
+            "species": {"type": ["str", "species"]},
+            "met_model": {"type": ["str"]},
+        },
+        "optional": {
+            "site": {"type": ["str"]},
+            "satellite": {"type": ["str"]},
+            "obs_region": {"type": ["str"]},
+            "selection": {"type": ["str"]},
+        },
+    },
+    "flux": {
+        "required": {
+            "species": {"type": ["str"]},
+            "source": {"type": ["str"]},
+            "domain": {"type": ["str"]},
+        },
+        "optional": {
+            "database": {"type": ["str"]},
+            "database_version": {"type": ["str"]},
+            "model": {"type": ["str"]},
+        },
+    },
+    "flux_timeseries": {
+        "required": {
+            "species": {"type": ["str"]},
+            "source": {"type": ["str"]},
+            "region": {"type": ["str"]},
+        },
+        "optional": {
+            "database": {"type": ["str"]},
+            "database_version": {"type": ["str"]},
+            "model": {"type": ["str"]},
+        },
+    },
+    "surface": {
+        "required": {
+            "species": {"type": ["str"]},
+            "site": {"type": ["str"]},
+            "inlet": {"type": ["str"]},
+            "instrument": {"type": ["str"]},
+            "network": {"type": ["str"]},
+            "platform": {"type": ["str"]},
+            "data_level": {"type": ["str"]},
+            "data_sublevel": {"type": ["str"]},
+            "dataset_source": {"type": ["str"]},
+            "data_source": {"type": ["str"]},
+            "sampling_period": {"type": ["str"]},
+            "source_format": {"type": ["str"]},
+        },
+        "optional": {},
+    },
+    "site_met": {
+        "required": {
+            "site": {"type": ["str"]},
+            "network": {"type": ["str"]},
+            "met_source": {"type": ["str"]},
+        },
+        "optional": {},
+    },
+}
+
+EXAMPLE_METADATA_VALUES: dict[str, dict[str, JsonValue]] = {
+    "boundary_conditions": {
+        "species": "co2",
+        "bc_input": "cams",
+        "domain": "europe",
+    },
+    "eulerian_model": {
+        "model": "GEOS-Chem",
+        "species": "co2",
+        "date": "2024-01-01T00:00:00Z",
+    },
+    "column": {
+        "species": "ch4",
+        "platform": "satellite",
+        "satellite": "GOSAT",
+        "selection": "LAND",
+        "domain": "EUROPE",
+        "site": "THW",
+        "network": "TCCON",
+        "obs_region": "BRAZIL",
+    },
+    "footprints": {
+        "model": "test_model",
+        "domain": "europe",
+        "inlet": "10m",
+        "time_resolved": True,
+        "high_spatial_resolution": True,
+        "short_lifetime": False,
+        "species": "inert",
+        "met_model": "ukv",
+        "site": "TMB",
+        "satellite": "GOSAT",
+        "obs_region": "BRAZIL",
+        "selection": "LAND",
+    },
+    "flux": {
+        "species": "co2",
+        "source": "gpp-cardamom",
+        "domain": "europe",
+        "database": "EDGAR",
+        "database_version": "v50",
+        "model": "cardamom",
+    },
+    "flux_timeseries": {
+        "species": "ch4",
+        "source": "crf",
+        "region": "uk",
+        "database": "UK GHGI",
+        "database_version": "2023",
+        "model": "inventory",
+    },
+    "surface": {
+        "species": "co2",
+        "site": "hfd",
+        "inlet": "100m",
+        "instrument": "picarro",
+        "network": "DECC",
+        "platform": "surface",
+        "data_level": "raw",
+        "data_sublevel": "none",
+        "dataset_source": "openghg",
+        "data_source": "CRDS",
+        "sampling_period": "1minute",
+        "source_format": "CRDS",
+    },
+    "site_met": {
+        "site": "TAC",
+        "network": "DECC",
+        "met_source": "ukv",
+    },
+}
+
+
+def build_openghg_catalog_spec(*, catalog_name: str = "openghg") -> CatalogSpec:
+    """Build a catalog spec with one record schema per OpenGHG data type.
+
+    Args:
+        catalog_name: Name to store in the generated catalog specification.
+
+    Returns:
+        Catalog specification containing OpenGHG-style record schemas.
+    """
+    return CatalogSpec(
+        catalog_name=catalog_name,
+        record_schemas={
+            data_type: _record_schema(data_type, config)
+            for data_type, config in OPENGHG_METADATA_DEFAULTS.items()
+        },
+    )
+
+
+def create_openghg_catalog(root: str | Path, *, catalog_name: str = "openghg") -> Catalog:
+    """Create or open an ogcat catalog with OpenGHG-style schemas.
+
+    Args:
+        root: Catalog root directory.
+        catalog_name: Name to use when creating a new catalog.
+
+    Returns:
+        Opened or newly created catalog.
+    """
+    root_path = Path(root).expanduser()
+    if (root_path / "catalog.json").exists():
+        return Catalog.open(root_path)
+    return Catalog.create(root_path, build_openghg_catalog_spec(catalog_name=catalog_name))
+
+
+def _record_schema(data_type: str, config: dict[str, dict[str, dict[str, list[str]]]]) -> RecordSchema:
+    """Translate one OpenGHG metadata config block into an ogcat record schema."""
+    metadata_fields: list[MetadataFieldDescription] = []
+    for field_name, field_config in config.get("required", {}).items():
+        metadata_fields.append(_metadata_field(data_type, field_name, field_config, required=True))
+    for field_name, field_config in config.get("optional", {}).items():
+        metadata_fields.append(_metadata_field(data_type, field_name, field_config, required=False))
+
+    return RecordSchema(
+        description=f"OpenGHG default metadata schema for {data_type}.",
+        directory_template=_directory_template(data_type),
+        filename_template="{original_stem}{original_suffix}",
+        metadata_fields=metadata_fields,
+    )
+
+
+def _directory_template(data_type: str) -> str:
+    """Return a readable storage layout for one OpenGHG-style data type."""
+    templates = {
+        "boundary_conditions": "boundary_conditions/{species|unknown}/{domain|unknown}",
+        "column": "column/{species|unknown}/{platform|unknown}",
+        "eulerian_model": "eulerian_model/{model|unknown}/{species|unknown}",
+        "flux": "flux/{species|unknown}/{domain|unknown}/{source|unknown}",
+        "flux_timeseries": "flux_timeseries/{species|unknown}/{region|unknown}/{source|unknown}",
+        "footprints": "footprints/{model|unknown}/{domain|unknown}/{inlet|unknown}",
+        "site_met": "site_met/{site|unknown}/{network|unknown}",
+        "surface": "surface/{species|unknown}/{site|unknown}/{inlet|unknown}",
+    }
+    return templates[data_type]
+
+
+def _metadata_field(
+    data_type: str,
+    field_name: str,
+    field_config: dict[str, list[str]],
+    *,
+    required: bool,
+) -> MetadataFieldDescription:
+    """Translate one OpenGHG metadata field config into an ogcat field description."""
+    type_names = field_config.get("type", [])
+    return MetadataFieldDescription(
+        name=field_name,
+        description="OpenGHG metadata field.",
+        example=EXAMPLE_METADATA_VALUES.get(data_type, {}).get(field_name),
+        required=required,
+        value_types=type_names,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Create an ogcat catalog with OpenGHG-style default schemas."
+    )
+    parser.add_argument("catalog_root", type=Path, help="Catalog root directory to create or open.")
+    parser.add_argument("--name", default="openghg", help="Catalog name to use when creating a catalog.")
+    parser.add_argument(
+        "--print-schemas",
+        action="store_true",
+        help="Print the available record schema names after opening the catalog.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Create or open a catalog with OpenGHG-style default schemas."""
+    args = _parse_args()
+    catalog = create_openghg_catalog(args.catalog_root, catalog_name=args.name)
+    print(f"Catalog ready at {catalog.root}")
+    if args.print_schemas:
+        print("Record schemas:")
+        for schema_name in catalog.list_record_schemas():
+            print(f"- {schema_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -2,6 +2,13 @@
 
 from ogcat.catalog import Catalog
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
-from ogcat.spec import CatalogSpec
+from ogcat.spec import CatalogSpec, RecordSchema
 
-__all__ = ["ArtifactLocator", "Catalog", "CatalogRecord", "CatalogSpec", "MetadataFieldDescription"]
+__all__ = [
+    "ArtifactLocator",
+    "Catalog",
+    "CatalogRecord",
+    "CatalogSpec",
+    "MetadataFieldDescription",
+    "RecordSchema",
+]

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -55,6 +55,8 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=record_type is not None)
         self._validate_metadata(schema=schema, metadata=metadata, record_type=record_type)
         resolved_record_type = "managed_file" if record_type is None else record_type
+        directory_template = _template_or_default(schema.directory_template, self.spec.directory_template)
+        filename_template = _template_or_default(schema.filename_template, self.spec.filename_template)
         chosen_operation = operation or self.spec.default_operation
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
@@ -85,8 +87,8 @@ class Catalog:
             files_root = self.root / self.spec.files_root
             target, rel_path, resolved_filename = render_storage_location(
                 files_root=files_root,
-                directory_template=schema.directory_template or self.spec.directory_template,
-                filename_template=schema.filename_template or self.spec.filename_template,
+                directory_template=directory_template,
+                filename_template=filename_template,
                 context=context,
             )
             target.parent.mkdir(parents=True, exist_ok=True)
@@ -113,8 +115,8 @@ class Catalog:
                 derived_metadata=derived_metadata,
                 naming_metadata={
                     "record_schema": "default" if record_type is None else record_type,
-                    "directory_template": schema.directory_template or self.spec.directory_template,
-                    "filename_template": schema.filename_template or self.spec.filename_template,
+                    "directory_template": directory_template,
+                    "filename_template": filename_template,
                     "resolved_filename": resolved_filename,
                 },
                 time_added=timestamp,
@@ -250,7 +252,7 @@ class Catalog:
             "filename_template": self.spec.filename_template,
             "field_resolution_order": list(self.spec.field_resolution_order),
             "record_count": len(self.repository.all()),
-            "has_metadata_fields": bool(self.spec.metadata_fields),
+            "has_metadata_fields": self._has_metadata_fields(),
             "record_schemas": self.list_record_schemas(),
         }
 
@@ -334,18 +336,30 @@ class Catalog:
         self,
         *,
         schema: RecordSchema,
-        metadata: MetadataDict,
+        metadata: object,
         record_type: str | None,
     ) -> None:
         """Apply lightweight required-field validation for the selected schema."""
-        missing = [field_name for field_name in schema.required_field_names() if field_name not in metadata]
-        if not missing:
-            return
         schema_name = (
             record_type if record_type is not None and record_type in self.spec.record_schemas else "default"
         )
+        if not isinstance(metadata, dict):
+            raise TypeError(
+                f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}"
+            )
+        missing = [field_name for field_name in schema.required_field_names() if field_name not in metadata]
+        if not missing:
+            return
         joined = ", ".join(missing)
         raise ValueError(f"Missing required metadata for schema {schema_name}: {joined}")
+
+    def _has_metadata_fields(self) -> bool:
+        """Return whether any default or named schema describes metadata fields."""
+        if self.spec.metadata_fields:
+            return True
+        if self.spec.get_schema().metadata_fields:
+            return True
+        return any(schema.metadata_fields for schema in self.spec.record_schemas.values())
 
 
 def _utc_timestamp() -> str:
@@ -359,6 +373,11 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     if spec.db_backend != "tinydb":
         raise ValueError(f"Unsupported db_backend: {spec.db_backend}")
     return TinyDbCatalogRepository(root / spec.db_path)
+
+
+def _template_or_default(value: str | None, default: str) -> str:
+    """Return a template value, treating only None as missing."""
+    return default if value is None else value
 
 
 def _coerce_artifact_locator(value: object) -> ArtifactLocator:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -342,9 +342,7 @@ class Catalog:
         if not missing:
             return
         schema_name = (
-            record_type
-            if record_type is not None and record_type in self.spec.record_schemas
-            else "default"
+            record_type if record_type is not None and record_type in self.spec.record_schemas else "default"
         )
         joined = ", ".join(missing)
         raise ValueError(f"Missing required metadata for schema {schema_name}: {joined}")

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -191,11 +191,16 @@ class Catalog:
             record_type = str(validated["record_type"])
             metadata = validated.get("metadata")  # type: ignore[assignment]
             schema = self._select_schema(record_type, require_known=False)
-            self._validate_metadata(
-                schema=schema,
-                metadata={} if metadata is None else metadata,  # type: ignore[arg-type]
-                record_type=record_type,
-            )
+            try:
+                self._validate_metadata(
+                    schema=schema,
+                    metadata={} if metadata is None else metadata,  # type: ignore[arg-type]
+                    record_type=record_type,
+                )
+            except TypeError as exc:
+                raise TypeError(f"artifact batch item {index}: {exc}") from exc
+            except ValueError as exc:
+                raise ValueError(f"artifact batch item {index}: {exc}") from exc
             records.append(
                 self._build_artifact_record(
                     record_type=record_type,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -51,7 +51,7 @@ class Catalog:
     ) -> CatalogRecord:
         """Add a file to the catalog using managed copy or move."""
         source = Path(path).expanduser().resolve()
-        metadata = metadata or {}
+        metadata = {} if metadata is None else metadata
         schema = self._select_schema(record_type, require_known=record_type is not None)
         self._validate_metadata(schema=schema, metadata=metadata, record_type=record_type)
         resolved_record_type = "managed_file" if record_type is None else record_type
@@ -152,7 +152,11 @@ class Catalog:
         delegates here.
         """
         schema = self._select_schema(record_type, require_known=False)
-        self._validate_metadata(schema=schema, metadata=metadata or {}, record_type=record_type)
+        self._validate_metadata(
+            schema=schema,
+            metadata={} if metadata is None else metadata,
+            record_type=record_type,
+        )
         record = self._build_artifact_record(
             record_type=record_type,
             locator=locator,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -55,8 +55,8 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=record_type is not None)
         self._validate_metadata(schema=schema, metadata=metadata, record_type=record_type)
         resolved_record_type = "managed_file" if record_type is None else record_type
-        directory_template = _template_or_default(schema.directory_template, self.spec.directory_template)
-        filename_template = _template_or_default(schema.filename_template, self.spec.filename_template)
+        directory_template = _require_template(schema.directory_template, field_name="directory_template")
+        filename_template = _require_template(schema.filename_template, field_name="filename_template")
         chosen_operation = operation or self.spec.default_operation
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
@@ -241,6 +241,7 @@ class Catalog:
         """Return a simple serialisable summary of the catalog."""
         db_path = self.root / self.spec.db_path
         files_root = self.root / self.spec.files_root
+        default_schema = self.spec.get_schema()
         return {
             "catalog_name": self.spec.catalog_name,
             "root_path": str(self.root),
@@ -248,8 +249,8 @@ class Catalog:
             "database_path": str(db_path),
             "files_root": str(files_root),
             "default_operation": self.spec.default_operation,
-            "directory_template": self.spec.directory_template,
-            "filename_template": self.spec.filename_template,
+            "directory_template": default_schema.directory_template,
+            "filename_template": default_schema.filename_template,
             "field_resolution_order": list(self.spec.field_resolution_order),
             "record_count": len(self.repository.all()),
             "has_metadata_fields": self._has_metadata_fields(),
@@ -355,8 +356,6 @@ class Catalog:
 
     def _has_metadata_fields(self) -> bool:
         """Return whether any default or named schema describes metadata fields."""
-        if self.spec.metadata_fields:
-            return True
         if self.spec.get_schema().metadata_fields:
             return True
         return any(schema.metadata_fields for schema in self.spec.record_schemas.values())
@@ -375,9 +374,11 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     return TinyDbCatalogRepository(root / spec.db_path)
 
 
-def _template_or_default(value: str | None, default: str) -> str:
-    """Return a template value, treating only None as missing."""
-    return default if value is None else value
+def _require_template(value: str | None, *, field_name: str) -> str:
+    """Return a schema template that should have been filled by the spec."""
+    if value is None:
+        raise ValueError(f"Default schema is missing {field_name}")
+    return value
 
 
 def _coerce_artifact_locator(value: object) -> ArtifactLocator:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -12,7 +12,7 @@ from ogcat.extractors import extract_derived_metadata
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.repository import CatalogRepository
-from ogcat.spec import CatalogSpec
+from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
 
@@ -47,10 +47,14 @@ class Catalog:
         path: str | Path,
         metadata: MetadataDict | None = None,
         operation: str | None = None,
+        record_type: str | None = None,
     ) -> CatalogRecord:
         """Add a file to the catalog using managed copy or move."""
         source = Path(path).expanduser().resolve()
         metadata = metadata or {}
+        schema = self._select_schema(record_type, require_known=record_type is not None)
+        self._validate_metadata(schema=schema, metadata=metadata, record_type=record_type)
+        resolved_record_type = "managed_file" if record_type is None else record_type
         chosen_operation = operation or self.spec.default_operation
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
@@ -58,7 +62,7 @@ class Catalog:
         timestamp = _utc_timestamp()
         date_added = timestamp[:10]
         draft_record = self._build_artifact_record(
-            record_type="managed_file",
+            record_type=resolved_record_type,
             locator=ArtifactLocator(kind="opaque", value=""),
             metadata=metadata,
             storage_mode=chosen_operation,
@@ -81,8 +85,8 @@ class Catalog:
             files_root = self.root / self.spec.files_root
             target, rel_path, resolved_filename = render_storage_location(
                 files_root=files_root,
-                directory_template=self.spec.directory_template,
-                filename_template=self.spec.filename_template,
+                directory_template=schema.directory_template or self.spec.directory_template,
+                filename_template=schema.filename_template or self.spec.filename_template,
                 context=context,
             )
             target.parent.mkdir(parents=True, exist_ok=True)
@@ -99,7 +103,7 @@ class Catalog:
             locator = ArtifactLocator.path(target, relative_path=rel_path)
             record = self._build_artifact_record(
                 record_id=record_id,
-                record_type="managed_file",
+                record_type=resolved_record_type,
                 locator=locator,
                 metadata=metadata,
                 storage_mode=storage_mode,
@@ -108,8 +112,9 @@ class Catalog:
                 suffixes=source.suffixes,
                 derived_metadata=derived_metadata,
                 naming_metadata={
-                    "directory_template": self.spec.directory_template,
-                    "filename_template": self.spec.filename_template,
+                    "record_schema": "default" if record_type is None else record_type,
+                    "directory_template": schema.directory_template or self.spec.directory_template,
+                    "filename_template": schema.filename_template or self.spec.filename_template,
                     "resolved_filename": resolved_filename,
                 },
                 time_added=timestamp,
@@ -144,6 +149,8 @@ class Catalog:
         ingest convenience wrapper that prepares a path-backed locator and then
         delegates here.
         """
+        schema = self._select_schema(record_type, require_known=False)
+        self._validate_metadata(schema=schema, metadata=metadata or {}, record_type=record_type)
         record = self._build_artifact_record(
             record_type=record_type,
             locator=locator,
@@ -179,11 +186,19 @@ class Catalog:
             except ValueError as exc:
                 raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
 
+            record_type = str(validated["record_type"])
+            metadata = validated.get("metadata")  # type: ignore[assignment]
+            schema = self._select_schema(record_type, require_known=False)
+            self._validate_metadata(
+                schema=schema,
+                metadata={} if metadata is None else metadata,  # type: ignore[arg-type]
+                record_type=record_type,
+            )
             records.append(
                 self._build_artifact_record(
-                    record_type=str(validated["record_type"]),
+                    record_type=record_type,
                     locator=locator,
-                    metadata=validated.get("metadata"),  # type: ignore[arg-type]
+                    metadata=metadata,  # type: ignore[arg-type]
                     storage_mode=(
                         None if validated.get("storage_mode") is None else str(validated["storage_mode"])
                     ),
@@ -236,11 +251,21 @@ class Catalog:
             "field_resolution_order": list(self.spec.field_resolution_order),
             "record_count": len(self.repository.all()),
             "has_metadata_fields": bool(self.spec.metadata_fields),
+            "record_schemas": self.list_record_schemas(),
         }
 
-    def list_metadata_fields(self) -> list[dict[str, JsonValue]]:
+    def list_metadata_fields(self, record_type: str | None = None) -> list[dict[str, JsonValue]]:
         """Return serialisable metadata field descriptions."""
-        return [field_description.to_dict() for field_description in self.spec.metadata_fields]
+        schema = self._select_schema(record_type, require_known=record_type is not None)
+        return [field_description.to_dict() for field_description in schema.metadata_fields]
+
+    def get_schema(self, record_type: str | None = None) -> dict[str, object]:
+        """Return a serialisable schema description."""
+        return self._select_schema(record_type, require_known=record_type is not None).to_dict()
+
+    def list_record_schemas(self) -> list[str]:
+        """Return available named record schema names."""
+        return self.spec.list_record_schemas()
 
     def get(self, record_id: str) -> CatalogRecord | None:
         """Get a record by id."""
@@ -294,6 +319,35 @@ class Catalog:
             derived_metadata={} if derived_metadata is None else dict(derived_metadata),
             naming_metadata={} if naming_metadata is None else dict(naming_metadata),
         )
+
+    def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
+        """Select the schema that applies to a record."""
+        if record_type is None:
+            return self.spec.get_schema()
+        if record_type in self.spec.record_schemas:
+            return self.spec.get_schema(record_type)
+        if require_known:
+            raise ValueError(f"Unknown record schema: {record_type}")
+        return self.spec.get_schema()
+
+    def _validate_metadata(
+        self,
+        *,
+        schema: RecordSchema,
+        metadata: MetadataDict,
+        record_type: str | None,
+    ) -> None:
+        """Apply lightweight required-field validation for the selected schema."""
+        missing = [field_name for field_name in schema.required_field_names() if field_name not in metadata]
+        if not missing:
+            return
+        schema_name = (
+            record_type
+            if record_type is not None and record_type in self.spec.record_schemas
+            else "default"
+        )
+        joined = ", ".join(missing)
+        raise ValueError(f"Missing required metadata for schema {schema_name}: {joined}")
 
 
 def _utc_timestamp() -> str:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -134,6 +134,10 @@ def add_command(
         ),
     ] = None,
     operation: Annotated[str | None, typer.Option("--operation", help="copy or move.")] = None,
+    record_type: Annotated[
+        str | None,
+        typer.Option("--record-type", help="Named record schema to use for this file."),
+    ] = None,
 ) -> None:
     """Add a file to the catalog."""
     extra_meta_items = list(ctx.args)
@@ -143,7 +147,15 @@ def add_command(
 
     active_catalog = _open_catalog_or_fail(catalog)
     metadata = _parse_meta_items([*meta_items, *extra_meta_items])
-    record = active_catalog.add_file(path, metadata=metadata, operation=operation)
+    try:
+        record = active_catalog.add_file(
+            path,
+            metadata=metadata,
+            operation=operation,
+            record_type=record_type,
+        )
+    except ValueError as exc:
+        _fail(str(exc))
     console.print(f"Added {record.id}: {record.stored_abspath}")
 
 
@@ -321,12 +333,20 @@ def info(
     )
     table.add_row("record count", str(description["record_count"]))
     table.add_row("metadata fields present", "yes" if description["has_metadata_fields"] else "no")
+    record_schemas = description["record_schemas"]
+    if not isinstance(record_schemas, list):
+        record_schemas = []
+    table.add_row("record schemas", ", ".join(str(item) for item in record_schemas) or "none")
     console.print(table)
 
 
 @app.command()
 def fields(
     catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    record_type: Annotated[
+        str | None,
+        typer.Option("--record-type", help="Named record schema whose fields should be shown."),
+    ] = None,
     json_mode: Annotated[
         bool,
         typer.Option("--json", help="Print metadata field descriptions as JSON."),
@@ -334,7 +354,10 @@ def fields(
 ) -> None:
     """List important metadata fields from the catalog spec."""
     active_catalog = _open_catalog_or_fail(catalog)
-    metadata_fields = active_catalog.list_metadata_fields()
+    try:
+        metadata_fields = active_catalog.list_metadata_fields(record_type=record_type)
+    except ValueError as exc:
+        _fail(str(exc))
 
     if json_mode:
         _print_json(metadata_fields)

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -370,13 +370,18 @@ def fields(
     table = Table(title="metadata fields", expand=True)
     table.add_column("name")
     table.add_column("required")
+    table.add_column("type")
     table.add_column("description", overflow="fold")
     table.add_column("example")
 
     for field_description in metadata_fields:
+        value_types = field_description.get("type", [])
+        if not isinstance(value_types, list):
+            value_types = []
         table.add_row(
             str(field_description["name"]),
             "yes" if field_description.get("required") else "no",
+            " | ".join(str(item) for item in value_types),
             str(field_description["description"]),
             "" if field_description.get("example") is None else json.dumps(field_description["example"]),
         )

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypeAlias, cast
 
@@ -19,19 +19,30 @@ class MetadataFieldDescription:
     description: str
     example: JsonValue | None = None
     required: bool = False
+    value_types: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the field description to a plain dictionary."""
-        return asdict(self)
+        payload: dict[str, JsonValue] = {
+            "name": self.name,
+            "description": self.description,
+            "example": self.example,
+            "required": self.required,
+        }
+        if self.value_types:
+            payload["type"] = list(self.value_types)
+        return payload
 
     @classmethod
     def from_dict(cls, data: dict[str, JsonValue]) -> MetadataFieldDescription:
         """Build a field description from a plain dictionary."""
+        value_types = data.get("type", [])
         return cls(
             name=str(data["name"]),
             description=str(data["description"]),
             example=data.get("example"),
             required=bool(data.get("required", False)),
+            value_types=_coerce_string_list(value_types),
         )
 
 

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -57,8 +57,12 @@ class RecordSchema:
         """Return this schema with missing naming templates filled from a fallback schema."""
         return RecordSchema(
             description=self.description,
-            directory_template=self.directory_template or fallback.directory_template,
-            filename_template=self.filename_template or fallback.filename_template,
+            directory_template=(
+                fallback.directory_template if self.directory_template is None else self.directory_template
+            ),
+            filename_template=(
+                fallback.filename_template if self.filename_template is None else self.filename_template
+            ),
             metadata_fields=list(self.metadata_fields),
         )
 

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -91,10 +91,7 @@ class CatalogSpec:
     def __post_init__(self) -> None:
         """Fill required defaults on the broad fallback schema."""
         self.record_schemas = dict(self.record_schemas)
-        if self.default_schema.directory_template is None:
-            self.default_schema.directory_template = DEFAULT_DIRECTORY_TEMPLATE
-        if self.default_schema.filename_template is None:
-            self.default_schema.filename_template = DEFAULT_FILENAME_TEMPLATE
+        self.default_schema = self.default_schema.with_fallbacks(_default_record_schema())
 
     def to_dict(self) -> dict[str, object]:
         """Convert the spec to a serialisable dictionary."""
@@ -142,12 +139,12 @@ class CatalogSpec:
             record_type: Optional record type. When omitted, the broad default schema is returned.
 
         Raises:
-            KeyError: If a non-default record type has no schema.
+            ValueError: If a non-default record type has no schema.
         """
         if record_type is None:
             return self.default_schema
         if record_type not in self.record_schemas:
-            raise KeyError(f"Unknown record schema: {record_type}")
+            raise ValueError(f"Unknown record schema: {record_type}")
         return self.record_schemas[record_type].with_fallbacks(self.default_schema)
 
     def list_record_schemas(self) -> list[str]:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -81,60 +81,31 @@ class CatalogSpec:
     db_backend: str = "tinydb"
     db_path: str = "db.json"
     files_root: str = "files"
-    directory_template: str = DEFAULT_DIRECTORY_TEMPLATE
-    filename_template: str = DEFAULT_FILENAME_TEMPLATE
     default_operation: Literal["copy", "move"] = "copy"
     field_resolution_order: list[str] = field(
         default_factory=lambda: ["top_level", "user_metadata", "derived_metadata"]
     )
-    metadata_fields: list[MetadataFieldDescription] = field(default_factory=list)
-    default_schema: RecordSchema | None = None
+    default_schema: RecordSchema = field(default_factory=lambda: _default_record_schema())
     record_schemas: dict[str, RecordSchema] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Keep legacy top-level defaults aligned with the explicit default schema."""
+        """Fill required defaults on the broad fallback schema."""
         self.record_schemas = dict(self.record_schemas)
-        if self.default_schema is None:
-            self.default_schema = RecordSchema(
-                directory_template=self.directory_template,
-                filename_template=self.filename_template,
-                metadata_fields=list(self.metadata_fields),
-            )
-            return
-
         if self.default_schema.directory_template is None:
-            self.default_schema.directory_template = self.directory_template
-        else:
-            self.directory_template = self.default_schema.directory_template
-
+            self.default_schema.directory_template = DEFAULT_DIRECTORY_TEMPLATE
         if self.default_schema.filename_template is None:
-            self.default_schema.filename_template = self.filename_template
-        else:
-            self.filename_template = self.default_schema.filename_template
-
-        if self.default_schema.metadata_fields:
-            self.metadata_fields = list(self.default_schema.metadata_fields)
-        else:
-            self.default_schema.metadata_fields = list(self.metadata_fields)
+            self.default_schema.filename_template = DEFAULT_FILENAME_TEMPLATE
 
     def to_dict(self) -> dict[str, object]:
         """Convert the spec to a serialisable dictionary."""
-        default_schema = self.default_schema or RecordSchema(
-            directory_template=self.directory_template,
-            filename_template=self.filename_template,
-            metadata_fields=list(self.metadata_fields),
-        )
         return {
             "catalog_name": self.catalog_name,
             "db_backend": self.db_backend,
             "db_path": self.db_path,
             "files_root": self.files_root,
-            "directory_template": self.directory_template,
-            "filename_template": self.filename_template,
             "default_operation": self.default_operation,
             "field_resolution_order": list(self.field_resolution_order),
-            "metadata_fields": [field_description.to_dict() for field_description in self.metadata_fields],
-            "default_schema": default_schema.to_dict(),
+            "default_schema": self.default_schema.to_dict(),
             "record_schemas": {
                 record_type: schema.to_dict() for record_type, schema in self.record_schemas.items()
             },
@@ -143,30 +114,14 @@ class CatalogSpec:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> CatalogSpec:
         """Build a spec from a dictionary."""
-        metadata_fields = [
-            _coerce_metadata_field_description(item)
-            for item in _coerce_object_list(data.get("metadata_fields"), field_name="metadata_fields")
-        ]
         default_schema = _coerce_record_schema(data.get("default_schema"), field_name="default_schema")
         record_schemas = _coerce_record_schema_mapping(data.get("record_schemas"))
-
-        directory_template = str(data.get("directory_template", DEFAULT_DIRECTORY_TEMPLATE))
-        filename_template = str(data.get("filename_template", DEFAULT_FILENAME_TEMPLATE))
-        if default_schema is not None:
-            if "directory_template" not in data and default_schema.directory_template is not None:
-                directory_template = default_schema.directory_template
-            if "filename_template" not in data and default_schema.filename_template is not None:
-                filename_template = default_schema.filename_template
-            if "metadata_fields" not in data:
-                metadata_fields = list(default_schema.metadata_fields)
 
         return cls(
             catalog_name=str(data["catalog_name"]),
             db_backend=str(data.get("db_backend", "tinydb")),
             db_path=str(data.get("db_path", "db.json")),
             files_root=str(data.get("files_root", "files")),
-            directory_template=directory_template,
-            filename_template=filename_template,
             default_operation=data.get("default_operation", "copy"),  # type: ignore[arg-type]
             field_resolution_order=[
                 str(item)
@@ -176,8 +131,7 @@ class CatalogSpec:
                 )
             ]
             or ["top_level", "user_metadata", "derived_metadata"],
-            metadata_fields=metadata_fields,
-            default_schema=default_schema,
+            default_schema=default_schema or _default_record_schema(),
             record_schemas=record_schemas,
         )
 
@@ -190,16 +144,11 @@ class CatalogSpec:
         Raises:
             KeyError: If a non-default record type has no schema.
         """
-        default_schema = self.default_schema or RecordSchema(
-            directory_template=self.directory_template,
-            filename_template=self.filename_template,
-            metadata_fields=list(self.metadata_fields),
-        )
         if record_type is None:
-            return default_schema
+            return self.default_schema
         if record_type not in self.record_schemas:
             raise KeyError(f"Unknown record schema: {record_type}")
-        return self.record_schemas[record_type].with_fallbacks(default_schema)
+        return self.record_schemas[record_type].with_fallbacks(self.default_schema)
 
     def list_record_schemas(self) -> list[str]:
         """Return available named record schema names."""
@@ -223,6 +172,15 @@ def _coerce_metadata_field_description(value: object) -> MetadataFieldDescriptio
     if not isinstance(value, dict):
         raise TypeError("metadata_fields entries must be dictionaries")
     return MetadataFieldDescription.from_dict(value)  # type: ignore[arg-type]
+
+
+def _default_record_schema() -> RecordSchema:
+    """Return the broad default schema used for generic ingest."""
+    return RecordSchema(
+        description="Generic fallback schema for heterogeneous files.",
+        directory_template=DEFAULT_DIRECTORY_TEMPLATE,
+        filename_template=DEFAULT_FILENAME_TEMPLATE,
+    )
 
 
 def _coerce_record_schema(value: object, *, field_name: str) -> RecordSchema | None:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -25,9 +25,7 @@ class RecordSchema:
     def to_dict(self) -> dict[str, object]:
         """Convert the schema to a serialisable dictionary."""
         payload: dict[str, object] = {
-            "metadata_fields": [
-                field_description.to_dict() for field_description in self.metadata_fields
-            ],
+            "metadata_fields": [field_description.to_dict() for field_description in self.metadata_fields],
         }
         if self.description:
             payload["description"] = self.description
@@ -67,9 +65,7 @@ class RecordSchema:
     def required_field_names(self) -> list[str]:
         """Return required metadata field names for this schema."""
         return [
-            field_description.name
-            for field_description in self.metadata_fields
-            if field_description.required
+            field_description.name for field_description in self.metadata_fields if field_description.required
         ]
 
 

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -9,6 +9,69 @@ from typing import Literal
 
 from ogcat.models import MetadataFieldDescription
 
+DEFAULT_DIRECTORY_TEMPLATE = "{year_added}/{original_stem}"
+DEFAULT_FILENAME_TEMPLATE = "{title_slug|original_stem}{original_suffix}"
+
+
+@dataclass(slots=True)
+class RecordSchema:
+    """Lightweight metadata and naming schema for one record type."""
+
+    description: str = ""
+    directory_template: str | None = None
+    filename_template: str | None = None
+    metadata_fields: list[MetadataFieldDescription] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        """Convert the schema to a serialisable dictionary."""
+        payload: dict[str, object] = {
+            "metadata_fields": [
+                field_description.to_dict() for field_description in self.metadata_fields
+            ],
+        }
+        if self.description:
+            payload["description"] = self.description
+        if self.directory_template is not None:
+            payload["directory_template"] = self.directory_template
+        if self.filename_template is not None:
+            payload["filename_template"] = self.filename_template
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> RecordSchema:
+        """Build a record schema from a dictionary."""
+        metadata_fields = [
+            _coerce_metadata_field_description(item)
+            for item in _coerce_object_list(data.get("metadata_fields"), field_name="metadata_fields")
+        ]
+        return cls(
+            description=str(data.get("description", "")),
+            directory_template=(
+                None if data.get("directory_template") is None else str(data["directory_template"])
+            ),
+            filename_template=(
+                None if data.get("filename_template") is None else str(data["filename_template"])
+            ),
+            metadata_fields=metadata_fields,
+        )
+
+    def with_fallbacks(self, fallback: RecordSchema) -> RecordSchema:
+        """Return this schema with missing naming templates filled from a fallback schema."""
+        return RecordSchema(
+            description=self.description,
+            directory_template=self.directory_template or fallback.directory_template,
+            filename_template=self.filename_template or fallback.filename_template,
+            metadata_fields=list(self.metadata_fields),
+        )
+
+    def required_field_names(self) -> list[str]:
+        """Return required metadata field names for this schema."""
+        return [
+            field_description.name
+            for field_description in self.metadata_fields
+            if field_description.required
+        ]
+
 
 @dataclass(slots=True)
 class CatalogSpec:
@@ -18,16 +81,49 @@ class CatalogSpec:
     db_backend: str = "tinydb"
     db_path: str = "db.json"
     files_root: str = "files"
-    directory_template: str = "{year_added}/{original_stem}"
-    filename_template: str = "{title_slug|original_stem}{original_suffix}"
+    directory_template: str = DEFAULT_DIRECTORY_TEMPLATE
+    filename_template: str = DEFAULT_FILENAME_TEMPLATE
     default_operation: Literal["copy", "move"] = "copy"
     field_resolution_order: list[str] = field(
         default_factory=lambda: ["top_level", "user_metadata", "derived_metadata"]
     )
     metadata_fields: list[MetadataFieldDescription] = field(default_factory=list)
+    default_schema: RecordSchema | None = None
+    record_schemas: dict[str, RecordSchema] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Keep legacy top-level defaults aligned with the explicit default schema."""
+        self.record_schemas = dict(self.record_schemas)
+        if self.default_schema is None:
+            self.default_schema = RecordSchema(
+                directory_template=self.directory_template,
+                filename_template=self.filename_template,
+                metadata_fields=list(self.metadata_fields),
+            )
+            return
+
+        if self.default_schema.directory_template is None:
+            self.default_schema.directory_template = self.directory_template
+        else:
+            self.directory_template = self.default_schema.directory_template
+
+        if self.default_schema.filename_template is None:
+            self.default_schema.filename_template = self.filename_template
+        else:
+            self.filename_template = self.default_schema.filename_template
+
+        if self.default_schema.metadata_fields:
+            self.metadata_fields = list(self.default_schema.metadata_fields)
+        else:
+            self.default_schema.metadata_fields = list(self.metadata_fields)
 
     def to_dict(self) -> dict[str, object]:
         """Convert the spec to a serialisable dictionary."""
+        default_schema = self.default_schema or RecordSchema(
+            directory_template=self.directory_template,
+            filename_template=self.filename_template,
+            metadata_fields=list(self.metadata_fields),
+        )
         return {
             "catalog_name": self.catalog_name,
             "db_backend": self.db_backend,
@@ -38,6 +134,10 @@ class CatalogSpec:
             "default_operation": self.default_operation,
             "field_resolution_order": list(self.field_resolution_order),
             "metadata_fields": [field_description.to_dict() for field_description in self.metadata_fields],
+            "default_schema": default_schema.to_dict(),
+            "record_schemas": {
+                record_type: schema.to_dict() for record_type, schema in self.record_schemas.items()
+            },
         }
 
     @classmethod
@@ -47,15 +147,26 @@ class CatalogSpec:
             _coerce_metadata_field_description(item)
             for item in _coerce_object_list(data.get("metadata_fields"), field_name="metadata_fields")
         ]
+        default_schema = _coerce_record_schema(data.get("default_schema"), field_name="default_schema")
+        record_schemas = _coerce_record_schema_mapping(data.get("record_schemas"))
+
+        directory_template = str(data.get("directory_template", DEFAULT_DIRECTORY_TEMPLATE))
+        filename_template = str(data.get("filename_template", DEFAULT_FILENAME_TEMPLATE))
+        if default_schema is not None:
+            if "directory_template" not in data and default_schema.directory_template is not None:
+                directory_template = default_schema.directory_template
+            if "filename_template" not in data and default_schema.filename_template is not None:
+                filename_template = default_schema.filename_template
+            if "metadata_fields" not in data:
+                metadata_fields = list(default_schema.metadata_fields)
+
         return cls(
             catalog_name=str(data["catalog_name"]),
             db_backend=str(data.get("db_backend", "tinydb")),
             db_path=str(data.get("db_path", "db.json")),
             files_root=str(data.get("files_root", "files")),
-            directory_template=str(data.get("directory_template", "{year_added}/{original_stem}")),
-            filename_template=str(
-                data.get("filename_template", "{title_slug|original_stem}{original_suffix}")
-            ),
+            directory_template=directory_template,
+            filename_template=filename_template,
             default_operation=data.get("default_operation", "copy"),  # type: ignore[arg-type]
             field_resolution_order=[
                 str(item)
@@ -66,7 +177,33 @@ class CatalogSpec:
             ]
             or ["top_level", "user_metadata", "derived_metadata"],
             metadata_fields=metadata_fields,
+            default_schema=default_schema,
+            record_schemas=record_schemas,
         )
+
+    def get_schema(self, record_type: str | None = None) -> RecordSchema:
+        """Return the effective schema for a record type.
+
+        Args:
+            record_type: Optional record type. When omitted, the broad default schema is returned.
+
+        Raises:
+            KeyError: If a non-default record type has no schema.
+        """
+        default_schema = self.default_schema or RecordSchema(
+            directory_template=self.directory_template,
+            filename_template=self.filename_template,
+            metadata_fields=list(self.metadata_fields),
+        )
+        if record_type is None:
+            return default_schema
+        if record_type not in self.record_schemas:
+            raise KeyError(f"Unknown record schema: {record_type}")
+        return self.record_schemas[record_type].with_fallbacks(default_schema)
+
+    def list_record_schemas(self) -> list[str]:
+        """Return available named record schema names."""
+        return sorted(self.record_schemas)
 
     def write(self, path: Path) -> None:
         """Write the spec JSON to disk."""
@@ -86,6 +223,33 @@ def _coerce_metadata_field_description(value: object) -> MetadataFieldDescriptio
     if not isinstance(value, dict):
         raise TypeError("metadata_fields entries must be dictionaries")
     return MetadataFieldDescription.from_dict(value)  # type: ignore[arg-type]
+
+
+def _coerce_record_schema(value: object, *, field_name: str) -> RecordSchema | None:
+    """Coerce a JSON-like schema object into a typed record schema."""
+    if value is None:
+        return None
+    if isinstance(value, RecordSchema):
+        return value
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a dictionary")
+    return RecordSchema.from_dict(value)  # type: ignore[arg-type]
+
+
+def _coerce_record_schema_mapping(value: object) -> dict[str, RecordSchema]:
+    """Coerce a JSON-like mapping of record type to schema."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("record_schemas must be a dictionary")
+
+    schemas: dict[str, RecordSchema] = {}
+    for record_type, raw_schema in value.items():
+        schema = _coerce_record_schema(raw_schema, field_name=f"record_schemas.{record_type}")
+        if schema is None:
+            raise TypeError(f"record_schemas.{record_type} must be a dictionary")
+        schemas[str(record_type)] = schema
+    return schemas
 
 
 def _coerce_object_list(value: object, *, field_name: str) -> list[object]:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -91,7 +91,10 @@ class CatalogSpec:
     def __post_init__(self) -> None:
         """Fill required defaults on the broad fallback schema."""
         self.record_schemas = _coerce_record_schema_mapping(self.record_schemas)
-        self.default_schema = self.default_schema.with_fallbacks(_default_record_schema())
+        default_schema = _coerce_record_schema(self.default_schema, field_name="default_schema")
+        self.default_schema = (default_schema or _default_record_schema()).with_fallbacks(
+            _default_record_schema()
+        )
 
     def to_dict(self) -> dict[str, object]:
         """Convert the spec to a serialisable dictionary."""

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -43,7 +43,7 @@ class RecordSchema:
             for item in _coerce_object_list(data.get("metadata_fields"), field_name="metadata_fields")
         ]
         return cls(
-            description=str(data.get("description", "")),
+            description=_coerce_optional_string(data.get("description"), default=""),
             directory_template=(
                 None if data.get("directory_template") is None else str(data["directory_template"])
             ),
@@ -90,7 +90,7 @@ class CatalogSpec:
 
     def __post_init__(self) -> None:
         """Fill required defaults on the broad fallback schema."""
-        self.record_schemas = dict(self.record_schemas)
+        self.record_schemas = _coerce_record_schema_mapping(self.record_schemas)
         self.default_schema = self.default_schema.with_fallbacks(_default_record_schema())
 
     def to_dict(self) -> dict[str, object]:
@@ -200,11 +200,21 @@ def _coerce_record_schema_mapping(value: object) -> dict[str, RecordSchema]:
 
     schemas: dict[str, RecordSchema] = {}
     for record_type, raw_schema in value.items():
-        schema = _coerce_record_schema(raw_schema, field_name=f"record_schemas.{record_type}")
+        schema = _coerce_record_schema(
+            raw_schema,
+            field_name=f"record_schemas[{record_type!r}]",
+        )
         if schema is None:
-            raise TypeError(f"record_schemas.{record_type} must be a dictionary")
+            raise TypeError(f"record_schemas[{record_type!r}] must be a dictionary")
         schemas[str(record_type)] = schema
     return schemas
+
+
+def _coerce_optional_string(value: object, *, default: str) -> str:
+    """Coerce optional JSON string-like values without turning null into 'None'."""
+    if value is None:
+        return default
+    return str(value)
 
 
 def _coerce_object_list(value: object, *, field_name: str) -> list[object]:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -203,13 +203,18 @@ def _coerce_record_schema_mapping(value: object) -> dict[str, RecordSchema]:
 
     schemas: dict[str, RecordSchema] = {}
     for record_type, raw_schema in value.items():
+        schema_name = str(record_type)
+        if schema_name in schemas:
+            raise ValueError(
+                f"record_schemas contains duplicate schema name after string coercion: {schema_name}"
+            )
         schema = _coerce_record_schema(
             raw_schema,
             field_name=f"record_schemas[{record_type!r}]",
         )
         if schema is None:
             raise TypeError(f"record_schemas[{record_type!r}] must be a dictionary")
-        schemas[str(record_type)] = schema
+        schemas[schema_name] = schema
     return schemas
 
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -587,7 +587,10 @@ def test_add_artifacts_rejects_non_dict_metadata_for_schema_validation(tmp_path:
         ),
     )
 
-    with pytest.raises(TypeError, match="Metadata for schema default must be a dictionary, got list"):
+    with pytest.raises(
+        TypeError,
+        match="artifact batch item 0: Metadata for schema default must be a dictionary, got list",
+    ):
         catalog.add_artifacts(
             [
                 {
@@ -595,6 +598,46 @@ def test_add_artifacts_rejects_non_dict_metadata_for_schema_validation(tmp_path:
                     "locator": ArtifactLocator.path("/tmp/data/file.nc"),
                     "metadata": ["not", "metadata"],
                 }
+            ]
+        )
+
+
+def test_add_artifacts_identifies_batch_item_for_missing_schema_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="artifacts",
+            record_schemas={
+                "external_reference": RecordSchema(
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="title",
+                            description="Short title.",
+                            required=True,
+                        )
+                    ]
+                )
+            },
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="artifact batch item 1: Missing required metadata for schema external_reference: title",
+    ):
+        catalog.add_artifacts(
+            [
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+                    "metadata": {"title": "First"},
+                },
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/second.nc"),
+                    "metadata": {},
+                },
             ]
         )
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -134,6 +134,41 @@ def test_add_file_uses_record_type_schema_for_naming(tmp_path: Path) -> None:
     assert expected.exists()
 
 
+def test_add_file_preserves_empty_schema_directory_template(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "anthropogenic.202401.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(
+                    directory_template="",
+                    filename_template="{product}{original_suffix}",
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="product",
+                            description="Product name.",
+                            required=True,
+                        )
+                    ],
+                )
+            },
+        ),
+    )
+
+    record = catalog.add_file(source, record_type="flux", metadata={"product": "CTE-HR"})
+
+    expected = root / "files" / "CTE-HR.nc"
+    assert _stored_path(record) == expected
+    assert record.naming_metadata["directory_template"] == ""
+    assert expected.exists()
+
+
 def test_add_file_rejects_unknown_explicit_record_schema(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()
@@ -524,6 +559,36 @@ def test_add_artifacts_raises_helpful_error_for_invalid_locator(tmp_path: Path) 
         assert "invalid locator" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Expected locator validation error")
+
+
+def test_add_artifacts_rejects_non_dict_metadata_for_schema_validation(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="artifacts",
+            default_schema=RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="title",
+                        description="Short title.",
+                        required=True,
+                    )
+                ]
+            ),
+        ),
+    )
+
+    with pytest.raises(TypeError, match="Metadata for schema default must be a dictionary, got list"):
+        catalog.add_artifacts(
+            [
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/file.nc"),
+                    "metadata": ["not", "metadata"],
+                }
+            ]
+        )
 
 
 def test_add_artifacts_assigns_sequential_record_ids_when_missing(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -215,6 +215,21 @@ def test_add_file_enforces_required_metadata_for_selected_schema(tmp_path: Path)
     assert catalog.describe()["record_count"] == 0
 
 
+def test_add_file_rejects_falsy_non_dict_metadata(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(TypeError, match="Metadata for schema default must be a dictionary, got list"):
+        catalog.add_file(source, metadata=[])  # type: ignore[arg-type]
+
+    assert catalog.describe()["record_count"] == 0
+
+
 def test_add_artifact_uses_default_schema_required_fields(tmp_path: Path) -> None:
     root = tmp_path / "catalog"
     catalog = Catalog.create(
@@ -238,6 +253,20 @@ def test_add_artifact_uses_default_schema_required_fields(tmp_path: Path) -> Non
             record_type="external_reference",
             locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
         )
+
+
+def test_add_artifact_rejects_falsy_non_dict_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(TypeError, match="Metadata for schema default must be a dictionary, got str"):
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+            metadata="",  # type: ignore[arg-type]
+        )
+
+    assert catalog.describe()["record_count"] == 0
 
 
 def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -49,13 +49,15 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
         root,
         CatalogSpec(
             catalog_name="fluxes",
-            directory_template=(
-                "{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/"
-                "{version|unversioned}/{flux_type|misc}"
-            ),
-            filename_template=(
-                "{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}"
-                "{original_suffix}"
+            default_schema=RecordSchema(
+                directory_template=(
+                    "{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/"
+                    "{version|unversioned}/{flux_type|misc}"
+                ),
+                filename_template=(
+                    "{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}"
+                    "{original_suffix}"
+                ),
             ),
         ),
     )
@@ -249,7 +251,9 @@ def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path
         root,
         CatalogSpec(
             catalog_name="fluxes",
-            filename_template="{year_month_or_original_stem}{original_suffix}",
+            default_schema=RecordSchema(
+                filename_template="{year_month_or_original_stem}{original_suffix}",
+            ),
         ),
     )
 
@@ -305,13 +309,15 @@ def test_add_file_appends_numeric_suffix_on_collision(tmp_path: Path) -> None:
         root,
         CatalogSpec(
             catalog_name="fluxes",
-            directory_template=(
-                "{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/"
-                "{version|unversioned}/{flux_type|misc}"
-            ),
-            filename_template=(
-                "{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}"
-                "{original_suffix}"
+            default_schema=RecordSchema(
+                directory_template=(
+                    "{species|UNKNOWN_SPECIES}/{domain|GLOBAL}/{product|unknown}/"
+                    "{version|unversioned}/{flux_type|misc}"
+                ),
+                filename_template=(
+                    "{product}_{version}_{species}_{domain}_{flux_type}_{year_month_or_original_stem}"
+                    "{original_suffix}"
+                ),
             ),
         ),
     )
@@ -345,8 +351,10 @@ def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -
         root,
         CatalogSpec(
             catalog_name="archives",
-            directory_template="{year_added}",
-            filename_template="bundle{original_suffix}",
+            default_schema=RecordSchema(
+                directory_template="{year_added}",
+                filename_template="bundle{original_suffix}",
+            ),
         ),
     )
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from ogcat import ArtifactLocator, Catalog, CatalogSpec
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 from ogcat.models import CatalogRecord
 
 
@@ -87,6 +87,120 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
     assert expected.exists()
     assert record.original_filename == "anthropogenic.202401.nc"
     assert record.storage_mode == "copy"
+
+
+def test_add_file_uses_record_type_schema_for_naming(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "anthropogenic.202401.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(
+                    directory_template="{species}/{domain|GLOBAL}/{product}",
+                    filename_template="{product}_{species}_{year_month_or_original_stem}{original_suffix}",
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="species",
+                            description="Gas species.",
+                            required=True,
+                        ),
+                        MetadataFieldDescription(
+                            name="product",
+                            description="Product name.",
+                            required=True,
+                        ),
+                    ],
+                )
+            },
+        ),
+    )
+
+    record = catalog.add_file(
+        source,
+        record_type="flux",
+        metadata={"product": "CTE-HR", "species": "CO2", "year": 2024, "month": 1},
+    )
+
+    expected = root / "files" / "CO2" / "GLOBAL" / "CTE-HR" / "CTE-HR_CO2_202401.nc"
+    assert _stored_path(record) == expected
+    assert record.record_type == "flux"
+    assert record.naming_metadata["record_schema"] == "flux"
+    assert expected.exists()
+
+
+def test_add_file_rejects_unknown_explicit_record_schema(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(ValueError, match="Unknown record schema: flux"):
+        catalog.add_file(source, record_type="flux")
+
+
+def test_add_file_enforces_required_metadata_for_selected_schema(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="species",
+                            description="Gas species.",
+                            required=True,
+                        )
+                    ]
+                )
+            },
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Missing required metadata for schema flux: species"):
+        catalog.add_file(source, record_type="flux", metadata={})
+
+    assert catalog.describe()["record_count"] == 0
+
+
+def test_add_artifact_uses_default_schema_required_fields(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="artifacts",
+            default_schema=RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="title",
+                        description="Short title.",
+                        required=True,
+                    )
+                ]
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Missing required metadata for schema default: title"):
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        )
 
 
 def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from ogcat import Catalog, CatalogSpec, MetadataFieldDescription
+from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 from ogcat.cli import app
 from ogcat.models import ArtifactLocator, CatalogRecord
 
@@ -37,7 +37,10 @@ def _create_catalog(tmp_path: Path, *, with_fields: bool = True) -> Catalog:
     )
     catalog = Catalog.create(
         tmp_path / "catalog",
-        CatalogSpec(catalog_name="fluxes", metadata_fields=metadata_fields),
+        CatalogSpec(
+            catalog_name="fluxes",
+            default_schema=RecordSchema(metadata_fields=metadata_fields),
+        ),
     )
     source = tmp_path / "anthropogenic.202401.nc"
     source.write_text("dummy", encoding="utf-8")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -134,6 +134,34 @@ def test_catalog_spec_normalises_constructor_record_schema_keys() -> None:
     assert spec.get_schema("1").directory_template == "{year_added}/{original_stem}"
 
 
+def test_catalog_spec_accepts_default_schema_dict_at_constructor_boundary() -> None:
+    spec = CatalogSpec(
+        catalog_name="files",
+        default_schema={
+            "metadata_fields": [
+                {
+                    "name": "title",
+                    "description": "Short title.",
+                    "required": True,
+                }
+            ]
+        },  # type: ignore[arg-type]
+    )
+
+    assert spec.default_schema.directory_template == "{year_added}/{original_stem}"
+    assert spec.default_schema.metadata_fields[0].name == "title"
+    assert spec.default_schema.metadata_fields[0].required is True
+
+
+def test_catalog_spec_rejects_invalid_default_schema_at_constructor_boundary() -> None:
+    try:
+        CatalogSpec(catalog_name="files", default_schema="not-a-schema")  # type: ignore[arg-type]
+    except TypeError as exc:
+        assert "default_schema must be a dictionary" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected TypeError for invalid default_schema")
+
+
 def test_record_schema_null_description_loads_as_empty_string() -> None:
     schema = RecordSchema.from_dict({"description": None, "metadata_fields": []})
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -113,6 +113,28 @@ def test_catalog_spec_rejects_malformed_list_fields() -> None:
             raise AssertionError(f"Expected malformed {field_name} to be rejected")
 
 
+def test_catalog_spec_does_not_mutate_default_schema_input() -> None:
+    schema = RecordSchema(metadata_fields=[MetadataFieldDescription(name="title", description="Title.")])
+
+    spec = CatalogSpec(catalog_name="files", default_schema=schema)
+
+    assert schema.directory_template is None
+    assert schema.filename_template is None
+    assert spec.default_schema.directory_template == "{year_added}/{original_stem}"
+    assert spec.default_schema.filename_template == "{title_slug|original_stem}{original_suffix}"
+
+
+def test_catalog_spec_get_schema_raises_value_error_for_unknown_schema() -> None:
+    spec = CatalogSpec(catalog_name="files")
+
+    try:
+        spec.get_schema("missing")
+    except ValueError as exc:
+        assert "Unknown record schema: missing" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for unknown record schema")
+
+
 def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tmp_path: Path) -> None:
     root = tmp_path / "fluxes"
     spec = CatalogSpec(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -124,6 +124,23 @@ def test_catalog_spec_does_not_mutate_default_schema_input() -> None:
     assert spec.default_schema.filename_template == "{title_slug|original_stem}{original_suffix}"
 
 
+def test_catalog_spec_normalises_constructor_record_schema_keys() -> None:
+    spec = CatalogSpec(
+        catalog_name="files",
+        record_schemas={1: RecordSchema(metadata_fields=[])},  # type: ignore[dict-item]
+    )
+
+    assert spec.list_record_schemas() == ["1"]
+    assert spec.get_schema("1").directory_template == "{year_added}/{original_stem}"
+
+
+def test_record_schema_null_description_loads_as_empty_string() -> None:
+    schema = RecordSchema.from_dict({"description": None, "metadata_fields": []})
+
+    assert schema.description == ""
+    assert "description" not in schema.to_dict()
+
+
 def test_catalog_spec_get_schema_raises_value_error_for_unknown_schema() -> None:
     spec = CatalogSpec(catalog_name="files")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,26 +24,31 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
         catalog_name="fluxes",
         default_operation="move",
         field_resolution_order=["user_metadata", "top_level", "derived_metadata"],
-        metadata_fields=[
-            MetadataFieldDescription(
-                name="species",
-                description="Gas species name used for grouping and search.",
-                example="CO2",
-                required=True,
-            ),
-            MetadataFieldDescription(
-                name="product",
-                description="Upstream product identifier.",
-                example="CTE-HR",
-            ),
-        ],
+        default_schema=RecordSchema(
+            metadata_fields=[
+                MetadataFieldDescription(
+                    name="species",
+                    description="Gas species name used for grouping and search.",
+                    example="CO2",
+                    required=True,
+                ),
+                MetadataFieldDescription(
+                    name="product",
+                    description="Upstream product identifier.",
+                    example="CTE-HR",
+                ),
+            ]
+        ),
     )
 
     Catalog.create(root, spec)
     serialized = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
     reloaded = CatalogSpec.read(root / "catalog.json")
 
-    assert serialized["metadata_fields"] == [
+    assert "metadata_fields" not in serialized
+    assert "directory_template" not in serialized
+    assert "filename_template" not in serialized
+    assert serialized["default_schema"]["metadata_fields"] == [
         {
             "name": "species",
             "description": "Gas species name used for grouping and search.",
@@ -58,34 +63,6 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
         },
     ]
     assert reloaded == spec
-
-
-def test_catalog_spec_preserves_legacy_top_level_schema_fields(tmp_path: Path) -> None:
-    root = tmp_path / "fluxes"
-    root.mkdir()
-    legacy_spec = {
-        "catalog_name": "fluxes",
-        "db_backend": "tinydb",
-        "db_path": "db.json",
-        "files_root": "files",
-        "directory_template": "{species}/{product}",
-        "filename_template": "{product}{original_suffix}",
-        "metadata_fields": [
-            {
-                "name": "species",
-                "description": "Gas species.",
-                "required": True,
-            }
-        ],
-    }
-    (root / "catalog.json").write_text(json.dumps(legacy_spec), encoding="utf-8")
-
-    spec = CatalogSpec.read(root / "catalog.json")
-
-    assert spec.directory_template == "{species}/{product}"
-    assert spec.filename_template == "{product}{original_suffix}"
-    assert spec.get_schema().directory_template == "{species}/{product}"
-    assert spec.get_schema().metadata_fields[0].required is True
 
 
 def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
@@ -127,7 +104,7 @@ def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
 
 
 def test_catalog_spec_rejects_malformed_list_fields() -> None:
-    for field_name in ["metadata_fields", "field_resolution_order"]:
+    for field_name in ["field_resolution_order"]:
         try:
             CatalogSpec.from_dict({"catalog_name": "fluxes", field_name: "not-a-list"})
         except TypeError as exc:
@@ -140,14 +117,16 @@ def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tm
     root = tmp_path / "fluxes"
     spec = CatalogSpec(
         catalog_name="fluxes",
-        metadata_fields=[
-            MetadataFieldDescription(
-                name="species",
-                description="Gas species name used for grouping and search.",
-                example="CO2",
-                required=True,
-            )
-        ],
+        default_schema=RecordSchema(
+            metadata_fields=[
+                MetadataFieldDescription(
+                    name="species",
+                    description="Gas species name used for grouping and search.",
+                    example="CO2",
+                    required=True,
+                )
+            ]
+        ),
     )
 
     catalog = Catalog.create(root, spec)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from ogcat import Catalog, CatalogSpec, MetadataFieldDescription
+from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 
 
 def test_create_and_open_catalog(tmp_path: Path) -> None:
@@ -60,6 +60,72 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
     assert reloaded == spec
 
 
+def test_catalog_spec_preserves_legacy_top_level_schema_fields(tmp_path: Path) -> None:
+    root = tmp_path / "fluxes"
+    root.mkdir()
+    legacy_spec = {
+        "catalog_name": "fluxes",
+        "db_backend": "tinydb",
+        "db_path": "db.json",
+        "files_root": "files",
+        "directory_template": "{species}/{product}",
+        "filename_template": "{product}{original_suffix}",
+        "metadata_fields": [
+            {
+                "name": "species",
+                "description": "Gas species.",
+                "required": True,
+            }
+        ],
+    }
+    (root / "catalog.json").write_text(json.dumps(legacy_spec), encoding="utf-8")
+
+    spec = CatalogSpec.read(root / "catalog.json")
+
+    assert spec.directory_template == "{species}/{product}"
+    assert spec.filename_template == "{product}{original_suffix}"
+    assert spec.get_schema().directory_template == "{species}/{product}"
+    assert spec.get_schema().metadata_fields[0].required is True
+
+
+def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
+    root = tmp_path / "fluxes"
+    spec = CatalogSpec(
+        catalog_name="fluxes",
+        default_schema=RecordSchema(
+            description="Generic fallback schema for heterogeneous files.",
+            directory_template="{year_added}/{original_stem}",
+            filename_template="{title_slug|original_stem}{original_suffix}",
+            metadata_fields=[
+                MetadataFieldDescription(name="title", description="Short title."),
+            ],
+        ),
+        record_schemas={
+            "flux": RecordSchema(
+                description="Schema for gridded flux datasets.",
+                directory_template="{species}/{product}",
+                filename_template="{product}_{species}{original_suffix}",
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="species",
+                        description="Gas species.",
+                        required=True,
+                    ),
+                    MetadataFieldDescription(name="product", description="Product name."),
+                ],
+            )
+        },
+    )
+
+    Catalog.create(root, spec)
+    serialized = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+    reloaded = CatalogSpec.read(root / "catalog.json")
+
+    assert serialized["default_schema"]["description"] == "Generic fallback schema for heterogeneous files."
+    assert serialized["record_schemas"]["flux"]["metadata_fields"][0]["required"] is True
+    assert reloaded == spec
+
+
 def test_catalog_spec_rejects_malformed_list_fields() -> None:
     for field_name in ["metadata_fields", "field_resolution_order"]:
         try:
@@ -104,3 +170,36 @@ def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tm
             "required": True,
         }
     ]
+
+
+def test_catalog_schema_helpers_return_serialisable_values(tmp_path: Path) -> None:
+    root = tmp_path / "fluxes"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="species",
+                            description="Gas species.",
+                            required=True,
+                        )
+                    ]
+                )
+            },
+        ),
+    )
+
+    assert catalog.list_record_schemas() == ["flux"]
+    assert catalog.describe()["record_schemas"] == ["flux"]
+    assert catalog.get_schema("flux")["metadata_fields"] == [
+        {
+            "name": "species",
+            "description": "Gas species.",
+            "example": None,
+            "required": True,
+        }
+    ]
+    assert catalog.list_metadata_fields("flux")[0]["name"] == "species"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -103,6 +103,22 @@ def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
     assert reloaded == spec
 
 
+def test_metadata_field_description_serialises_type_information() -> None:
+    field_description = MetadataFieldDescription(
+        name="species",
+        description="Gas species.",
+        example="co2",
+        required=True,
+        value_types=["str", "species"],
+    )
+
+    payload = field_description.to_dict()
+    reloaded = MetadataFieldDescription.from_dict(payload)
+
+    assert payload["type"] == ["str", "species"]
+    assert reloaded == field_description
+
+
 def test_catalog_spec_rejects_malformed_list_fields() -> None:
     for field_name in ["field_resolution_order"]:
         try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -150,6 +150,21 @@ def test_catalog_spec_normalises_constructor_record_schema_keys() -> None:
     assert spec.get_schema("1").directory_template == "{year_added}/{original_stem}"
 
 
+def test_catalog_spec_rejects_record_schema_key_collisions_after_string_coercion() -> None:
+    try:
+        CatalogSpec(
+            catalog_name="files",
+            record_schemas={
+                1: RecordSchema(description="Integer key."),  # type: ignore[dict-item]
+                "1": RecordSchema(description="String key."),
+            },
+        )
+    except ValueError as exc:
+        assert "duplicate schema name after string coercion: 1" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for colliding record schema keys")
+
+
 def test_catalog_spec_accepts_default_schema_dict_at_constructor_boundary() -> None:
     spec = CatalogSpec(
         catalog_name="files",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -193,6 +193,7 @@ def test_catalog_schema_helpers_return_serialisable_values(tmp_path: Path) -> No
     )
 
     assert catalog.list_record_schemas() == ["flux"]
+    assert catalog.describe()["has_metadata_fields"] is True
     assert catalog.describe()["record_schemas"] == ["flux"]
     assert catalog.get_schema("flux")["metadata_fields"] == [
         {
@@ -203,3 +204,13 @@ def test_catalog_schema_helpers_return_serialisable_values(tmp_path: Path) -> No
         }
     ]
     assert catalog.list_metadata_fields("flux")[0]["name"] == "species"
+
+
+def test_record_schema_fallbacks_preserve_empty_templates() -> None:
+    schema = RecordSchema(directory_template="", filename_template="")
+    fallback = RecordSchema(directory_template="{year_added}", filename_template="{original_filename}")
+
+    resolved = schema.with_fallbacks(fallback)
+
+    assert resolved.directory_template == ""
+    assert resolved.filename_template == ""


### PR DESCRIPTION
## Summary
- Add a lightweight `RecordSchema` model with `default_schema` plus named `record_schemas` on `CatalogSpec`
- Make `default_schema` the source of truth for metadata fields and naming templates, removing the earlier MVP top-level schema fields before there is real catalog migration burden
- Make file ingest and artifact creation schema-aware with required-metadata checks and schema-specific naming
- Expose schema helpers on `Catalog` and update the CLI `add`, `fields`, and `info` commands for coherence
- Add a short design note documenting the schema-first model and intentionally deferred richer schema behavior

## Testing
- Added unit coverage for schema round-tripping, schema selection, required-field validation, schema-aware naming, empty-template fallback behavior, non-dict metadata errors, and default-schema copy behavior
- Ran the project test suite and static checks locally: `ruff format --check .`, `ruff check .`, `pytest`, and `pyright`