### PR TITLE
Add lightweight catalog transactions and rollback

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,17 @@ The abstraction is useful even in the current small codebase:
 
 This is not a claim that multiple backends already exist. It only means the package boundary is already in place.
 
+## Transaction Boundaries And Rollback
+
+Catalog writes use a lightweight unit-of-work helper for multi-step operations such as managed
+file ingest. With the current TinyDB backend this is a best-effort rollback mechanism based on
+compensating actions: staged records can be deleted and owned copied files can be removed if a later
+step fails. It is not a true database transaction and should not be described as ACID.
+
+Each unit of work exposes an `operation_id` so future audit logging or hooks can correlate staged
+record writes, storage activity, and cleanup. Stronger backends can map the same conceptual API to
+native transaction support later.
+
 ## Why Templates and Metadata Live in `catalog.json`
 
 The default schema, optional named record schemas, default operation, and field resolution order

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -3,6 +3,7 @@
 from ogcat.catalog import Catalog
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.spec import CatalogSpec, RecordSchema
+from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import (
     ValidationIssue,
     ValidationReport,
@@ -18,7 +19,10 @@ __all__ = [
     "CatalogRecord",
     "CatalogSpec",
     "MetadataFieldDescription",
+    "OperationState",
+    "RollbackFailure",
     "RecordSchema",
+    "UnitOfWork",
     "ValidationIssue",
     "ValidationReport",
     "validate_metadata",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import shutil
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -14,6 +15,7 @@ from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.repository import CatalogRepository
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.tinydb_repository import TinyDbCatalogRepository
+from ogcat.transactions import UnitOfWork
 from ogcat.validation import validate_metadata
 
 
@@ -74,11 +76,11 @@ class Catalog:
             suffixes=source.suffixes,
             time_added=timestamp,
         )
-        persisted_record = self.repository.insert(draft_record)
-        record_id = _require_record_id(persisted_record)
 
-        target: Path | None = None
-        try:
+        with self.transaction() as transaction:
+            persisted_record = transaction.insert_staged_record(draft_record)
+            record_id = _require_record_id(persisted_record)
+
             context = build_naming_context(
                 record_id=record_id,
                 original_path=source,
@@ -95,6 +97,10 @@ class Catalog:
             target.parent.mkdir(parents=True, exist_ok=True)
 
             if chosen_operation == "copy":
+                transaction.register_rollback(
+                    lambda path=target: path.unlink(missing_ok=True),
+                    description=f"remove copied file {target}",
+                )
                 shutil.copy2(source, target)
                 storage_mode = "copy"
             else:
@@ -123,14 +129,8 @@ class Catalog:
                 time_added=timestamp,
             )
             self.repository.update(record)
+            transaction.commit()
             return record
-        except Exception:
-            if chosen_operation == "copy" and target is not None:
-                with suppress(Exception):
-                    target.unlink()
-            with suppress(Exception):
-                self.repository.delete(record_id)
-            raise
 
     def add_artifact(
         self,
@@ -145,12 +145,14 @@ class Catalog:
         derived_metadata: MetadataDict | None = None,
         naming_metadata: MetadataDict | None = None,
         time_added: str | None = None,
+        transaction: UnitOfWork | None = None,
     ) -> CatalogRecord:
         """Add an artifact record without performing any file operation.
 
         This is the minimal general record API. `add_file()` remains the managed
         ingest convenience wrapper that prepares a path-backed locator and then
-        delegates here.
+        delegates here. Pass a catalog transaction to stage the record as part
+        of a larger best-effort unit of work.
         """
         schema = self._select_schema(record_type, require_known=False)
         self._validate_metadata(
@@ -170,7 +172,23 @@ class Catalog:
             naming_metadata=naming_metadata,
             time_added=time_added,
         )
-        return self.repository.insert(record)
+        if transaction is not None:
+            return transaction.insert_staged_record(record)
+        with self.transaction() as unit_of_work:
+            persisted = unit_of_work.insert_staged_record(record)
+            unit_of_work.commit()
+            return persisted
+
+    @contextmanager
+    def transaction(self) -> Iterator[UnitOfWork]:
+        """Create a best-effort unit of work for composed catalog operations.
+
+        The current TinyDB backend uses staged writes and compensating rollback
+        actions. This context manager does not provide true database
+        transactions or ACID semantics.
+        """
+        with UnitOfWork(self.repository) as transaction:
+            yield transaction
 
     def add_artifacts(
         self,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -173,6 +173,8 @@ class Catalog:
             time_added=time_added,
         )
         if transaction is not None:
+            if transaction.repository is not self.repository:
+                raise ValueError("Transaction is bound to a different catalog repository.")
             return transaction.insert_staged_record(record)
         with self.transaction() as unit_of_work:
             persisted = unit_of_work.insert_staged_record(record)

--- a/src/ogcat/transactions.py
+++ b/src/ogcat/transactions.py
@@ -1,0 +1,169 @@
+"""Best-effort catalog transaction helpers.
+
+The TinyDB-backed implementation uses compensating rollback actions. This is a
+unit-of-work helper, not a true database transaction or ACID boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol, cast
+from uuid import uuid4
+
+from ogcat.models import CatalogRecord
+from ogcat.repository import CatalogRepository
+
+
+class OperationState(StrEnum):
+    """Lifecycle state for a best-effort catalog operation."""
+
+    PLANNED = "planned"
+    STAGED = "staged"
+    COMMITTED = "committed"
+    ROLLED_BACK = "rolled_back"
+    FAILED = "failed"
+
+
+class RollbackAction(Protocol):
+    """Action that can compensate for part of a staged operation."""
+
+    @property
+    def description(self) -> str:
+        """Human-readable cleanup description."""
+        ...
+
+    def undo(self) -> None:
+        """Undo the staged operation."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CallableRollbackAction:
+    """Rollback action backed by a callable."""
+
+    description: str
+    callback: Callable[[], None]
+
+    def undo(self) -> None:
+        """Run the rollback callback."""
+        self.callback()
+
+
+@dataclass(frozen=True, slots=True)
+class RollbackFailure:
+    """A rollback action failure captured during best-effort cleanup."""
+
+    description: str
+    exception: BaseException
+
+
+class UnitOfWork:
+    """Best-effort unit of work for catalog record staging and cleanup.
+
+    Args:
+        repository: Repository used for staged catalog record writes.
+        operation_id: Optional externally supplied operation id. If omitted, a
+            random id is generated for audit/debug correlation.
+    """
+
+    def __init__(self, repository: CatalogRepository, *, operation_id: str | None = None) -> None:
+        self.repository = repository
+        self.operation_id = operation_id or uuid4().hex
+        self.state = OperationState.PLANNED
+        self.rollback_errors: list[RollbackFailure] = []
+        self._rollback_actions: list[RollbackAction] = []
+
+    def __enter__(self) -> UnitOfWork:
+        """Enter the unit-of-work context."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> bool:
+        """Rollback uncommitted work and preserve any active exception."""
+        if self.state is not OperationState.COMMITTED:
+            self.rollback(original_exception=exc)
+        return False
+
+    def register_rollback(
+        self,
+        action: RollbackAction | Callable[[], None],
+        *,
+        description: str | None = None,
+    ) -> RollbackAction:
+        """Register an action to run if the unit of work rolls back.
+
+        Args:
+            action: A rollback action object or a no-argument callable.
+            description: Human-readable cleanup description for callable
+                actions. Ignored for action objects that already carry one.
+
+        Returns:
+            The registered rollback action.
+        """
+        if callable(action) and not hasattr(action, "undo"):
+            rollback_action: RollbackAction = CallableRollbackAction(
+                description=description or getattr(action, "__name__", "rollback action"),
+                callback=action,
+            )
+        else:
+            rollback_action = cast(RollbackAction, action)
+        self._rollback_actions.append(rollback_action)
+        if self.state is OperationState.PLANNED:
+            self.state = OperationState.STAGED
+        return rollback_action
+
+    def insert_staged_record(self, record: CatalogRecord) -> CatalogRecord:
+        """Insert a staged record and delete it if the unit of work rolls back."""
+        persisted = self.repository.insert(record)
+        if persisted.id is None:
+            raise RuntimeError("Repository returned a persisted record without an id.")
+        record_id = persisted.id
+        self.register_rollback(
+            lambda: self.repository.delete(record_id),
+            description=f"delete staged catalog record {record_id}",
+        )
+        self.state = OperationState.STAGED
+        return persisted
+
+    def stage_record(self, record: CatalogRecord) -> CatalogRecord:
+        """Alias for ``insert_staged_record``."""
+        return self.insert_staged_record(record)
+
+    def commit(self) -> None:
+        """Commit staged work and discard rollback actions."""
+        self._rollback_actions.clear()
+        self.state = OperationState.COMMITTED
+
+    def rollback(self, *, original_exception: BaseException | None = None) -> None:
+        """Run registered rollback actions in reverse order.
+
+        Args:
+            original_exception: Optional exception that triggered rollback. When
+                supplied, rollback failure summaries are added as exception notes
+                so the original failure remains visible to callers.
+        """
+        if self.state is OperationState.COMMITTED:
+            return
+        while self._rollback_actions:
+            action = self._rollback_actions.pop()
+            try:
+                action.undo()
+            except Exception as exc:
+                self.rollback_errors.append(RollbackFailure(action.description, exc))
+
+        if self.rollback_errors:
+            self.state = OperationState.FAILED
+            if original_exception is not None:
+                for failure in self.rollback_errors:
+                    original_exception.add_note(
+                        f"rollback failed for {failure.description}: "
+                        f"{type(failure.exception).__name__}: {failure.exception}"
+                    )
+        else:
+            self.state = OperationState.ROLLED_BACK

--- a/src/ogcat/transactions.py
+++ b/src/ogcat/transactions.py
@@ -106,6 +106,8 @@ class UnitOfWork:
         Returns:
             The registered rollback action.
         """
+        if self.state is OperationState.COMMITTED:
+            raise RuntimeError("Cannot register rollback action after commit.")
         if callable(action) and not hasattr(action, "undo"):
             rollback_action: RollbackAction = CallableRollbackAction(
                 description=description or getattr(action, "__name__", "rollback action"),
@@ -120,6 +122,8 @@ class UnitOfWork:
 
     def insert_staged_record(self, record: CatalogRecord) -> CatalogRecord:
         """Insert a staged record and delete it if the unit of work rolls back."""
+        if self.state is OperationState.COMMITTED:
+            raise RuntimeError("Cannot stage record after commit.")
         persisted = self.repository.insert(record)
         if persisted.id is None:
             raise RuntimeError("Repository returned a persisted record without an id.")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -430,6 +430,30 @@ def test_add_file_rolls_back_record_when_naming_fails(
     assert list((root / "files").rglob("*.nc")) == []
 
 
+def test_add_file_rolls_back_record_after_staged_insert_before_file_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "broken.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_before_file_write(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("simulated post-insert failure")
+
+    monkeypatch.setattr("ogcat.catalog.render_storage_location", fail_before_file_write)
+
+    with pytest.raises(RuntimeError, match="simulated post-insert failure"):
+        catalog.add_file(source)
+
+    assert catalog.repository.all() == []
+    assert list((root / "files").rglob("*.nc")) == []
+
+
 def test_add_file_removes_partial_target_when_copy_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -453,6 +477,56 @@ def test_add_file_removes_partial_target_when_copy_fails(
 
     assert catalog.describe()["record_count"] == 0
     assert list((root / "files").rglob("*.nc")) == []
+
+
+def test_add_file_removes_copied_target_when_record_update_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "copied.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_update(record: CatalogRecord) -> None:
+        raise OSError("simulated update failure")
+
+    monkeypatch.setattr(catalog.repository, "update", fail_update)
+
+    with pytest.raises(OSError, match="simulated update failure"):
+        catalog.add_file(source)
+
+    assert source.exists()
+    assert catalog.describe()["record_count"] == 0
+    assert list((root / "files").rglob("copied.nc")) == []
+
+
+def test_add_file_removes_copied_target_when_metadata_extraction_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "metadata.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_extract(path: Path) -> dict[str, object]:
+        raise ValueError("simulated metadata failure")
+
+    monkeypatch.setattr("ogcat.catalog.extract_derived_metadata", fail_extract)
+
+    with pytest.raises(ValueError, match="simulated metadata failure"):
+        catalog.add_file(source)
+
+    assert source.exists()
+    assert catalog.describe()["record_count"] == 0
+    assert list((root / "files").rglob("metadata.nc")) == []
 
 
 def test_add_file_does_not_delete_moved_file_when_record_update_fails(
@@ -480,6 +554,22 @@ def test_add_file_does_not_delete_moved_file_when_record_update_fails(
     assert moved_files[0].read_text(encoding="utf-8") == "dummy"
     assert not source.exists()
     assert catalog.describe()["record_count"] == 0
+
+
+def test_add_file_committed_record_shape_does_not_include_transaction_metadata(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source)
+
+    assert "operation_id" not in record.to_dict()
+    assert "transaction_id" not in record.to_dict()
+    assert catalog.repository.all() == [record]
 
 
 def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,113 @@
+"""Best-effort transaction behavior tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import ArtifactLocator, Catalog, CatalogRecord, CatalogSpec, OperationState, UnitOfWork
+
+
+def _artifact_record() -> CatalogRecord:
+    """Build a simple non-file artifact record."""
+    return CatalogRecord(
+        catalog="artifacts",
+        time_added="2026-04-27T12:00:00Z",
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+    )
+
+
+def test_catalog_transaction_rolls_back_staged_artifact_when_later_work_fails(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(RuntimeError, match="later operation failed"), catalog.transaction() as transaction:
+        persisted = transaction.insert_staged_record(_artifact_record())
+        assert persisted.id == "1"
+        raise RuntimeError("later operation failed")
+
+    assert catalog.repository.all() == []
+
+
+def test_add_artifact_can_stage_record_in_catalog_transaction(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(RuntimeError, match="later operation failed"), catalog.transaction() as transaction:
+        record = catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+            transaction=transaction,
+        )
+        assert record.id == "1"
+        raise RuntimeError("later operation failed")
+
+    assert catalog.repository.all() == []
+
+
+def test_catalog_transaction_commit_keeps_staged_artifact(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with catalog.transaction() as transaction:
+        persisted = transaction.insert_staged_record(_artifact_record())
+        operation_id = transaction.operation_id
+        transaction.commit()
+
+    assert operation_id
+    assert transaction.state is OperationState.COMMITTED
+    assert catalog.repository.all() == [persisted]
+
+
+def test_commit_prevents_registered_rollback_actions_from_running(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+    calls: list[str] = []
+
+    with catalog.transaction() as transaction:
+        transaction.register_rollback(lambda: calls.append("rollback"), description="record call")
+        transaction.commit()
+
+    assert calls == []
+    assert transaction.rollback_errors == []
+
+
+def test_rollback_action_failure_is_recorded_and_original_exception_remains_visible(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    def fail_rollback() -> None:
+        raise OSError("cleanup failed")
+
+    with (
+        pytest.raises(RuntimeError, match="original failure") as exc_info,
+        UnitOfWork(catalog.repository) as transaction,
+    ):
+        transaction.register_rollback(fail_rollback, description="failing cleanup")
+        raise RuntimeError("original failure")
+
+    assert transaction.state is OperationState.FAILED
+    assert len(transaction.rollback_errors) == 1
+    assert transaction.rollback_errors[0].description == "failing cleanup"
+    assert "original failure" in str(exc_info.value)
+    assert exc_info.value.__notes__ == [
+        "rollback failed for failing cleanup: OSError: cleanup failed",
+    ]
+
+
+def test_direct_add_artifact_commits_normally(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CO2"},
+    )
+
+    assert record.id == "1"
+    assert catalog.repository.all() == [record]

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -74,6 +74,43 @@ def test_commit_prevents_registered_rollback_actions_from_running(tmp_path: Path
     assert transaction.rollback_errors == []
 
 
+def test_transaction_rejects_rollback_registration_after_commit(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with catalog.transaction() as transaction:
+        transaction.commit()
+
+        with pytest.raises(RuntimeError, match="Cannot register rollback action after commit"):
+            transaction.register_rollback(lambda: None, description="too late")
+
+
+def test_transaction_rejects_record_staging_after_commit(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with catalog.transaction() as transaction:
+        transaction.commit()
+
+        with pytest.raises(RuntimeError, match="Cannot stage record after commit"):
+            transaction.insert_staged_record(_artifact_record())
+
+
+def test_add_artifact_rejects_transaction_from_another_catalog(tmp_path: Path) -> None:
+    first = Catalog.create(tmp_path / "first", CatalogSpec(catalog_name="first"))
+    second = Catalog.create(tmp_path / "second", CatalogSpec(catalog_name="second"))
+
+    with first.transaction() as transaction, pytest.raises(ValueError, match="different catalog repository"):
+        second.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+            transaction=transaction,
+        )
+
+    assert first.repository.all() == []
+    assert second.repository.all() == []
+
+
 def test_rollback_action_failure_is_recorded_and_original_exception_remains_visible(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a best-effort `UnitOfWork` layer with staged record insertion, rollback actions, operation ids, and rollback failure capture.
- Refactor `Catalog.add_file()` to use the shared transaction path instead of bespoke cleanup logic.
- Allow `Catalog.add_artifact()` to participate in a caller-managed catalog transaction while preserving the existing simple direct API.
- Document the TinyDB rollback model as compensating-action based, not ACID.

## Testing
- Added unit tests for rollback after staged record creation, copy/write failures, metadata extraction failures, committed records, and rollback failure reporting.
- Verified the focused catalog and repository suites, the new transaction tests, lint/format checks, and `pyright`.
- Full test suite passes with one existing optional skip.