### PR TITLE
Add search display controls for limits and fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+## Project setup
+
+- Prefer `uv` for all Python environment and dependency management.
+- Use the project-local virtual environment at `.venv/`.
+- Do not silently use a global Python, system Python, conda environment, or ad-hoc `pip install`.
+- If `.venv/` is missing, stop and ask whether to run `uv sync`.
+- If imports fail because optional dependencies are missing, inspect `pyproject.toml` for extras and ask which extras to install rather than inventing a workaround.
+- Run Python commands through uv, for example:
+  - `uv run python ...`
+  - `uv run pytest ...`
+  - `uv run ruff check ...`
+  - `uv run mypy ...`
+
+## Development workflow
+
+- Make small, focused changes.
+- Preserve the existing public API unless explicitly asked to change it.
+- Prefer readability over clever abstraction.
+- Use `pathlib` for filesystem paths.
+- Follow PEP naming conventions.
+- Follow Google Python style when in doubt.
+- Use type hints for new or changed public Python code.
+
+## Docstrings
+
+- Public modules, classes, functions, and methods should have Google-style docstrings.
+- Private helpers should have at least a one-line docstring.
+- If a private helper has several arguments, non-obvious behavior, or important return values, use a full Google-style docstring.
+
+## Checks
+
+For changed Python code, run:
+
+;;;
+uv run ruff check <changed files>
+uv run ruff format --check <changed files>
+;;;
+
+If formatting is needed, run:
+
+;;;
+uv run ruff format <changed files>
+;;;
+
+Then run the most appropriate available type checker. Prefer the tool already configured in the repo:
+
+;;;
+uv run mypy ...
+uv run pyright ...
+uv run ty check ...
+;;;
+
+Use whichever of these is available and configured. Do not add a new type checker without asking.
+
+## Tests
+
+- Run focused tests while developing.
+- Before pushing or opening a PR, run the full test suite if it is reasonably quick.
+- If the full suite takes more than about a minute, use judgement: run the relevant subset and explain what was not run.
+- Prefer:
+
+;;;
+uv run pytest
+;;;
+
+or a focused command such as:
+
+;;;
+uv run pytest tests/path/to/test_file.py -q
+;;;
+
+## Git hygiene
+
+- Do not commit unless explicitly asked.
+- Do not push unless explicitly asked.
+- Before finishing, summarize:
+  - files changed,
+  - checks run,
+  - checks not run,
+  - any assumptions or follow-up needed.
+
+## When blocked
+
+If environment setup, missing extras, failing credentials, missing data, or unavailable services block progress, stop and report the blocker. Do not create mock replacements or bypass project tooling unless explicitly asked.
+
+## Scientific/data code
+
+- Preserve coordinates, dimensions, metadata, and attrs unless the task requires changing them.
+- Prefer xarray-native operations for labelled arrays.
+- Avoid eager `.values`/NumPy conversion unless there is a clear reason.
+- Keep units explicit.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ ogcat search --catalog ./example-catalog --regex version='^v4\.[0-9]+$'
 ogcat search --catalog ./example-catalog --where derived_metadata.netcdf.dims.time=12 --paths
 ogcat search --catalog ./example-catalog --where species=CO2 --limit 20
 ogcat search --catalog ./example-catalog --where species=CO2 --fields id,species,user_metadata.domain,path
+ogcat search --catalog ./example-catalog --where species=CO2 --fields id,species,path --format tsv
 ogcat search --catalog ./example-catalog --where species=CO2 --all
 ```
 
@@ -151,7 +152,7 @@ ogcat fields --catalog ./example-catalog
 ogcat fields --catalog ./example-catalog --json
 ```
 
-`ogcat search` supports exact equality through `--where`, substring matching through `--contains`, and regular expressions through `--regex`. Human-readable search output is capped by default; use `--limit N` to choose a cap or `--all` to show every match. Use `--fields a,b,c` to choose table columns. For automation and shell use, `--json`, `--ids`, and `--paths` provide stable machine-friendly outputs; `--json` prints full matching records and ignores `--fields` and the default display cap.
+`ogcat search` supports exact equality through `--where`, substring matching through `--contains`, and regular expressions through `--regex`. Human-readable search output is capped by default; use `--limit N` to choose a cap or `--all` to show every match. Use `--fields a,b,c` to choose displayed fields, and `--format table|plain|csv|tsv|pipe` to choose the display format. For automation and shell use, `--json`, `--ids`, and `--paths` provide stable machine-friendly outputs; `--json` prints full matching records and ignores `--fields`, `--format`, and the default display cap.
 
 ## Search Semantics
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ ogcat search --catalog ./example-catalog --where species=CO2
 ogcat search --catalog ./example-catalog --contains title=anthropogenic --ignore-case
 ogcat search --catalog ./example-catalog --regex version='^v4\.[0-9]+$'
 ogcat search --catalog ./example-catalog --where derived_metadata.netcdf.dims.time=12 --paths
+ogcat search --catalog ./example-catalog --where species=CO2 --limit 20
+ogcat search --catalog ./example-catalog --where species=CO2 --fields id,species,user_metadata.domain,path
+ogcat search --catalog ./example-catalog --where species=CO2 --all
 ```
 
 Show a record or print its stored path:
@@ -148,7 +151,7 @@ ogcat fields --catalog ./example-catalog
 ogcat fields --catalog ./example-catalog --json
 ```
 
-`ogcat search` supports exact equality through `--where`, substring matching through `--contains`, and regular expressions through `--regex`. For automation and shell use, `--json`, `--ids`, and `--paths` provide stable machine-friendly outputs.
+`ogcat search` supports exact equality through `--where`, substring matching through `--contains`, and regular expressions through `--regex`. Human-readable search output is capped by default; use `--limit N` to choose a cap or `--all` to show every match. Use `--fields a,b,c` to choose table columns. For automation and shell use, `--json`, `--ids`, and `--paths` provide stable machine-friendly outputs; `--json` prints full matching records and ignores `--fields` and the default display cap.
 
 ## Search Semantics
 

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -12,6 +12,8 @@ from rich.console import Console
 from rich.table import Table
 
 from ogcat.catalog import Catalog
+from ogcat.models import CatalogRecord
+from ogcat.search import flatten_lookup
 from ogcat.spec import CatalogSpec
 
 app = typer.Typer(
@@ -20,6 +22,8 @@ app = typer.Typer(
 )
 console = Console()
 error_console = Console(stderr=True)
+DEFAULT_SEARCH_LIMIT = 50
+DEFAULT_SEARCH_FIELDS = ["id", "title", "product", "species", "path"]
 
 
 def _fail(message: str, *, code: int = 1) -> NoReturn:
@@ -105,6 +109,52 @@ def _parse_key_value_options(items: list[str]) -> dict[str, str]:
     return parsed
 
 
+def _parse_fields_option(fields: str | None) -> list[str] | None:
+    """Parse a comma-separated display field list."""
+    if fields is None:
+        return None
+    parsed = [field.strip() for field in fields.split(",")]
+    if any(not field for field in parsed):
+        raise typer.BadParameter("--fields must be a comma-separated list of field names.")
+    return parsed
+
+
+def _resolve_display_field(
+    record: CatalogRecord,
+    field: str,
+    *,
+    resolution_order: list[str],
+) -> Any:
+    """Resolve a display field without changing search semantics."""
+    if field == "path":
+        return record.path()
+    if field == "locator.uri":
+        return record.locator.value if record.locator.kind == "uri" else None
+    return flatten_lookup(record, field, resolution_order=resolution_order)
+
+
+def _format_display_value(value: Any) -> str:
+    """Format a display value for table output."""
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def _displayed_results(
+    results: list[CatalogRecord],
+    *,
+    limit: int | None,
+    all_results: bool,
+    json_mode: bool,
+) -> list[CatalogRecord]:
+    """Apply display-only result capping."""
+    if json_mode or all_results or limit is None:
+        return results
+    return results[:limit]
+
+
 @app.command()
 def init(
     root: Annotated[Path, typer.Argument(help="Catalog root directory.")],
@@ -180,7 +230,10 @@ def search(
     ] = False,
     json_mode: Annotated[
         bool,
-        typer.Option("--json", help="Print matching records as JSON."),
+        typer.Option(
+            "--json",
+            help="Print full matching records as JSON. Ignores --fields and default display cap.",
+        ),
     ] = False,
     ids_only: Annotated[
         bool,
@@ -190,9 +243,33 @@ def search(
         bool,
         typer.Option("--paths", help="Print only matching stored paths."),
     ] = False,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", min=0, help="Cap displayed results. Does not affect --json output."),
+    ] = None,
+    all_results: Annotated[
+        bool,
+        typer.Option("--all", help="Show all results, disabling the default display cap."),
+    ] = False,
+    fields: Annotated[
+        str | None,
+        typer.Option(
+            "--fields",
+            help=(
+                "Comma-separated table fields. Supports flattened names and dotted paths. "
+                "Ignored with --json, --ids, and --paths."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Search records in a catalog."""
     _validate_output_flags(json_mode=json_mode, ids_only=ids_only, paths_only=paths_only)
+    if all_results and limit is not None:
+        raise typer.BadParameter("Use either --all or --limit, not both.")
+    display_limit = limit if limit is not None else DEFAULT_SEARCH_LIMIT
+    display_fields = DEFAULT_SEARCH_FIELDS
+    if not any([json_mode, ids_only, paths_only]):
+        display_fields = _parse_fields_option(fields) or DEFAULT_SEARCH_FIELDS
     active_catalog = _open_catalog_or_fail(catalog)
     results = active_catalog.search(
         where=_parse_meta_items([] if where is None else where),
@@ -205,13 +282,20 @@ def search(
         _print_json([record.to_dict() for record in results])
         return
 
+    shown_results = _displayed_results(
+        results,
+        limit=display_limit,
+        all_results=all_results,
+        json_mode=json_mode,
+    )
+
     if ids_only:
-        for record in results:
+        for record in shown_results:
             typer.echo(record.id)
         return
 
     if paths_only:
-        for record in results:
+        for record in shown_results:
             resolved = record.path()
             if resolved is not None:
                 typer.echo(str(resolved))
@@ -222,23 +306,29 @@ def search(
         return
 
     table = Table(title="ogcat search results")
-    table.add_column("id")
-    table.add_column("title")
-    table.add_column("product")
-    table.add_column("species")
-    table.add_column("path")
+    for field in display_fields:
+        table.add_column(field, overflow="fold")
 
-    for record in results:
-        resolved_path = record.path()
+    for record in shown_results:
         table.add_row(
-            record.id,
-            str(record.user_metadata.get("title", "")),
-            str(record.user_metadata.get("product", "")),
-            str(record.user_metadata.get("species", "")),
-            "" if resolved_path is None else str(resolved_path),
+            *[
+                _format_display_value(
+                    _resolve_display_field(
+                        record,
+                        field,
+                        resolution_order=active_catalog.spec.field_resolution_order,
+                    )
+                )
+                for field in display_fields
+            ]
         )
 
     console.print(f"{len(results)} result(s)")
+    if len(shown_results) < len(results):
+        console.print(
+            f"Showing {len(shown_results)} of {len(results)} matches. "
+            "Use --limit N, --all, or --json for more."
+        )
     console.print(table)
 
 

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import os
+import sys
 from pathlib import Path
-from typing import Annotated, Any, NoReturn
+from typing import Annotated, Any, Literal, NoReturn
 
 import typer
 from rich.console import Console
@@ -24,6 +26,7 @@ console = Console()
 error_console = Console(stderr=True)
 DEFAULT_SEARCH_LIMIT = 50
 DEFAULT_SEARCH_FIELDS = ["id", "title", "product", "species", "path"]
+SearchOutputFormat = Literal["table", "plain", "csv", "tsv", "pipe"]
 
 
 def _fail(message: str, *, code: int = 1) -> NoReturn:
@@ -119,6 +122,21 @@ def _parse_fields_option(fields: str | None) -> list[str] | None:
     return parsed
 
 
+def _parse_search_output_format(output_format: str) -> SearchOutputFormat:
+    """Parse the search table/delimited output format."""
+    if output_format == "table":
+        return "table"
+    if output_format == "plain":
+        return "plain"
+    if output_format == "csv":
+        return "csv"
+    if output_format == "tsv":
+        return "tsv"
+    if output_format == "pipe":
+        return "pipe"
+    raise typer.BadParameter("Expected one of: table, plain, csv, tsv, pipe.")
+
+
 def _resolve_display_field(
     record: CatalogRecord,
     field: str,
@@ -140,6 +158,50 @@ def _format_display_value(value: Any) -> str:
     if isinstance(value, (dict, list)):
         return json.dumps(value, sort_keys=True)
     return str(value)
+
+
+def _search_display_rows(
+    records: list[CatalogRecord],
+    *,
+    fields: list[str],
+    resolution_order: list[str],
+) -> list[list[str]]:
+    """Resolve search records into display-ready string rows."""
+    return [
+        [
+            _format_display_value(
+                _resolve_display_field(
+                    record,
+                    field,
+                    resolution_order=resolution_order,
+                )
+            )
+            for field in fields
+        ]
+        for record in records
+    ]
+
+
+def _print_search_table(*, fields: list[str], rows: list[list[str]]) -> None:
+    """Print search results as a Rich table."""
+    table = Table(title="ogcat search results")
+    for field in fields:
+        table.add_column(field, overflow="fold")
+    for row in rows:
+        table.add_row(*row)
+    console.print(table)
+
+
+def _print_delimited_search_output(
+    *,
+    fields: list[str],
+    rows: list[list[str]],
+    delimiter: str,
+) -> None:
+    """Print search results as delimiter-separated text with a header row."""
+    writer = csv.writer(sys.stdout, delimiter=delimiter, lineterminator="\n")
+    writer.writerow(fields)
+    writer.writerows(rows)
 
 
 def _displayed_results(
@@ -256,11 +318,20 @@ def search(
         typer.Option(
             "--fields",
             help=(
-                "Comma-separated table fields. Supports flattened names and dotted paths. "
+                "Comma-separated display fields. Supports flattened names and dotted paths. "
                 "Ignored with --json, --ids, and --paths."
             ),
         ),
     ] = None,
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            help=(
+                "Display format: table, plain, csv, tsv, or pipe. Ignored with --json, --ids, and --paths."
+            ),
+        ),
+    ] = "table",
 ) -> None:
     """Search records in a catalog."""
     _validate_output_flags(json_mode=json_mode, ids_only=ids_only, paths_only=paths_only)
@@ -268,8 +339,10 @@ def search(
         raise typer.BadParameter("Use either --all or --limit, not both.")
     display_limit = limit if limit is not None else DEFAULT_SEARCH_LIMIT
     display_fields = DEFAULT_SEARCH_FIELDS
+    parsed_output_format: SearchOutputFormat = "table"
     if not any([json_mode, ids_only, paths_only]):
         display_fields = _parse_fields_option(fields) or DEFAULT_SEARCH_FIELDS
+        parsed_output_format = _parse_search_output_format(output_format)
     active_catalog = _open_catalog_or_fail(catalog)
     results = active_catalog.search(
         where=_parse_meta_items([] if where is None else where),
@@ -301,27 +374,29 @@ def search(
                 typer.echo(str(resolved))
         return
 
-    if not results:
+    if not results and parsed_output_format == "table":
         console.print("No records matched.")
         return
 
-    table = Table(title="ogcat search results")
-    for field in display_fields:
-        table.add_column(field, overflow="fold")
+    rows = _search_display_rows(
+        shown_results,
+        fields=display_fields,
+        resolution_order=active_catalog.spec.field_resolution_order,
+    )
 
-    for record in shown_results:
-        table.add_row(
-            *[
-                _format_display_value(
-                    _resolve_display_field(
-                        record,
-                        field,
-                        resolution_order=active_catalog.spec.field_resolution_order,
-                    )
-                )
-                for field in display_fields
-            ]
+    if parsed_output_format != "table":
+        delimiters = {"plain": " ", "csv": ",", "tsv": "\t", "pipe": "|"}
+        _print_delimited_search_output(
+            fields=display_fields,
+            rows=rows,
+            delimiter=delimiters[parsed_output_format],
         )
+        if len(shown_results) < len(results):
+            error_console.print(
+                f"Showing {len(shown_results)} of {len(results)} matches. "
+                "Use --limit N, --all, or --json for more."
+            )
+        return
 
     console.print(f"{len(results)} result(s)")
     if len(shown_results) < len(results):
@@ -329,7 +404,7 @@ def search(
             f"Showing {len(shown_results)} of {len(results)} matches. "
             "Use --limit N, --all, or --json for more."
         )
-    console.print(table)
+    _print_search_table(fields=display_fields, rows=rows)
 
 
 @app.command()

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -355,9 +355,10 @@ def search(
         _print_json([record.to_dict() for record in results])
         return
 
+    result_limit = limit if any([ids_only, paths_only]) else display_limit
     shown_results = _displayed_results(
         results,
-        limit=display_limit,
+        limit=result_limit,
         all_results=all_results,
         json_mode=json_mode,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,175 @@ def test_search_json_output(tmp_path: Path) -> None:
     assert payload[0]["user_metadata"]["species"] == "CO2"
 
 
+def test_search_limit_caps_human_output(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2", "title": f"record-{index}"},
+            }
+            for index in range(3)
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--limit", "2"],
+    )
+
+    assert result.exit_code == 0
+    assert "3 result(s)" in result.stdout
+    assert "Showing 2 of 3 matches. Use --limit N, --all, or --json for more." in result.stdout
+    assert records[0].id in result.stdout
+    assert records[1].id in result.stdout
+    assert "record-2" not in result.stdout
+
+
+def test_search_all_disables_default_cap(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2", "title": f"record-{index}"},
+            }
+            for index in range(51)
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--all"],
+    )
+
+    assert result.exit_code == 0
+    assert "51 result(s)" in result.stdout
+    assert "Showing 50 of 51 matches" not in result.stdout
+    assert "record-50" in result.stdout
+
+
+def test_search_default_cap_limits_human_output(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2", "title": f"record-{index}"},
+            }
+            for index in range(51)
+        ]
+    )
+
+    result = runner.invoke(app, ["search", "--catalog", str(catalog.root), "--where", "species=CO2"])
+
+    assert result.exit_code == 0
+    assert "51 result(s)" in result.stdout
+    assert "Showing 50 of 51 matches. Use --limit N, --all, or --json for more." in result.stdout
+    assert "record-49" in result.stdout
+    assert "record-50" not in result.stdout
+
+
+def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--fields", "id,species,path"],
+    )
+
+    assert result.exit_code == 0
+    assert "id" in result.stdout
+    assert "species" in result.stdout
+    assert "path" in result.stdout
+    assert _record_id(record) in result.stdout
+    assert "CO2" in result.stdout
+    assert "anthropogenic" in result.stdout
+    assert "files" in result.stdout
+    assert "product" not in result.stdout
+    assert "CTE-HR" not in result.stdout
+
+
+def test_search_fields_supports_dotted_paths_and_locator_uri(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2", "domain": "EUROPE"},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--where",
+            "species=CO2",
+            "--fields",
+            "id,user_metadata.domain,locator.uri",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "user_metadata.domain" in result.stdout
+    assert "locator.uri" in result.stdout
+    assert "EUROPE" in result.stdout
+    assert "s3://bucket/example.zarr" in result.stdout
+
+
+def test_search_json_ignores_fields_and_display_cap(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2", "title": f"record-{index}"},
+            }
+            for index in range(51)
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--where",
+            "species=CO2",
+            "--fields",
+            "id,,species",
+            "--limit",
+            "2",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert len(payload) == 51
+    assert set(payload[0]) >= {"id", "locator", "user_metadata"}
+    assert payload[0]["user_metadata"]["species"] == "CO2"
+
+
+def test_search_rejects_limit_with_all(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--limit", "1", "--all"],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --all or --limit, not both." in result.output
+
+
 def test_show_json_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
     record = catalog.search()[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,8 +99,8 @@ def test_search_limit_caps_human_output(tmp_path: Path) -> None:
     stdout = strip_ansi(result.stdout)
     assert "3 result(s)" in stdout
     assert "Showing 2 of 3 matches. Use --limit N, --all, or --json for more." in stdout
-    assert records[0].id in stdout
-    assert records[1].id in stdout
+    assert _record_id(records[0]) in stdout
+    assert _record_id(records[1]) in stdout
     assert "record-2" not in stdout
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import csv
 import json
 import re
+from io import StringIO
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -203,6 +205,88 @@ def test_search_fields_supports_dotted_paths_and_locator_uri(tmp_path: Path) -> 
     assert "s3://bucket/example.zarr" in stdout
 
 
+def test_search_format_tsv_outputs_data_without_rich_table(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2"},
+            }
+            for index in range(2)
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--where",
+            "species=CO2",
+            "--fields",
+            "id,species,locator.uri",
+            "--format",
+            "tsv",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert strip_ansi(result.stdout).splitlines() == [
+        "id\tspecies\tlocator.uri",
+        f"{_record_id(records[0])}\tCO2\ts3://bucket/record-0.zarr",
+    ]
+    assert "result(s)" not in strip_ansi(result.stdout)
+    assert "Showing 1 of 2 matches. Use --limit N, --all, or --json for more." in strip_ansi(result.stderr)
+
+
+def test_search_format_csv_quotes_values(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2", "title": "A value, with comma"},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--where",
+            "species=CO2",
+            "--fields",
+            "id,title",
+            "--format",
+            "csv",
+        ],
+    )
+
+    assert result.exit_code == 0
+    rows = list(csv.reader(StringIO(strip_ansi(result.stdout))))
+    assert rows == [
+        ["id", "title"],
+        [_record_id(record), "A value, with comma"],
+    ]
+
+
+def test_search_rejects_unknown_format_for_display_output(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--format", "yaml"],
+    )
+
+    assert result.exit_code != 0
+    assert "Expected one of: table, plain, csv, tsv, pipe." in strip_ansi(result.output)
+
+
 def test_search_json_ignores_fields_and_display_cap(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     catalog.add_artifacts(
@@ -228,6 +312,8 @@ def test_search_json_ignores_fields_and_display_cap(tmp_path: Path) -> None:
             "id,,species",
             "--limit",
             "2",
+            "--format",
+            "not-a-format",
             "--json",
         ],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,6 +493,50 @@ def test_search_paths_skips_non_path_backed_records(tmp_path: Path) -> None:
     assert lines[0].endswith("source.nc")
 
 
+def test_search_ids_and_paths_are_not_capped_by_default(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    for index in range(51):
+        source = tmp_path / f"source-{index}.nc"
+        source.write_text("dummy", encoding="utf-8")
+        catalog.add_file(source, metadata={"species": "CO2"})
+
+    ids_result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--ids"],
+    )
+    paths_result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--paths"],
+    )
+
+    assert ids_result.exit_code == 0
+    assert paths_result.exit_code == 0
+    assert len([line for line in strip_ansi(ids_result.stdout).splitlines() if line.strip()]) == 51
+    assert len([line for line in strip_ansi(paths_result.stdout).splitlines() if line.strip()]) == 51
+
+
+def test_search_limit_can_cap_ids_output(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/record-{index}.zarr"),
+                "metadata": {"species": "CO2"},
+            }
+            for index in range(3)
+        ]
+    )
+
+    result = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--ids", "--limit", "2"],
+    )
+
+    assert result.exit_code == 0
+    assert strip_ansi(result.stdout).splitlines() == ["1", "2"]
+
+
 def test_search_human_output_uses_empty_path_for_non_path_backed_records(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     catalog.add_artifact(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -10,6 +11,11 @@ from ogcat.cli import app
 from ogcat.models import ArtifactLocator, CatalogRecord
 
 runner = CliRunner()
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
 
 
 def _record_id(record: CatalogRecord) -> str:
@@ -66,7 +72,7 @@ def test_search_json_output(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.stdout)
+    payload = json.loads(strip_ansi(result.stdout))
     assert [item["id"] for item in payload] == [_record_id(record)]
     assert payload[0]["user_metadata"]["species"] == "CO2"
 
@@ -90,11 +96,12 @@ def test_search_limit_caps_human_output(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert "3 result(s)" in result.stdout
-    assert "Showing 2 of 3 matches. Use --limit N, --all, or --json for more." in result.stdout
-    assert records[0].id in result.stdout
-    assert records[1].id in result.stdout
-    assert "record-2" not in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "3 result(s)" in stdout
+    assert "Showing 2 of 3 matches. Use --limit N, --all, or --json for more." in stdout
+    assert records[0].id in stdout
+    assert records[1].id in stdout
+    assert "record-2" not in stdout
 
 
 def test_search_all_disables_default_cap(tmp_path: Path) -> None:
@@ -116,9 +123,10 @@ def test_search_all_disables_default_cap(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert "51 result(s)" in result.stdout
-    assert "Showing 50 of 51 matches" not in result.stdout
-    assert "record-50" in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "51 result(s)" in stdout
+    assert "Showing 50 of 51 matches" not in stdout
+    assert "record-50" in stdout
 
 
 def test_search_default_cap_limits_human_output(tmp_path: Path) -> None:
@@ -137,10 +145,11 @@ def test_search_default_cap_limits_human_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["search", "--catalog", str(catalog.root), "--where", "species=CO2"])
 
     assert result.exit_code == 0
-    assert "51 result(s)" in result.stdout
-    assert "Showing 50 of 51 matches. Use --limit N, --all, or --json for more." in result.stdout
-    assert "record-49" in result.stdout
-    assert "record-50" not in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "51 result(s)" in stdout
+    assert "Showing 50 of 51 matches. Use --limit N, --all, or --json for more." in stdout
+    assert "record-49" in stdout
+    assert "record-50" not in stdout
 
 
 def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
@@ -153,15 +162,16 @@ def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert "id" in result.stdout
-    assert "species" in result.stdout
-    assert "path" in result.stdout
-    assert _record_id(record) in result.stdout
-    assert "CO2" in result.stdout
-    assert "anthropogenic" in result.stdout
-    assert "files" in result.stdout
-    assert "product" not in result.stdout
-    assert "CTE-HR" not in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "id" in stdout
+    assert "species" in stdout
+    assert "path" in stdout
+    assert _record_id(record) in stdout
+    assert "CO2" in stdout
+    assert "anthropogenic" in stdout
+    assert "files" in stdout
+    assert "product" not in stdout
+    assert "CTE-HR" not in stdout
 
 
 def test_search_fields_supports_dotted_paths_and_locator_uri(tmp_path: Path) -> None:
@@ -186,10 +196,11 @@ def test_search_fields_supports_dotted_paths_and_locator_uri(tmp_path: Path) -> 
     )
 
     assert result.exit_code == 0
-    assert "user_metadata.domain" in result.stdout
-    assert "locator.uri" in result.stdout
-    assert "EUROPE" in result.stdout
-    assert "s3://bucket/example.zarr" in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "user_metadata.domain" in stdout
+    assert "locator.uri" in stdout
+    assert "EUROPE" in stdout
+    assert "s3://bucket/example.zarr" in stdout
 
 
 def test_search_json_ignores_fields_and_display_cap(tmp_path: Path) -> None:
@@ -222,7 +233,7 @@ def test_search_json_ignores_fields_and_display_cap(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.stdout)
+    payload = json.loads(strip_ansi(result.stdout))
     assert len(payload) == 51
     assert set(payload[0]) >= {"id", "locator", "user_metadata"}
     assert payload[0]["user_metadata"]["species"] == "CO2"
@@ -237,7 +248,7 @@ def test_search_rejects_limit_with_all(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "Use either --all or --limit, not both." in result.output
+    assert "Use either --all or --limit, not both." in strip_ansi(result.output)
 
 
 def test_show_json_output(tmp_path: Path) -> None:
@@ -247,7 +258,7 @@ def test_show_json_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["show", _record_id(record), "--catalog", str(catalog.root), "--json"])
 
     assert result.exit_code == 0
-    payload = json.loads(result.stdout)
+    payload = json.loads(strip_ansi(result.stdout))
     assert payload["id"] == _record_id(record)
     assert payload["record_type"] == "managed_file"
     assert payload["locator"]["kind"] == "path"
@@ -260,9 +271,10 @@ def test_info_human_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["info", "--catalog", str(catalog.root)])
 
     assert result.exit_code == 0
-    assert "catalog info" in result.stdout
-    assert "fluxes" in result.stdout
-    assert "record count" in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "catalog info" in stdout
+    assert "fluxes" in stdout
+    assert "record count" in stdout
 
 
 def test_info_json_output(tmp_path: Path) -> None:
@@ -271,7 +283,7 @@ def test_info_json_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["info", "--catalog", str(catalog.root), "--json"])
 
     assert result.exit_code == 0
-    payload = json.loads(result.stdout)
+    payload = json.loads(strip_ansi(result.stdout))
     assert payload["catalog_name"] == "fluxes"
     assert payload["record_count"] == 1
     assert payload["has_metadata_fields"] is True
@@ -283,9 +295,10 @@ def test_fields_human_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["fields", "--catalog", str(catalog.root)])
 
     assert result.exit_code == 0
-    assert "metadata fields" in result.stdout
-    assert "species" in result.stdout
-    assert "Gas species name used for grouping" in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "metadata fields" in stdout
+    assert "species" in stdout
+    assert "Gas species name used for grouping" in stdout
 
 
 def test_fields_json_output(tmp_path: Path) -> None:
@@ -294,7 +307,7 @@ def test_fields_json_output(tmp_path: Path) -> None:
     result = runner.invoke(app, ["fields", "--catalog", str(catalog.root), "--json"])
 
     assert result.exit_code == 0
-    payload = json.loads(result.stdout)
+    payload = json.loads(strip_ansi(result.stdout))
     assert payload[0]["name"] == "species"
     assert payload[0]["required"] is True
 
@@ -305,7 +318,7 @@ def test_fields_human_output_handles_missing_field_descriptions(tmp_path: Path) 
     result = runner.invoke(app, ["fields", "--catalog", str(catalog.root)])
 
     assert result.exit_code == 0
-    assert "No metadata fields are defined in this catalog." in result.stdout
+    assert "No metadata fields are defined in this catalog." in strip_ansi(result.stdout)
 
 
 def test_add_accepts_multiple_metadata_items_after_single_meta_flag(tmp_path: Path) -> None:
@@ -362,14 +375,14 @@ def test_show_missing_record_returns_helpful_error(tmp_path: Path) -> None:
     result = runner.invoke(app, ["show", "missing", "--catalog", str(catalog.root)])
 
     assert result.exit_code == 1
-    assert "Error: Record not found: missing" in result.stderr
+    assert "Error: Record not found: missing" in strip_ansi(result.stderr)
 
 
 def test_missing_catalog_configuration_returns_helpful_error() -> None:
     result = runner.invoke(app, ["info"])
 
     assert result.exit_code != 0
-    assert "Provide --catalog or set OGCAT_CATALOG." in result.stderr
+    assert "Provide --catalog or set OGCAT_CATALOG." in strip_ansi(result.stderr)
 
 
 def test_search_paths_skips_non_path_backed_records(tmp_path: Path) -> None:
@@ -389,7 +402,7 @@ def test_search_paths_skips_non_path_backed_records(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    lines = [line for line in strip_ansi(result.stdout).splitlines() if line.strip()]
     assert len(lines) == 1
     assert lines[0].endswith("source.nc")
 
@@ -405,5 +418,6 @@ def test_search_human_output_uses_empty_path_for_non_path_backed_records(tmp_pat
     result = runner.invoke(app, ["search", "--catalog", str(catalog.root), "--where", "species=CO2"])
 
     assert result.exit_code == 0
-    assert "Remote artifact" in result.stdout
-    assert "None" not in result.stdout
+    stdout = strip_ansi(result.stdout)
+    assert "Remote artifact" in stdout
+    assert "None" not in stdout


### PR DESCRIPTION
## Summary
- Add `--limit`, `--all`, and `--fields` to `ogcat search` as presentation-layer controls
- Keep `--json` as full-record output and leave search semantics untouched
- Document the new options and default human-output cap in the README

## Testing
- Added CLI coverage for default cap behavior, explicit limits, `--all`, field selection, dotted display paths, and JSON interaction
- Ran the full test suite locally: `96 passed, 1 skipped`