### PR TITLE
Add hook and plugin extension points

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ catalog.search(where={"derived_metadata.netcdf.dims.time": 12})
 Register simple hooks directly in Python:
 
 ```python
-from ogcat import PluginRegistry
+from ogcat import Catalog, CatalogSpec, PluginRegistry
 from ogcat.hooks import OperationContext
 
 
@@ -120,6 +120,7 @@ class FilenameTitlePlugin:
             context.user_metadata.setdefault("title", context.source_path.stem)
 
 
+spec = CatalogSpec(catalog_name="files")
 plugins = PluginRegistry([FilenameTitlePlugin()])
 catalog = Catalog.create("example-catalog", spec, plugins=plugins)
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ catalog = Catalog.create("example-catalog", spec, plugins=plugins)
 See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for hook lifecycle,
 rollback, and transaction examples.
 
+In this hook model, `add_artifact()` records an artifact locator but does not write artifact data.
+`add_file()` is the bundled local-file operation that copies or moves data before writing the record.
+
 ## CLI
 
 Initialise a catalog:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ adding files by copy or move, listing metadata field descriptions, and locating 
   can grow beyond copied or moved local files without changing the basic catalog shape.
 - Naming and templates: file placement under `files/` is driven by simple directory and filename templates evaluated from record id, source filename parts, timestamps, and user metadata.
 - Derived metadata extractors: optional extractors can add lightweight summaries after ingest. The current implementation includes a netCDF extractor when `xarray` is installed.
+- Hooks and plugins: projects can register Python hook objects to add domain-specific metadata,
+  validation, rollback, and lifecycle behavior without adding that logic to `ogcat` core.
 - Search and CLI: search supports exact equality, substring contains, and regex matching, with flattened field lookup and dotted-path access for nested metadata. The CLI exposes the same search model and adds shell-oriented output modes.
 
 ## Catalog Layout
@@ -104,6 +106,26 @@ catalog.search(contains={"title": "anthropogenic"}, ignore_case=True)
 catalog.search(where={"user_metadata.product.family.revision": 2})
 catalog.search(where={"derived_metadata.netcdf.dims.time": 12})
 ```
+
+Register simple hooks directly in Python:
+
+```python
+from ogcat import PluginRegistry
+from ogcat.hooks import OperationContext
+
+
+class FilenameTitlePlugin:
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        if context.source_path is not None:
+            context.user_metadata.setdefault("title", context.source_path.stem)
+
+
+plugins = PluginRegistry([FilenameTitlePlugin()])
+catalog = Catalog.create("example-catalog", spec, plugins=plugins)
+```
+
+See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for hook lifecycle,
+rollback, and transaction examples.
 
 ## CLI
 
@@ -203,4 +225,5 @@ The current direction is:
 
 See [docs/architecture.md](docs/architecture.md),
 [docs/design-note-artifact-locators.md](docs/design-note-artifact-locators.md),
+[docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md),
 and [docs/roadmap.md](docs/roadmap.md) for more detail.

--- a/docs/design-note-artifact-locators.md
+++ b/docs/design-note-artifact-locators.md
@@ -42,8 +42,9 @@ break in record shape.
 
 ## New API Surface
 
-`Catalog.add_file(...)` is now a convenience wrapper around a more general
-`Catalog.add_artifact(...)` method.
+`Catalog.add_file(...)` and `Catalog.add_artifact(...)` now share the same internal add-operation
+lifecycle. `add_file(...)` is the local-file specialisation: it resolves a path locator, copies or
+moves the source file, extracts generic metadata, and writes a record.
 
 `add_artifact(...)` does not perform file operations. It registers a record with an explicit
 `record_type` and `locator`. That keeps the current managed-file path simple while creating a small

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -1,0 +1,132 @@
+# Hooks, Plugins, And Transactions
+
+`ogcat` hooks let projects add domain-specific ingest behavior without adding that domain logic to
+`ogcat` core. A plugin is just a Python object with one or more hook methods registered on a
+`PluginRegistry` or `HookManager`.
+
+Hooks are called in registration order. Most hook failures fail the catalog operation and use the
+normal transaction rollback path. `after_commit` is different: it runs after the catalog operation
+has already committed, so failures are reported as Python warnings rather than changing a successful
+catalog write into an exception.
+
+## Direct Registration
+
+```python
+from ogcat import Catalog, CatalogSpec, PluginRegistry
+from ogcat.hooks import OperationContext
+
+
+class FilenameMetadataPlugin:
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        if context.source_path is None:
+            return
+        context.user_metadata.setdefault("title", context.source_path.stem)
+
+
+plugins = PluginRegistry([FilenameMetadataPlugin()])
+catalog = Catalog.create("example-catalog", CatalogSpec(catalog_name="files"), plugins=plugins)
+record = catalog.add_file("co2_example.nc")
+```
+
+Use `before_validate_metadata` for metadata defaults, normalisation, or light parsing that must run
+before schema validation and naming templates.
+
+## Validation Hooks
+
+Hooks can add project-specific validation without changing `RecordSchema` or importing a project
+package into `ogcat`:
+
+```python
+class SpeciesRequiredPlugin:
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        if "species" not in context.user_metadata:
+            raise ValueError("species is required for this catalog")
+```
+
+Raising from a pre-commit hook fails the add operation. If work has already been staged, the active
+`UnitOfWork` runs rollback actions before the exception returns to the caller.
+
+## Derived Metadata Warnings
+
+Metadata discovery hooks can add warning-only findings and still allow ingest to succeed:
+
+```python
+from ogcat import HookWarning
+
+
+class SoftFilenameParser:
+    def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+        context.add_warning(
+            HookWarning(
+                hook_name="filename-parser",
+                message="could not infer averaging period from filename",
+                code="filename.missing_averaging_period",
+            )
+        )
+        return {"filename_stem": context.source_path.stem if context.source_path else None}
+```
+
+Warnings recorded before commit are stored under `record.derived_metadata["hook_warnings"]`.
+
+## Rollback Participation
+
+Hooks that create external side effects should register cleanup work with `context.rollback()`:
+
+```python
+class ExternalIndexPlugin:
+    def after_write_artifact(self, context: OperationContext) -> None:
+        external_id = write_external_index(context.operation_id)
+
+        context.rollback(
+            lambda: delete_external_index(external_id),
+            description=f"delete external index entry {external_id}",
+        )
+```
+
+Rollback actions run in reverse registration order. They are best-effort compensating actions, not
+database transactions.
+
+## Composed Transactions
+
+Callers can pass a `UnitOfWork` to compose multiple catalog operations. In this mode the caller owns
+commit and rollback decisions:
+
+```python
+from ogcat import ArtifactLocator
+
+with catalog.transaction() as transaction:
+    first = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/first.zarr"),
+        transaction=transaction,
+    )
+    second = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/second.zarr"),
+        transaction=transaction,
+    )
+
+    transaction.commit()
+```
+
+If a hook fails inside a caller-owned transaction, `add_artifact(..., transaction=transaction)` raises
+but does not immediately roll back the whole transaction. The caller can inspect state, add
+diagnostics, roll back, or let the transaction context manager roll back on exit.
+
+## Lifecycle Points
+
+The initial hook surface is intentionally small:
+
+- `before_validate_metadata(context)`
+- `after_validate_metadata(context, report)`
+- `plan_locator(context)`
+- `before_write_artifact(context)`
+- `after_write_artifact(context)`
+- `extract_metadata(context)`
+- `before_commit(context)`
+- `after_commit(context)`
+- `on_error(context, error)`
+- `on_rollback(context, error)`
+
+The context includes the catalog root, operation id, operation name, record type, user metadata,
+derived metadata, planned locators, source information, storage mode, and rollback registration.

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -9,6 +9,20 @@ normal transaction rollback path. `after_commit` is different: it runs after the
 has already committed, so failures are reported as Python warnings rather than changing a successful
 catalog write into an exception.
 
+Terminology matters:
+
+- a **record** is the catalog database entry;
+- an **artifact** is the data object being catalogued;
+- a **locator** describes where the artifact is or will be;
+- an **operation** coordinates validation, locator resolution, optional artifact work, record writes,
+  hooks, and rollback.
+
+`Catalog.add_artifact(...)` is record-only in this version: it records a locator for an artifact, but
+does not write artifact data. `Catalog.add_file(...)` is a bundled local-file operation: it resolves a
+path locator, copies or moves the source file, extracts generic metadata, and writes the record.
+Future data-from-memory writes should be modeled as explicit operations or artifact writers rather
+than as record-write hooks.
+
 ## Direct Registration
 
 ```python
@@ -74,7 +88,7 @@ Hooks that create external side effects should register cleanup work with `conte
 
 ```python
 class ExternalIndexPlugin:
-    def after_write_artifact(self, context: OperationContext) -> None:
+    def after_record_write(self, context: OperationContext) -> None:
         external_id = write_external_index(context.operation_id)
 
         context.rollback(
@@ -119,14 +133,22 @@ The initial hook surface is intentionally small:
 
 - `before_validate_metadata(context)`
 - `after_validate_metadata(context, report)`
-- `plan_locator(context)`
-- `before_write_artifact(context)`
-- `after_write_artifact(context)`
+- `resolve_artifact_locator(context)`
+- `before_record_write(context)`
+- `after_record_write(context)`
 - `extract_metadata(context)`
 - `before_commit(context)`
 - `after_commit(context)`
 - `on_error(context, error)`
 - `on_rollback(context, error)`
 
-The context includes the catalog root, operation id, operation name, record type, user metadata,
+Hooks exert their effect by mutating `OperationContext`, raising an exception, or registering
+rollback work:
+
+- mutate `user_metadata` before validation to add defaults or normalise caller input;
+- mutate `planned_locators` during `resolve_artifact_locator`; the first locator is canonical;
+- return or add `derived_metadata` during `extract_metadata`;
+- call `context.rollback(...)` after creating external side effects.
+
+The context includes the catalog root, operation id, operation type, record type, user metadata,
 derived metadata, planned locators, source information, storage mode, and rollback registration.

--- a/docs/ogcat_long_term_plan.md
+++ b/docs/ogcat_long_term_plan.md
@@ -1,0 +1,2123 @@
+# ogcat long-term implementation plan
+
+Status: draft for Codex-driven development  
+Audience: ogcat maintainers, OpenGHG maintainers, future plugin authors  
+Primary goal: evolve ogcat from a lightweight catalog MVP into a practical, extensible data-catalog and artifact-management layer that can eventually replace or orchestrate much of OpenGHG's storage/object-store logic without importing OpenGHG's domain-specific behaviour into ogcat core.
+
+---
+
+## 1. Executive summary
+
+ogcat should remain simple for the common case:
+
+> "I have a file or object, I want ogcat to place or reference it, store useful metadata, and let me search it later."
+
+The long-term direction is more ambitious:
+
+> "ogcat should provide generic cataloging, artifact tracking, locator management, validation, operation orchestration, logging, and extensibility primitives. Domain packages such as OpenGHG should add record schemas, data schemas, parsers, standardisers, transformers, export formats, and storage adapters as plugins."
+
+The plan below uses four priority levels.
+
+- **Priority 1**: harden the current TinyDB-backed MVP without over-building it. Add the abstractions that prevent redesign later: records/artifacts/locators, schema validation, hooks, lightweight unit-of-work/journal semantics, fsspec-backed storage, structured logging, better CLI, docs, and tests.
+- **Priority 2**: make plugins real. Add entry-point discovery, operation pipelines, batch ingest, richer example projects, and a first OpenGHG plugin/adaptor layer.
+- **Priority 3**: prepare for multi-user and larger-scale operation. Add a stronger backend path, server-managed transactions, richer search/indexing, permissions, durable event logs, and worker execution.
+- **Priority 4**: enterprise-grade polish and ecosystem integration. Add UI/server features, policy engines, provenance graphs, publishing workflows, and interoperability with systems such as iRODS, RO-Crate, DataLad, Intake, and institutional object stores.
+
+The immediate target is not to turn TinyDB into Postgres. The immediate target is to make the core concepts correct enough that a Postgres/server backend can implement the same interfaces later.
+
+---
+
+## 2. Background and design pressure
+
+### 2.1 Problems inherited from OpenGHG-style storage
+
+OpenGHG has shown that a metadata-first "object store" can be powerful, especially for real scientific datasets that need to be found by semantic attributes rather than by filesystem location alone. The same experience also exposes several problems that ogcat should avoid:
+
+- domain-specific parsers and storage rules make simple or unusual data awkward to add;
+- metadata keys, formatting, schema, and validation tend to become dispersed across parser/storage code;
+- object-store and metastore logic can become tightly coupled to domain logic;
+- logging is often per-user rather than per-catalog, making multi-user debugging difficult;
+- storage operations are hard to reason about when a catalog record is written but the artifact write fails, or vice versa;
+- adding new data types can require invasive changes instead of registering a schema and parser/transform hooks;
+- exports such as ObsPack-style bundles are workflow outputs, not primitive storage behaviours, but they need catalog awareness;
+- concurrency and durability assumptions are usually implicit;
+- object-store interfaces are useful but historically not formalised as clean backend/protocol contracts.
+
+### 2.2 What ogcat should provide
+
+ogcat core should provide generic machinery:
+
+- catalog records;
+- artifacts attached to records;
+- locators for local paths, fsspec URLs, external URIs, and deferred/planned storage locations;
+- metadata dictionaries plus optional schemas;
+- validation;
+- metadata extraction from self-describing files where generic extraction is reasonable;
+- operation records and operation journals;
+- hook/plugin interfaces;
+- structured catalog-level logging;
+- storage planning and path generation;
+- backend abstractions;
+- CLI and Python API parity;
+- documentation and examples.
+
+### 2.3 What ogcat core should not provide
+
+ogcat core should not encode OpenGHG-specific concepts such as:
+
+- surface/flux/model/input/output data-type semantics;
+- OpenGHG-specific `metakey` formatting;
+- species/site/network-specific validation;
+- ObsPack-specific export rules;
+- ICOS/OpenGHG retrieval semantics;
+- atmospheric inversion-specific schemas;
+- domain-specific NetCDF/Zarr scientific schemas beyond generic metadata discovery.
+
+Those belong in plugins.
+
+---
+
+## 3. Core architecture target
+
+The following conceptual architecture should guide all priorities.
+
+```text
+                     CLI / Python API / future server
+                                |
+                          Catalog service
+                                |
+       ----------------------------------------------------
+       |                    |                 |            |
+   Backend API          Storage API       Hook API      Logging
+       |                    |                 |            |
+ TinyDB / SQLite /      fsspec / local /  plugins /     event log /
+ Postgres later         external URI      schemas       audit log
+       |
+ CatalogRecord + Artifact + Locator + Operation + Journal
+```
+
+### 3.1 Essential domain-neutral concepts
+
+#### `CatalogRecord`
+
+A logical catalog entry.
+
+Suggested fields:
+
+- `id`: stable, generated by ogcat unless supplied.
+- `kind`: broad record kind, e.g. `dataset`, `document`, `run`, `bundle`, `collection`, `external`.
+- `schema_name`: optional record schema name.
+- `schema_version`: optional schema version.
+- `title`: optional human-friendly title.
+- `description`: optional text.
+- `metadata`: flexible dictionary.
+- `tags`: list of strings.
+- `artifacts`: list of artifact descriptors.
+- `created_at`, `updated_at`.
+- `created_by`, `updated_by`.
+- `version`: integer or semantic string for optimistic update checks.
+- `status`: `active`, `planned`, `failed`, `deprecated`, `deleted`.
+- `lineage`: optional references to source records and operations.
+
+#### `Artifact`
+
+A physical or virtual object associated with a record.
+
+Suggested fields:
+
+- `artifact_id`: stable within record.
+- `role`: e.g. `primary`, `metadata`, `preview`, `log`, `script`, `config`, `derived`.
+- `locator`: a locator object.
+- `media_type`: e.g. `application/netcdf`, `application/x-zarr`, `text/plain`.
+- `format`: human-oriented format tag, e.g. `netcdf`, `zarr`, `csv`, `pdf`, `directory`.
+- `size_bytes`: optional.
+- `hashes`: optional dict, e.g. `{"sha256": "..."}`.
+- `created_at`.
+- `metadata`: artifact-level metadata.
+- `status`: `planned`, `available`, `missing`, `failed`, `external`.
+
+#### `Locator`
+
+A serialisable description of where an artifact lives or will live.
+
+Suggested locator types:
+
+- `local_path`: path on a local or shared filesystem.
+- `fsspec_url`: URL plus storage options reference.
+- `external_uri`: URI not managed by ogcat, e.g. ICOS URI, DOI landing page, FTP URL.
+- `planned_path`: path planned by ogcat but not yet written.
+- `openghg_object`: compatibility locator for OpenGHG object-store-backed data.
+- `inline`: only for very small metadata-like payloads; use sparingly.
+- `bundle_member`: member within an archive or bundle.
+
+A locator should be serialisable and should not require importing a domain plugin to understand its basic shape.
+
+#### `Operation`
+
+A catalogued action that may produce, transform, validate, export, or update records/artifacts.
+
+Suggested fields:
+
+- `operation_id`.
+- `operation_type`: `add`, `ingest`, `extract_metadata`, `validate`, `transform`, `export`, `delete`, `repair`.
+- `status`: `planned`, `running`, `succeeded`, `failed`, `rolled_back`.
+- `inputs`: record IDs, locators, or external parameters.
+- `outputs`: created/updated record IDs and artifact IDs.
+- `parameters`: serialisable dict.
+- `started_at`, `ended_at`.
+- `created_by`.
+- `log_ref`: link to event log/journal entries.
+- `error`: structured error summary if failed.
+
+---
+
+## 4. Priority levels
+
+## Priority 1: harden the MVP and create stable extension seams
+
+Priority 1 is the work Codex should be able to start immediately. Keep changes incremental. Do not implement a server. Do not require Postgres. Do not make OpenGHG a hard dependency. Do not require async in the core. Build the smallest APIs that make later backends and plugins possible.
+
+### P1 target outcomes
+
+By the end of Priority 1:
+
+1. ogcat has a documented record/artifact/locator model.
+2. TinyDB remains the default backend, but sits behind a backend protocol.
+3. basic validation uses Pydantic or a similarly explicit schema layer.
+4. fsspec is the storage abstraction for local and remote filesystems, but local-path usage remains simple.
+5. adding a record from memory or file uses a unit-of-work style operation that can clean up after partial failure.
+6. hooks exist at stable points in add/ingest/search/show/storage flows.
+7. logs are catalog-level, structured, queryable enough for debugging, and filterable by user/session/operation.
+8. CLI and Python API stay in parity for core operations.
+9. examples are reorganised into small, reliable demonstrations.
+10. Sphinx docs can be built and include at least one tutorial-style example.
+
+---
+
+### Issue P1-01: Write the architecture decision record for ogcat core concepts
+
+Labels: `priority:1`, `area:architecture`, `kind:docs`
+
+#### Goal
+
+Create a concise architecture decision record that defines the canonical vocabulary for ogcat.
+
+#### Rationale
+
+Before adding transactions, hooks, fsspec, validation, or plugins, the repository needs a shared vocabulary. This prevents every feature from inventing its own meaning of "object", "record", "artifact", "metadata", "locator", "operation", and "store".
+
+#### Tasks
+
+- Add `docs/adr/0001-core-concepts.md` or equivalent.
+- Define:
+  - catalog;
+  - backend;
+  - record;
+  - artifact;
+  - locator;
+  - metadata;
+  - schema;
+  - hook;
+  - operation;
+  - unit of work;
+  - journal;
+  - event log.
+- Include a "non-goals" section:
+  - ogcat core does not know OpenGHG data types;
+  - ogcat core does not implement a general database;
+  - TinyDB backend is not ACID;
+  - hooks must not make core depend on plugin packages.
+- Add a short diagram.
+- Add a "compatibility target" note explaining that OpenGHG object-store logic should eventually sit behind adapters/plugins.
+
+#### Acceptance criteria
+
+- The ADR is linked from the README.
+- The ADR is short enough to read before contributing.
+- All subsequent P1 issues use this vocabulary.
+
+#### Codex prompt
+
+```text
+Create docs/adr/0001-core-concepts.md for ogcat. Define catalog, backend, record, artifact, locator, metadata, schema, hook, operation, unit of work, journal, and event log. Keep the document domain-neutral, but include a short note that OpenGHG-specific parsers/schemas/storage adapters should live in plugins rather than ogcat core.
+```
+
+---
+
+### Issue P1-02: Introduce explicit Pydantic models for records, artifacts, and locators
+
+Labels: `priority:1`, `area:model`, `kind:feature`
+
+#### Goal
+
+Replace implicit dictionaries at the API boundary with explicit model classes while preserving flexible metadata.
+
+#### Design
+
+Create model classes such as:
+
+- `CatalogRecord`
+- `Artifact`
+- `Locator`
+- concrete locator variants:
+  - `LocalPathLocator`
+  - `FSSpecLocator`
+  - `ExternalURILocator`
+  - `PlannedPathLocator`
+
+Avoid over-validating user metadata. The record model should validate ogcat's own structural fields and allow `metadata: dict[str, Any]`.
+
+#### Tasks
+
+- Add a model module, for example `src/ogcat/models.py`.
+- Use Pydantic models or dataclasses plus Pydantic `TypeAdapter`.
+- Preserve JSON-serialisable output.
+- Add `model_version` fields where needed.
+- Add conversion helpers:
+  - `CatalogRecord.from_mapping(...)`
+  - `record.to_mapping()` or `record.model_dump(...)`
+  - `normalise_locator(...)`
+- Keep backwards compatibility with existing TinyDB documents as much as practical.
+- Add migration notes if the existing record shape changes.
+
+#### Acceptance criteria
+
+- Existing tests still pass or are updated for the new canonical shape.
+- A record can be round-tripped through JSON.
+- A record can be stored and loaded through the TinyDB backend.
+- Metadata remains flexible.
+- CLI output remains understandable.
+
+#### Testing
+
+- Unit tests for valid and invalid record structures.
+- Round-trip tests for local, fsspec, external, and planned locators.
+- Regression tests for existing sample catalog entries.
+
+#### Codex prompt
+
+```text
+Add explicit ogcat model classes for CatalogRecord, Artifact, and Locator variants. Keep metadata flexible, but validate ogcat's structural fields. Update the TinyDB repository code to store and load these models. Add round-trip tests and keep the current CLI behaviour working.
+```
+
+---
+
+### Issue P1-03: Define a backend protocol and keep TinyDB as the default backend
+
+Labels: `priority:1`, `area:backend`, `kind:feature`
+
+#### Goal
+
+Make the current TinyDB implementation one backend behind a small protocol so SQLite/Postgres/server backends can be added later without rewriting the public API.
+
+#### Proposed protocol
+
+```python
+class CatalogBackend(Protocol):
+    def add_record(self, record: CatalogRecord) -> CatalogRecord: ...
+    def get_record(self, record_id: str) -> CatalogRecord | None: ...
+    def update_record(self, record: CatalogRecord) -> CatalogRecord: ...
+    def delete_record(self, record_id: str) -> None: ...
+    def search(self, query: CatalogQuery) -> list[CatalogRecord]: ...
+    def list_fields(self) -> FieldSummary: ...
+```
+
+Keep query support intentionally modest in P1.
+
+#### Tasks
+
+- Create `src/ogcat/backends/base.py`.
+- Move TinyDB-specific logic to `src/ogcat/backends/tinydb.py`.
+- Keep any existing `Catalog` facade thin.
+- Define a `CatalogQuery` model or simple query object.
+- Make backend choice configurable later, but default to TinyDB now.
+- Do not expose TinyDB types in the public API.
+
+#### Acceptance criteria
+
+- Existing code can still open a local TinyDB-backed catalog with minimal changes.
+- Tests can run backend contract tests against TinyDB.
+- No public API requires direct TinyDB imports.
+
+#### Testing
+
+- Add backend contract tests.
+- Use temporary directories for isolated catalog files.
+- Include tests for:
+  - add;
+  - get;
+  - search;
+  - update;
+  - delete/tombstone if supported;
+  - field summary.
+
+#### Codex prompt
+
+```text
+Refactor ogcat's TinyDB storage behind a CatalogBackend protocol. Preserve the existing simple Catalog API, but isolate TinyDB-specific code. Add backend contract tests that can later be reused for SQLite or Postgres backends.
+```
+
+---
+
+### Issue P1-04: Implement a lightweight unit-of-work and operation journal
+
+Labels: `priority:1`, `area:durability`, `kind:feature`
+
+#### Goal
+
+Provide recoverable add/ingest/update operations even though TinyDB does not provide real transactions.
+
+#### Rationale
+
+A common failure mode:
+
+1. create a catalog record with a planned artifact locator;
+2. try to write data to the planned location;
+3. write fails;
+4. the catalog now contains a misleading record unless cleanup runs reliably.
+
+ogcat needs a unit-of-work abstraction that coordinates catalog writes, artifact writes, hooks, and rollback actions. In TinyDB mode this is a best-effort transaction simulation with a durable journal, not ACID.
+
+#### Proposed API
+
+```python
+with catalog.unit_of_work(operation_type="add", user_id=user_id) as uow:
+    record = uow.plan_record(...)
+    artifact = uow.plan_artifact(...)
+    uow.write_artifact(artifact, data)
+    uow.add_record(record)
+```
+
+#### Journal states
+
+- `started`
+- `planned`
+- `artifact_write_started`
+- `artifact_write_succeeded`
+- `catalog_write_started`
+- `catalog_write_succeeded`
+- `hooks_started`
+- `committed`
+- `rollback_started`
+- `rolled_back`
+- `failed`
+
+#### Rollback actions
+
+Examples:
+
+- remove created file;
+- remove temporary file;
+- remove record by ID;
+- restore previous record version;
+- mark record as failed if destructive cleanup is unsafe;
+- run plugin rollback hook.
+
+#### Tasks
+
+- Add `OperationJournal` interface.
+- Store journal entries as JSON Lines in a catalog-controlled `logs/` or `.ogcat/journal/` directory.
+- Implement `UnitOfWork`.
+- Ensure operations have unique `operation_id`.
+- Add cleanup behaviour for failed file writes and failed catalog writes.
+- Add a `catalog recover` or `catalog doctor` command to inspect incomplete journal entries.
+- Make rollback idempotent.
+- Never silently delete data unless ogcat created it and the rollback action says it is safe.
+
+#### Acceptance criteria
+
+- If artifact writing fails after a record is planned but before commit, no active record remains.
+- If catalog writing fails after an artifact was created, the artifact is removed or marked orphaned according to the rollback policy.
+- Incomplete operations can be inspected from the CLI.
+- Journal entries include enough information to debug failures.
+
+#### Testing
+
+- Simulate exceptions at each operation phase.
+- Verify rollback actions run in reverse order.
+- Verify rollback can be called twice safely.
+- Verify journal state transitions.
+- Include tests using temporary local files.
+
+#### Codex prompt
+
+```text
+Implement a lightweight UnitOfWork and OperationJournal for ogcat. This is not a real TinyDB transaction system; it is a recoverable operation protocol with JSONL journal entries and idempotent rollback actions. Cover add-from-memory and add-from-file style workflows with tests that inject failures at each phase.
+```
+
+---
+
+### Issue P1-05: Add structured catalog-level logging
+
+Labels: `priority:1`, `area:logging`, `kind:feature`
+
+#### Goal
+
+Replace or supplement per-user ad hoc logs with catalog-level structured event logs.
+
+#### Rationale
+
+In a shared catalog, the maintainer should be able to answer:
+
+- what did this user try to do?
+- which record/artifact did it touch?
+- which operation failed?
+- was the failure in metadata extraction, validation, storage, backend write, hook execution, or export?
+- what traceback or error type occurred?
+- which plugin was involved?
+- which version of ogcat/plugin was running?
+
+#### Logging design
+
+Use a structured event model. Avoid only writing free-text lines.
+
+Suggested fields:
+
+- `timestamp`
+- `level`
+- `event`
+- `message`
+- `operation_id`
+- `record_id`
+- `artifact_id`
+- `user_id`
+- `session_id`
+- `catalog_path`
+- `backend`
+- `plugin`
+- `hook`
+- `command`
+- `cwd`
+- `hostname`
+- `pid`
+- `process_name`
+- `python_version`
+- `ogcat_version`
+- `exception_type`
+- `exception_message`
+- `traceback`
+- `extra`
+
+#### Storage
+
+Priority 1 should support:
+
+- JSON Lines event log in catalog state directory;
+- optional console output;
+- optional per-user log for local development if desired, but catalog-level logs are primary for shared catalogs.
+
+Potential layout:
+
+```text
+catalog-root/
+  .ogcat/
+    catalog.json
+    journal/
+      operations-YYYYMM.jsonl
+    logs/
+      events-YYYYMM.jsonl
+```
+
+#### CLI
+
+Add a log inspection command:
+
+```bash
+ogcat logs --user USER
+ogcat logs --record RECORD_ID
+ogcat logs --operation OPERATION_ID
+ogcat logs --level error
+ogcat logs --since 2026-04-01
+```
+
+#### Tasks
+
+- Add logging configuration module.
+- Add event model.
+- Add JSONL event writer.
+- Add logging context helpers.
+- Bind `operation_id`, `user_id`, `session_id`, `catalog_path`.
+- Log every unit-of-work start/success/failure/rollback.
+- Log hook start/success/failure.
+- Log validation failures.
+- Log storage failures.
+- Add CLI filtering.
+
+#### Acceptance criteria
+
+- A failed add operation produces a structured error event.
+- Logs can be filtered by user ID.
+- Logs can be filtered by operation ID.
+- Tests do not depend on exact traceback formatting.
+- The logging system works without requiring structlog, but can use structlog internally if it remains lightweight.
+
+#### Testing
+
+- Unit tests for event serialisation.
+- CLI tests for `ogcat logs`.
+- Failure-injection tests from P1-04 should assert key log events exist.
+
+#### Codex prompt
+
+```text
+Add catalog-level structured logging to ogcat. Write JSONL event logs under the catalog state directory, bind user/session/operation context, and add an `ogcat logs` command that filters by user, record, operation, level, and time. Integrate with UnitOfWork and hook execution.
+```
+
+---
+
+### Issue P1-06: Add fsspec-based storage primitives without making simple local use harder
+
+Labels: `priority:1`, `area:storage`, `kind:feature`
+
+#### Goal
+
+Use fsspec as the generic filesystem abstraction while preserving simple local path workflows.
+
+#### Design principles
+
+- Local files should remain trivial.
+- Remote protocols should not require core code changes.
+- Storage options should not be stored unsafely in records.
+- Locators should be descriptive and serialisable.
+- P1 should not promise robust concurrent remote writes.
+
+#### Proposed components
+
+- `StorageManager`
+- `PathPlanner`
+- `ArtifactWriter`
+- `ArtifactReader`
+- `FSSpecLocator`
+- `StorageProfile`
+
+#### Storage profile
+
+A storage profile is a named configuration resolved outside the record:
+
+```yaml
+profiles:
+  default:
+    protocol: file
+    root: ./data
+  hpc-work:
+    protocol: file
+    root: /user/work/$USER/ogcat
+  s3-project:
+    protocol: s3
+    root: s3://bucket/prefix
+    storage_options_env: OGCAT_S3_OPTIONS
+```
+
+The record stores `profile_name` and relative path, or a resolved URL if appropriate. Avoid storing secrets.
+
+#### Tasks
+
+- Add fsspec as an optional or core dependency depending on packaging preference.
+- Add storage profiles.
+- Add path planning:
+  - deterministic path templates;
+  - collision handling;
+  - optional hash suffix;
+  - extension handling.
+- Add atomic-ish local writes:
+  - write to temporary path;
+  - fsync/close where appropriate;
+  - rename into place when possible.
+- Add generic artifact metadata:
+  - size;
+  - modified time;
+  - hashes where requested.
+- Add tests using local filesystem.
+- Add optional tests for memory filesystem.
+
+#### Acceptance criteria
+
+- `catalog.add_file(path)` can copy/register a file using local fsspec.
+- `catalog.add_bytes(...)` or equivalent can write data from memory to a planned path.
+- Failed writes cooperate with the unit-of-work rollback protocol.
+- Existing simple path-based add/search workflows remain simple.
+
+#### Testing
+
+- Local filesystem write/read tests.
+- Memory filesystem tests if useful.
+- Failure injection for partial writes.
+- Path-planning tests.
+
+#### Codex prompt
+
+```text
+Add fsspec-based storage primitives to ogcat while keeping local paths simple. Implement storage profiles, path planning, safe local write via temporary file and rename where possible, locator serialisation, and integration with UnitOfWork rollback.
+```
+
+---
+
+### Issue P1-07: Add schema validation with permissive metadata by default
+
+Labels: `priority:1`, `area:schema`, `kind:feature`
+
+#### Goal
+
+Support rich domain schemas without making the default "just add some metadata" use case painful.
+
+#### Design
+
+There are two levels of validation:
+
+1. **Core structural validation**: required for all records. This validates ogcat-owned fields.
+2. **Optional record schema validation**: selected by `schema_name` and `schema_version`. This validates domain metadata.
+
+In P1, schema registration can be simple and in-process.
+
+#### Proposed API
+
+```python
+catalog.register_schema("paper", PaperSchema, version="1")
+catalog.validate(record)
+catalog.add(..., schema_name="paper")
+```
+
+#### Schema policy options
+
+- `off`: do not run optional schema validation.
+- `warn`: validate and log warnings, but allow record.
+- `strict`: reject invalid records.
+
+Default should probably be `warn` for interactive CLI and `strict` for explicit `validate`.
+
+#### Tasks
+
+- Add schema registry.
+- Add validation result model:
+  - `valid`;
+  - `warnings`;
+  - `errors`;
+  - `schema_name`;
+  - `schema_version`.
+- Add CLI:
+  - `ogcat validate RECORD_ID`
+  - `ogcat validate --all`
+  - `ogcat validate --file path/to/record.json`
+- Add Python API.
+- Support Pydantic schemas.
+- Keep JSON Schema export as a later enhancement unless simple.
+
+#### Acceptance criteria
+
+- A record can be added with no domain schema.
+- A record can be validated against a registered schema.
+- Invalid metadata can be rejected in strict mode.
+- Validation failures appear in logs.
+- Validation results are machine-readable.
+
+#### Testing
+
+- Schema registry tests.
+- Strict/warn/off tests.
+- CLI tests for validation.
+
+#### Codex prompt
+
+```text
+Add optional schema validation for ogcat records. Core record structure should always be validated; domain metadata should be validated only when a schema is selected. Support warn/strict/off policy modes and add Python API plus CLI validation commands.
+```
+
+---
+
+### Issue P1-08: Define hook points and a minimal hook execution engine
+
+Labels: `priority:1`, `area:plugins`, `kind:feature`
+
+#### Goal
+
+Provide stable customisation points without implementing a full plugin system yet.
+
+#### Hook points
+
+Priority 1 should define hook names and call them in the core workflow:
+
+- `before_record_validate`
+- `after_record_validate`
+- `before_metadata_extract`
+- `after_metadata_extract`
+- `before_path_plan`
+- `after_path_plan`
+- `before_artifact_write`
+- `after_artifact_write`
+- `before_record_commit`
+- `after_record_commit`
+- `on_operation_error`
+- `on_operation_rollback`
+
+#### Hook signature
+
+Keep signatures explicit. Avoid passing too much mutable state.
+
+```python
+class HookContext(BaseModel):
+    catalog_id: str | None
+    operation_id: str
+    user_id: str | None
+    session_id: str
+    dry_run: bool = False
+
+class HookResult(BaseModel):
+    metadata_updates: dict[str, Any] = {}
+    warnings: list[str] = []
+```
+
+#### Tasks
+
+- Add `HookManager`.
+- Allow hooks to be registered programmatically.
+- Hooks can:
+  - add metadata;
+  - emit warnings;
+  - fail operation if configured as required.
+- Hook execution must be logged.
+- Hook failures must interact with unit-of-work rollback.
+- Do not implement package entry-point auto-discovery in P1 unless it is trivial; reserve full plugin discovery for P2.
+
+#### Acceptance criteria
+
+- A test hook can add metadata during add.
+- A failing required hook aborts the operation and triggers rollback.
+- A failing optional hook logs a warning.
+- Hook behaviour is covered by tests.
+
+#### Codex prompt
+
+```text
+Add a minimal HookManager with explicit hook points around validation, metadata extraction, path planning, artifact writing, record commit, error handling, and rollback. Programmatic registration is enough for P1. Log hook execution and integrate required-hook failures with UnitOfWork rollback.
+```
+
+---
+
+### Issue P1-09: Add generic metadata extraction for self-describing files
+
+Labels: `priority:1`, `area:metadata`, `kind:feature`
+
+#### Goal
+
+Provide useful generic metadata extraction without importing domain-specific parser logic.
+
+#### Scope
+
+Priority 1 should support:
+
+- generic filesystem metadata;
+- generic NetCDF metadata if the optional dependency is installed;
+- generic Zarr metadata if the optional dependency is installed;
+- generic directory/file tree summaries for examples like `ls -R` dumps;
+- basic text metadata such as suffix, encoding guess if cheap, size.
+
+Do not attempt OpenGHG-specific standardisation here.
+
+#### Extracted metadata examples
+
+For NetCDF:
+
+- dimensions;
+- coordinates;
+- variables;
+- global attributes;
+- variable attributes;
+- time coverage if easily derived;
+- units if present;
+- conventions attribute if present.
+
+For Zarr:
+
+- group paths;
+- arrays;
+- dimensions/shape/chunks where discoverable;
+- attributes;
+- consolidated metadata flag if discoverable.
+
+#### Tasks
+
+- Define `MetadataExtractor` protocol.
+- Add builtin extractors:
+  - file metadata;
+  - directory summary;
+  - NetCDF optional extractor;
+  - Zarr optional extractor.
+- Add hook integration:
+  - `before_metadata_extract`;
+  - `after_metadata_extract`.
+- Add CLI option:
+  - `ogcat add path --extract-metadata`
+  - `ogcat extract-metadata path --json`
+- Keep failures non-fatal by default unless `--require-metadata`.
+
+#### Acceptance criteria
+
+- NetCDF extraction works when dependencies are installed.
+- Missing optional dependency gives a clear error.
+- Extracted metadata is nested under a clear namespace, e.g. `metadata["netcdf"]`, not mixed into user metadata.
+- Metadata extraction failures are logged.
+
+#### Testing
+
+- Use tiny generated NetCDF/Zarr fixtures.
+- Test optional dependency missing behaviour if feasible.
+- Avoid large binary fixtures.
+
+#### Codex prompt
+
+```text
+Add generic metadata extraction protocols and builtin extractors for file metadata, directory summaries, and optional NetCDF/Zarr metadata. Keep extracted metadata namespaced and do not add OpenGHG-specific standardisation. Add CLI and tests with tiny generated fixtures.
+```
+
+---
+
+### Issue P1-10: Improve CLI/API parity and add `info`, `fields`, and machine-readable output
+
+Labels: `priority:1`, `area:cli`, `kind:feature`
+
+#### Goal
+
+Make the CLI useful for real catalog inspection and scripting.
+
+#### Commands
+
+Existing or near-existing commands should be normalised:
+
+```bash
+ogcat add
+ogcat search
+ogcat show
+ogcat path
+```
+
+Add:
+
+```bash
+ogcat info
+ogcat fields
+ogcat validate
+ogcat logs
+ogcat doctor
+```
+
+#### `info`
+
+Curated catalog summary, not a raw dump of `catalog.json`.
+
+Should show:
+
+- catalog path;
+- backend;
+- number of records;
+- number of artifacts;
+- known schemas;
+- storage profiles;
+- recent failed operations;
+- log/journal location;
+- ogcat version.
+
+#### `fields`
+
+A summary of metadata keys seen in records.
+
+Should show:
+
+- field path, e.g. `metadata.site`;
+- observed types;
+- count;
+- example values;
+- schemas that define the field if known.
+
+This helps users discover searchable metadata.
+
+#### `search --json`
+
+Machine-readable output for scripts.
+
+#### ID selection
+
+For commands requiring IDs (`show`, `path`, later `validate`):
+
+- allow exact ID;
+- allow unambiguous prefix;
+- allow `--first` from search;
+- allow `--format compact` to show copyable IDs;
+- consider shell-friendly `ogcat search ... --ids`.
+
+Avoid interactive selection in P1 unless cheap.
+
+#### Tasks
+
+- Add output formatting layer:
+  - human table;
+  - compact;
+  - JSON.
+- Add Python API equivalents:
+  - `catalog.info()`;
+  - `catalog.fields()`;
+  - `catalog.validate(...)`;
+  - `catalog.logs(...)`;
+  - `catalog.doctor()`.
+- Improve errors:
+  - no matches;
+  - multiple ID prefix matches;
+  - invalid metadata query;
+  - missing artifact path;
+  - backend unavailable.
+- Add CLI tests.
+
+#### Acceptance criteria
+
+- Every new CLI command has an API equivalent.
+- JSON output is stable enough for scripts.
+- Error messages tell the user what to do next.
+- ID prefix selection works for unambiguous prefixes and fails cleanly otherwise.
+
+#### Codex prompt
+
+```text
+Improve ogcat CLI/API parity. Add curated `info`, metadata `fields`, `validate`, `logs`, and `doctor` commands. Add JSON output for search/show/info/fields where useful. Support unambiguous ID prefixes and script-friendly ID output. Add CLI tests and clearer errors.
+```
+
+---
+
+### Issue P1-11: Add file locking and explicit concurrency caveats for TinyDB
+
+Labels: `priority:1`, `area:concurrency`, `kind:feature`
+
+#### Goal
+
+Reduce accidental catalog corruption in simple shared-filesystem scenarios while being explicit about limitations.
+
+#### Design
+
+- Use file locking around TinyDB writes.
+- Use optimistic version checks for record updates.
+- Do not promise robust high-concurrency writes on NFS.
+- Make the locking strategy backend-configurable.
+- Add documentation warning about NFS and shared HPC filesystems.
+
+#### Tasks
+
+- Add lock wrapper around TinyDB write operations.
+- Add timeout and clear error if lock cannot be acquired.
+- Include process/user/host metadata in lock file if feasible.
+- Add stale lock diagnostic command in `doctor`.
+- Add record version increment on update.
+- Add conflict error if expected version does not match.
+
+#### Acceptance criteria
+
+- Concurrent write tests do not corrupt the catalog in local temporary filesystem tests.
+- Lock timeout errors are clear.
+- Docs explicitly state limitations.
+
+#### Testing
+
+- Multiprocessing local test with several writers if practical.
+- Unit tests for version conflict.
+- Doctor test for stale-looking lock metadata.
+
+#### Codex prompt
+
+```text
+Add a simple file-locking layer around TinyDB writes and optimistic record version checks. Be explicit in docs that this improves safety but is not a robust multi-user transaction system, especially on NFS/HPC filesystems. Add diagnostics to `ogcat doctor`.
+```
+
+---
+
+### Issue P1-12: Reorganise examples into small, installable, reproducible examples
+
+Labels: `priority:1`, `area:examples`, `kind:docs`
+
+#### Goal
+
+Make examples useful for users and maintainers without relying on sys.path hacks or large external data.
+
+#### Example conventions
+
+Each example should live under:
+
+```text
+examples/
+  <example-name>/
+    README.rst
+    pyproject.toml             # optional, only if extra deps are needed
+    data/
+      README.md
+      small-fixtures...
+    scripts/
+      run_example.py
+    expected/
+      README.md
+```
+
+Rules:
+
+- assume ogcat is installed;
+- no modifying `sys.path`;
+- small fixtures only;
+- generated data is acceptable;
+- external downloads must be optional;
+- examples should be runnable from a clean checkout;
+- any resulting catalog should be written under a temporary or example-local ignored directory;
+- examples should have one clear purpose.
+
+#### P1 example set
+
+1. **basic-file-catalog**
+   - Add local files.
+   - Search by metadata.
+   - Show paths.
+   - Use `info` and `fields`.
+
+2. **metadata-extraction-netcdf**
+   - Generate a tiny NetCDF file.
+   - Extract generic metadata.
+   - Search by extracted fields.
+
+3. **transaction-failure-demo**
+   - Demonstrate failed artifact write and rollback.
+   - Show journal/log output.
+
+4. **mini-bibdesk**
+   - Catalog papers and attachments.
+   - Parse `.bib` or `.ris` using optional dependencies.
+   - Autofile PDFs and auxiliary material.
+   - Keep this example small and separate from core.
+
+#### Documentation format
+
+Use Sphinx with either:
+
+- `.rst` pages containing code blocks and command transcripts; or
+- notebook-style examples rendered through a Jupyter/Sphinx integration.
+
+Given the user's preference, `.rst` plus Jupyter execution directives can work, but keep examples simple enough that command-line scripts are the authoritative source.
+
+#### Acceptance criteria
+
+- At least two examples run in CI as smoke tests.
+- Examples do not depend on private paths.
+- Example data is small and license-compatible.
+- README explains how to run examples after installing ogcat.
+
+#### Codex prompt
+
+```text
+Reorganise ogcat examples into small installable examples. Remove sys.path hacks. Add basic-file-catalog, metadata-extraction-netcdf, transaction-failure-demo, and a minimal mini-bibdesk example. Keep data small, write generated catalogs to ignored output directories, and add smoke tests for selected examples.
+```
+
+---
+
+### Issue P1-13: Establish documentation structure with Sphinx and API references
+
+Labels: `priority:1`, `area:docs`, `kind:docs`
+
+#### Goal
+
+Create documentation that can explain ogcat to skeptical OpenGHG users and to new users with simpler needs.
+
+#### Suggested docs layout
+
+```text
+docs/
+  index.rst
+  install.rst
+  quickstart.rst
+  concepts.rst
+  cli.rst
+  python-api.rst
+  records-artifacts-locators.rst
+  metadata-and-schemas.rst
+  storage-profiles.rst
+  hooks.rst
+  transactions-and-logging.rst
+  examples/
+    basic-file-catalog.rst
+    metadata-extraction-netcdf.rst
+    mini-bibdesk.rst
+  plugins/
+    overview.rst
+    openghg-plugin-sketch.rst
+  adr/
+    0001-core-concepts.md
+```
+
+#### Style
+
+- Google-style docstrings in code.
+- Sphinx autodoc or autosummary for API.
+- Tutorials should be task-oriented.
+- Reference pages should be terse and complete.
+- Avoid Intake-style examples that look impressive but do not answer "how do I use this for my own files?"
+
+#### Tasks
+
+- Add Sphinx config if not present.
+- Add docs dependencies as optional extra, e.g. `ogcat[docs]`.
+- Add API reference generation.
+- Add quickstart.
+- Link examples.
+- Add a "For OpenGHG developers" page explaining how ogcat differs from OpenGHG storage.
+
+#### Acceptance criteria
+
+- `sphinx-build` succeeds locally/CI.
+- Public classes/functions have Google-style docstrings.
+- Quickstart covers:
+  - create/open catalog;
+  - add file;
+  - add metadata;
+  - search;
+  - show path;
+  - inspect fields;
+  - validate if schema present.
+
+#### Codex prompt
+
+```text
+Set up or tidy the ogcat Sphinx documentation. Add quickstart, concepts, CLI, Python API, storage profiles, hooks, transactions/logging, examples, and a page for OpenGHG developers. Use Google-style docstrings and ensure docs build in CI.
+```
+
+---
+
+### Issue P1-14: Add packaging extras and development workflow hygiene
+
+Labels: `priority:1`, `area:packaging`, `kind:maintenance`
+
+#### Goal
+
+Keep the core lightweight while making optional integrations discoverable.
+
+#### Suggested extras
+
+- `ogcat[netcdf]`: NetCDF/xarray/h5netcdf dependencies as chosen.
+- `ogcat[zarr]`: zarr-related metadata extraction.
+- `ogcat[fsspec]`: only if fsspec is not core.
+- `ogcat[bib]`: `.bib`/`.ris` parser dependencies.
+- `ogcat[docs]`: Sphinx and docs build dependencies.
+- `ogcat[test]`: pytest and test helpers.
+- `ogcat[dev]`: lint/test/docs tools.
+
+#### Tasks
+
+- Review `pyproject.toml`.
+- Add optional dependencies.
+- Add scripts/entry points.
+- Add ruff/mypy/pytest config if appropriate.
+- Add CI matrix if not present.
+- Keep Python version policy explicit, probably Python 3.11+.
+
+#### Acceptance criteria
+
+- `pip install -e .[dev]` or uv equivalent works.
+- `pytest` works.
+- `ruff check` works if ruff is adopted.
+- `sphinx-build` works with docs extra.
+- Core install does not pull heavy scientific packages unnecessarily.
+
+#### Codex prompt
+
+```text
+Tidy ogcat packaging. Keep core lightweight, define optional extras for NetCDF, Zarr, bibliography parsing, docs, tests, and dev tooling. Ensure editable install plus tests/docs commands are documented and work.
+```
+
+---
+
+### Issue P1-15: Add tests that exercise behaviour, not idiosyncratic implementation details
+
+Labels: `priority:1`, `area:testing`, `kind:maintenance`
+
+#### Goal
+
+Create confidence in the architectural seams without freezing every incidental representation.
+
+#### Test layers
+
+1. **Model tests**
+   - record/artifact/locator validation;
+   - JSON round trips;
+   - schema validation.
+
+2. **Backend contract tests**
+   - add/get/update/search/delete/list fields;
+   - can run against TinyDB and future backends.
+
+3. **Unit-of-work tests**
+   - failure injection;
+   - rollback;
+   - journal state.
+
+4. **Storage tests**
+   - path planning;
+   - local write/read;
+   - fsspec memory filesystem if used;
+   - cleanup.
+
+5. **Hook tests**
+   - metadata update hook;
+   - required hook failure;
+   - optional hook warning.
+
+6. **CLI tests**
+   - `add`;
+   - `search`;
+   - `show`;
+   - `path`;
+   - `info`;
+   - `fields`;
+   - `validate`;
+   - `logs`;
+   - `doctor`.
+
+7. **Example smoke tests**
+   - a small subset only;
+   - avoid making examples the main test mechanism.
+
+#### Avoid
+
+- asserting exact pretty-table whitespace unless testing formatting;
+- overfitting tests to one metadata key convention;
+- requiring heavy dependencies for core tests;
+- large binary fixtures;
+- relying on live external services.
+
+#### Acceptance criteria
+
+- Test suite documents intended behaviour.
+- Optional tests are marked.
+- Future backend implementations can reuse contract tests.
+
+#### Codex prompt
+
+```text
+Create a layered testing plan and implement the first batch of tests for models, TinyDB backend contract, UnitOfWork rollback, storage path planning, hooks, CLI output, and selected example smoke tests. Avoid overfitting to incidental formatting.
+```
+
+---
+
+## Priority 2: make plugins, operations, and real examples first-class
+
+Priority 2 should start once Priority 1 APIs exist and have tests. The goal is to prove that ogcat can host domain-specific logic without becoming domain-specific.
+
+### P2 target outcomes
+
+- Entry-point plugin discovery works.
+- Plugins can register schemas, metadata extractors, operations, hooks, CLI subcommands if needed, and storage adapters.
+- Operation pipelines support ingest/standardise/transform/export workflows.
+- OpenGHG plugin prototype demonstrates replacing or orchestrating parts of OpenGHG storage logic.
+- Examples become convincing enough for users outside ogcat development.
+- Batch operations exist, but core remains synchronous and backend-neutral.
+
+---
+
+### Issue P2-01: Add entry-point based plugin discovery
+
+Labels: `priority:2`, `area:plugins`, `kind:feature`
+
+#### Goal
+
+Allow packages to register ogcat extensions without modifying ogcat core.
+
+#### Plugin capabilities
+
+A plugin should be able to register:
+
+- schemas;
+- metadata extractors;
+- hooks;
+- path templates;
+- operations;
+- storage profiles or storage profile types;
+- CLI command groups if needed;
+- display formatters.
+
+#### Proposed entry point
+
+```toml
+[project.entry-points."ogcat.plugins"]
+openghg = "ogcat_openghg.plugin:register"
+papers = "ogcat_papers.plugin:register"
+```
+
+#### Acceptance criteria
+
+- Plugin discovery can be disabled.
+- Plugin load errors are clear and logged.
+- Plugin registration is idempotent.
+- Tests include a tiny fake plugin.
+
+---
+
+### Issue P2-02: Define operation pipelines for ingest, transform, validate, and export
+
+Labels: `priority:2`, `area:operations`, `kind:feature`
+
+#### Goal
+
+Represent multi-step workflows without hardcoding OpenGHG pipelines.
+
+#### Examples
+
+- ingest file -> extract metadata -> validate -> write artifact -> create record;
+- transform NetCDF -> validate output schema -> create derived record;
+- export selected records -> create bundle artifact;
+- parse bibliography -> autofile attachments -> create paper records.
+
+#### Design
+
+An operation pipeline should be inspectable and loggable:
+
+```text
+operation:
+  name: ingest-netcdf
+  steps:
+    - extract-metadata
+    - validate-record
+    - validate-data-schema
+    - write-artifact
+    - commit-record
+```
+
+#### Acceptance criteria
+
+- A pipeline can be dry-run.
+- A pipeline can log each step.
+- A pipeline can fail and rollback safely.
+- Hooks can attach to step boundaries.
+
+---
+
+### Issue P2-03: Add an OpenGHG plugin prototype
+
+Labels: `priority:2`, `area:openghg`, `kind:feature`
+
+#### Goal
+
+Demonstrate that OpenGHG-specific storage/domain logic can move out of core OpenGHG code and into an ogcat plugin or adapter.
+
+#### Initial scope
+
+- Register OpenGHG-like record schemas.
+- Map OpenGHG metadata conventions to ogcat metadata.
+- Add parser/standardiser operation stubs.
+- Add ZarrStore-compatible locator/storage adapter sketch.
+- Provide read-only adapter that can expose ogcat records through an ObjectStore-like interface.
+- Keep OpenGHG as an optional dependency.
+
+#### Non-goals
+
+- Full replacement of OpenGHG storage in P2.
+- Large migration tooling.
+- ObsPack export completion.
+
+#### Acceptance criteria
+
+- The plugin can be installed separately.
+- It can register schemas and hooks.
+- It can ingest or register at least one tiny OpenGHG-like NetCDF/Zarr fixture.
+- It can return an object/path through a minimal ObjectStore-like adapter.
+
+---
+
+### Issue P2-04: Add a read-only OpenGHG ObjectStore adapter backed by ogcat
+
+Labels: `priority:2`, `area:openghg`, `kind:feature`
+
+#### Goal
+
+Create a compatibility layer so existing OpenGHG code can read data found via ogcat.
+
+#### Design
+
+Extract or emulate the useful parts of the OpenGHG `ObjectStore` interface:
+
+- search by metadata;
+- retrieve object locator/path;
+- return metadata;
+- expose object references.
+
+Start read-only. Writes should go through ogcat operations.
+
+#### Acceptance criteria
+
+- Adapter can be used in a tiny compatibility test.
+- Adapter does not require ogcat core to import OpenGHG.
+- Adapter has clear limitations documented.
+
+---
+
+### Issue P2-05: Add richer batch ingest with synchronous execution
+
+Labels: `priority:2`, `area:batch`, `kind:feature`
+
+#### Goal
+
+Support parsing a pre-existing data collection without requiring async/server infrastructure.
+
+#### Design
+
+- Accept manifests or path globs.
+- Plan batch first.
+- Dry-run shows intended records/artifacts.
+- Execute sequentially by default.
+- Optional local thread/process executor can be added behind an execution interface, but do not require it.
+
+#### CLI
+
+```bash
+ogcat ingest manifest.yaml --dry-run
+ogcat ingest manifest.yaml --continue-on-error
+ogcat ingest /data/**/*.nc --schema openghg.surface --extract-metadata
+```
+
+#### Acceptance criteria
+
+- Batch ingest can resume or skip already-added files.
+- Failures are logged per operation.
+- Summary output includes success/failure counts.
+- Batch operation does not corrupt catalog on partial failure.
+
+---
+
+### Issue P2-06: Build the mini BibDesk clone as a serious example
+
+Labels: `priority:2`, `area:examples`, `kind:example`
+
+#### Goal
+
+Demonstrate that ogcat is useful outside OpenGHG.
+
+#### Features
+
+- Parse `.bib` and `.ris` files using optional bibliography parser dependencies.
+- Create `paper` records.
+- Attach PDFs and auxiliary files.
+- Autofile attachments using a path template.
+- Search by author/year/title/tag.
+- Export a simple bibliography listing.
+- Keep example small enough to run locally.
+
+#### Candidate optional libraries to evaluate
+
+- `pybtex`
+- `bibtexparser`
+- `rispy`
+
+#### Acceptance criteria
+
+- Example can be run from a clean checkout.
+- It uses plugin/hook/schema features rather than special core code.
+- It has a tutorial page.
+
+---
+
+### Issue P2-07: Build OpenGHG/Fluxie-style format preparation example
+
+Labels: `priority:2`, `area:examples`, `kind:example`
+
+#### Goal
+
+Show how ogcat can simplify "data must be in a particular format" workflows.
+
+#### Example workflow
+
+- Register raw NetCDF/Zarr artifact.
+- Extract metadata.
+- Validate against an input schema.
+- Run a transformation operation that writes a standardised artifact.
+- Validate output.
+- Search for datasets that are ready for Fluxie/OpenGHG-style use.
+
+#### Acceptance criteria
+
+- Uses tiny generated data.
+- Keeps scientific domain logic in example/plugin code.
+- Demonstrates provenance from raw to standardised record.
+
+---
+
+### Issue P2-08: Build inversion/ML experiment tracking example
+
+Labels: `priority:2`, `area:examples`, `kind:example`
+
+#### Goal
+
+Demonstrate ogcat as a lightweight project catalog for runs, configs, outputs, scripts, and logs.
+
+#### Record kinds
+
+- `experiment`
+- `run`
+- `config`
+- `output`
+- `log`
+- `script`
+- `environment`
+
+#### Features
+
+- Register config files.
+- Register SLURM scripts.
+- Register log files.
+- Register output datasets.
+- Search runs by metadata.
+- Link runs to input data records.
+- Store path to external HPC output directory without moving data.
+
+#### Acceptance criteria
+
+- Example does not require actual HPC.
+- Uses generated files.
+- Demonstrates domain logic living outside core.
+
+---
+
+### Issue P2-09: Build EDGAR FTP/catalog front-end example
+
+Labels: `priority:2`, `area:examples`, `kind:example`
+
+#### Goal
+
+Show ogcat as a searchable front-end to remote data that may not be downloaded immediately.
+
+#### Features
+
+- Catalog remote FTP/HTTP URLs as external locators.
+- Store parsed metadata from filenames/directories.
+- Allow user to search and then download/register selected files.
+- Keep live network access optional; include a small static fixture manifest.
+
+#### Acceptance criteria
+
+- Works offline with a manifest fixture.
+- Clearly distinguishes external locator from managed artifact.
+- Demonstrates delayed materialisation.
+
+---
+
+### Issue P2-10: Build ICOS URI discovery example
+
+Labels: `priority:2`, `area:examples`, `kind:example`
+
+#### Goal
+
+Show how ogcat can catalog external persistent URIs without downloading data.
+
+#### Features
+
+- Store ICOS metadata URI/access URI as external locators.
+- Search by metadata.
+- Provide operation hook for domain package to materialise data later.
+- Keep ICOS-specific retrieval outside ogcat core.
+
+#### Acceptance criteria
+
+- Example uses small static metadata fixtures.
+- No live credentials required.
+- Demonstrates search/discovery rather than storage.
+
+---
+
+## Priority 3: scalable backends, server-managed transactions, indexing, and access control
+
+Priority 3 is where ogcat moves from a robust local/shared-file catalog toward a service that can support multiple users more safely.
+
+### P3 target outcomes
+
+- SQLite backend for stronger local semantics.
+- Postgres backend or server-managed catalog prototype.
+- Real transaction management where backend supports it.
+- Search indexes beyond TinyDB scans.
+- Better permissions/access control.
+- Worker execution for batch operations.
+- More complete audit/provenance/event querying.
+
+### P3 themes
+
+#### P3-A: SQLite backend
+
+SQLite is a natural stepping stone:
+
+- still lightweight;
+- single-file;
+- real transactions;
+- better indexing;
+- no server required;
+- easier migration path to SQLAlchemy/Postgres.
+
+Consider storing flexible metadata as JSON and indexing selected fields.
+
+#### P3-B: Postgres backend
+
+Postgres should support:
+
+- multi-user writes;
+- row-level locking;
+- JSONB metadata;
+- migrations;
+- stronger search;
+- transaction-aware operation records;
+- server deployment later.
+
+Use SQLAlchemy or another mature layer only after the domain model is stable.
+
+#### P3-C: Catalog server
+
+A server can centralise:
+
+- authentication;
+- user identity;
+- permissions;
+- transaction boundaries;
+- operation execution;
+- logs;
+- plugin loading;
+- storage profile access.
+
+Do not require server mode for simple users.
+
+#### P3-D: Search/indexing
+
+Add optional indexing:
+
+- selected metadata fields;
+- full-text search;
+- artifact format/media type;
+- temporal fields;
+- geospatial/spatiotemporal fields later if needed by plugins.
+
+Avoid making the core query language too ambitious. Plugins can expose domain-specific query helpers.
+
+#### P3-E: Permissions/access control
+
+Start with practical access control:
+
+- catalog admin;
+- writer;
+- reader;
+- operation runner;
+- plugin manager.
+
+At the record/artifact level:
+
+- public/private/project visibility;
+- read/write permission;
+- external locator credentials handled by storage profile, not record metadata.
+
+#### P3-F: Worker/batch execution
+
+Add execution abstraction:
+
+- local sequential executor;
+- local process/thread executor;
+- server worker;
+- optional Celery/Dask/SLURM integration through plugins later.
+
+Keep operation logs and journals consistent regardless of executor.
+
+---
+
+## Priority 4: enterprise-grade features and ecosystem interoperability
+
+Priority 4 should remain directional until P1-P3 reveal real usage patterns.
+
+### P4 target outcomes
+
+- policy-based data lifecycle management;
+- richer provenance graphs;
+- publication/export workflows;
+- UI or desktop/web front-end;
+- multi-protocol access;
+- stronger institutional integration.
+
+### P4 inspirations
+
+#### iRODS-like capabilities to borrow conceptually
+
+Do not clone iRODS. Borrow concepts selectively:
+
+- metadata-driven workflows;
+- automated ingest;
+- policy hooks;
+- audit logs;
+- storage tiering;
+- indexing;
+- publication workflows;
+- provenance;
+- multiple client protocols.
+
+ogcat should be the lower-entry, Pythonic, project-friendly version for teams that do not want to deploy an enterprise data-management platform.
+
+#### Interoperability targets
+
+Evaluate later:
+
+- RO-Crate for packaging metadata/provenance;
+- DataLad/git-annex for dataset versioning and large-file references;
+- Intake for data source descriptions;
+- frictionless data packages for tabular data;
+- OpenLineage-style event models for workflow lineage;
+- S3-compatible object stores;
+- institutional identity providers;
+- iRODS bridges where sites already use iRODS.
+
+---
+
+## 5. Cross-cutting design decisions
+
+### 5.1 Transactions and rollback
+
+Use these terms carefully:
+
+- **Unit of work**: ogcat-level operation boundary.
+- **Journal**: durable record of operation state transitions.
+- **Rollback action**: compensating action for a completed sub-step.
+- **Transaction**: only use for real backend transactions where the backend supports them.
+
+In TinyDB mode, say "transaction-like" or "recoverable operation", not ACID transaction.
+
+### 5.2 Logging
+
+Prefer catalog-level structured logs over per-user free-text logs.
+
+P1 logs should be:
+
+- JSONL;
+- filterable;
+- linked to operation IDs;
+- suitable for support/debugging;
+- safe enough not to dump secrets.
+
+Later logs can be stored in SQL or a log service.
+
+### 5.3 Metadata flexibility versus schema
+
+Default stance:
+
+- ogcat should accept flexible metadata;
+- schemas are opt-in;
+- schema validation should improve confidence, not block exploratory cataloging unless strict mode is requested;
+- domain plugins should own domain schemas.
+
+### 5.4 Hooks
+
+Hooks are necessary, but dangerous if uncontrolled.
+
+Rules:
+
+- hook order is deterministic;
+- hook failures are explicit;
+- required versus optional hooks are distinguished;
+- hooks are logged;
+- hooks can participate in rollback;
+- hooks should not mutate records invisibly unless the mutation is returned as a structured update.
+
+### 5.5 Async and concurrency
+
+Do not make the P1 core async.
+
+Reasonable path:
+
+- P1: synchronous operations; explicit operation boundaries; file locks for TinyDB.
+- P2: batch operations and optional executor abstraction.
+- P3: server/worker architecture if needed.
+- P4: more advanced orchestration.
+
+Avoid half-async APIs that make simple usage harder without solving real concurrency.
+
+### 5.6 Human readability
+
+Maintain human-readable catalog state where possible:
+
+- JSON/JSONL for TinyDB and logs;
+- clear paths;
+- useful CLI output;
+- metadata field inspection;
+- no opaque binary catalog unless backend requires it.
+
+### 5.7 Secrets
+
+Never store secrets in catalog records.
+
+Use:
+
+- environment variables;
+- storage profile references;
+- credential providers;
+- future server-side secrets management.
+
+---
+
+## 6. Documentation and examples plan
+
+### 6.1 Documentation audiences
+
+1. **Simple user**
+   - wants to catalog files and search them.
+   - needs quickstart.
+
+2. **Scientific/data workflow user**
+   - wants metadata extraction, validation, transformations, and provenance.
+   - needs tutorials and examples.
+
+3. **Plugin author**
+   - wants schemas, hooks, operations, storage profiles.
+   - needs reference docs.
+
+4. **OpenGHG developer**
+   - wants to understand how ogcat could replace storage logic.
+   - needs migration/adaptor notes.
+
+5. **Maintainer/admin**
+   - wants logs, recovery, locks, diagnostics.
+   - needs operations docs.
+
+### 6.2 Suggested tutorial sequence
+
+1. Create a catalog.
+2. Add a file.
+3. Add metadata.
+4. Search.
+5. Inspect fields.
+6. Show artifact path.
+7. Add data from memory.
+8. Recover from a failed operation.
+9. Validate a record with a schema.
+10. Extract NetCDF metadata.
+11. Add a plugin hook.
+12. Run a batch ingest.
+13. Use the OpenGHG plugin prototype.
+
+### 6.3 Examples repository decision
+
+Keep examples in the main repo for now if they are small and CI-friendly.
+
+Consider a parallel examples repo later if:
+
+- examples require large data;
+- examples require heavy domain dependencies;
+- examples need live services;
+- examples become more like tutorials than tests.
+
+### 6.4 RST plus Jupyter directive
+
+A practical docs pattern:
+
+- canonical runnable code lives in `examples/<name>/scripts/`;
+- docs pages include short snippets and command transcripts;
+- optional Jupyter execution is used for richer examples;
+- keep notebooks out of the critical docs path until the docs build is stable.
+
+---
+
+## 7. Testing strategy
+
+### 7.1 Principles
+
+- Test behaviour and contracts, not every incidental representation.
+- Use small generated fixtures.
+- Keep core tests independent of heavy optional dependencies.
+- Use optional markers for NetCDF/Zarr/OpenGHG examples.
+- Reuse backend contract tests for TinyDB, SQLite, and Postgres later.
+- Use failure injection for durability features.
+- Keep examples as smoke tests, not as the main specification.
+
+### 7.2 Test fixtures
+
+Suggested fixtures:
+
+- tiny text file;
+- tiny JSON file;
+- tiny generated NetCDF file;
+- tiny generated Zarr group;
+- fake bibliography file;
+- fake EDGAR manifest;
+- fake ICOS metadata record;
+- fake OpenGHG-like data record;
+- fake SLURM script/log/config/output directory.
+
+### 7.3 CI stages
+
+Initial:
+
+```text
+lint
+unit tests
+CLI tests
+docs build
+selected example smoke tests
+```
+
+Later:
+
+```text
+optional scientific tests
+plugin tests
+backend contract tests for SQLite/Postgres
+integration tests
+```
+
+---
+
+## 8. Suggested GitHub issue generation format
+
+The sections named `Issue P*-NN` are intended to be machine-splittable.
+
+A simple script can:
+
+1. split this document on headings matching `^### Issue `;
+2. use the heading as the issue title;
+3. parse the `Labels:` line;
+4. use the rest of the section as the body;
+5. call `gh issue create`.
+
+Suggested labels:
+
+```text
+priority:1
+priority:2
+priority:3
+priority:4
+area:architecture
+area:model
+area:backend
+area:durability
+area:logging
+area:storage
+area:schema
+area:plugins
+area:metadata
+area:cli
+area:concurrency
+area:examples
+area:docs
+area:packaging
+area:testing
+area:openghg
+area:operations
+area:batch
+kind:feature
+kind:docs
+kind:maintenance
+kind:example
+```
+
+---
+
+## 9. Recommended immediate implementation order
+
+For Priority 1, do this order:
+
+1. P1-01 architecture decision record.
+2. P1-02 record/artifact/locator models.
+3. P1-03 backend protocol.
+4. P1-10 CLI/API parity for `info` and `fields` if these are already nearly implemented.
+5. P1-04 unit-of-work and journal.
+6. P1-05 structured logging.
+7. P1-06 fsspec storage primitives.
+8. P1-07 schema validation.
+9. P1-08 hook engine.
+10. P1-09 metadata extraction.
+11. P1-11 TinyDB locking and concurrency caveats.
+12. P1-12 examples.
+13. P1-13 docs.
+14. P1-14 packaging extras.
+15. P1-15 broad testing improvements.
+
+Rationale:
+
+- models and backend boundaries should come before durability features;
+- unit-of-work and logging should come before complicated hooks;
+- fsspec storage should integrate with unit-of-work from the start;
+- docs and examples should be written once the basic APIs settle, but not postponed indefinitely.
+
+---
+
+## 10. Open questions
+
+These should be resolved during P1/P2, not before starting.
+
+1. Should fsspec be a hard dependency or an optional extra?
+2. Should Pydantic models be public API objects or internal validation only?
+3. What is the canonical on-disk TinyDB/catalog layout?
+4. Should `delete` mean tombstone by default?
+5. How much metadata field indexing should TinyDB mode attempt?
+6. Should schemas be Pydantic-only initially, or should JSON Schema be a first-class input?
+7. How much plugin capability should exist before OpenGHG integration starts?
+8. Should examples stay in the main repo or move to an examples repo later?
+9. What is the smallest useful ObjectStore-like interface to extract from OpenGHG?
+10. How should user identity be determined in local/HPC use: OS user, explicit config, environment variable, or server identity later?
+11. How should storage profiles handle credentials without leaking secrets into records/logs?
+12. Should operation journals live in the catalog directory, next to the TinyDB file, or in a platform-specific state directory?
+13. How should record IDs be generated: UUID, ULID, content-derived, slug-plus-suffix, or backend-specific?
+14. Should path templates be pure format strings, small Python callables, or plugin-defined objects?
+15. Should example data include generated fixtures only, or small checked-in binary files where useful?
+
+---
+
+## 11. Compact roadmap
+
+### Priority 1: robust local catalog
+
+- explicit models;
+- backend protocol;
+- TinyDB backend hardening;
+- unit-of-work/journal;
+- structured logging;
+- fsspec storage;
+- schema validation;
+- hook points;
+- generic metadata extraction;
+- better CLI/API parity;
+- examples and docs;
+- targeted tests.
+
+### Priority 2: plugins and domain workflows
+
+- plugin discovery;
+- operation pipelines;
+- OpenGHG plugin prototype;
+- read-only ObjectStore adapter;
+- batch ingest;
+- mini BibDesk example;
+- OpenGHG/Fluxie-style example;
+- inversion/ML tracking example;
+- EDGAR and ICOS discovery examples.
+
+### Priority 3: scale and multi-user safety
+
+- SQLite backend;
+- Postgres backend;
+- server mode;
+- transaction-aware operations;
+- indexing/search;
+- permissions;
+- worker execution;
+- richer audit/provenance queries.
+
+### Priority 4: ecosystem and enterprise features
+
+- policy-driven lifecycle;
+- provenance graphs;
+- publication/export workflows;
+- UI/front-end;
+- iRODS-style interoperability where useful;
+- RO-Crate/DataLad/Intake-style bridges;
+- institutional deployment patterns.
+
+---
+
+## 12. Definition of success
+
+ogcat succeeds if:
+
+- a user can create a useful catalog in minutes;
+- a maintainer can debug failures from catalog-level logs;
+- failed writes do not leave misleading active records;
+- metadata remains flexible but can be validated when needed;
+- domain packages can add schemas, parsers, transformations, and exports without patching ogcat core;
+- OpenGHG can progressively move storage/object-store concerns into ogcat-backed adapters;
+- future backends can implement stronger transactions and concurrency without changing the conceptual API;
+- examples are good enough to explain the project to skeptical users.

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,7 +1,9 @@
 """Public package interface for ogcat."""
 
 from ogcat.catalog import Catalog
+from ogcat.hooks import HookManager, HookWarning, OperationContext
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
+from ogcat.plugins import PluginRegistry
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import (
@@ -18,8 +20,12 @@ __all__ = [
     "Catalog",
     "CatalogRecord",
     "CatalogSpec",
+    "HookManager",
+    "HookWarning",
     "MetadataFieldDescription",
     "OperationState",
+    "OperationContext",
+    "PluginRegistry",
     "RollbackFailure",
     "RecordSchema",
     "UnitOfWork",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -107,22 +107,23 @@ class Catalog:
             """Resolve the managed-file storage path for this operation."""
             naming_context = build_naming_context(
                 record_id=context.operation_id,
+                operation_id=context.operation_id,
                 original_path=source,
                 metadata=context.user_metadata,
                 date_added=timestamp[:10],
             )
-            target, rel_path, resolved_filename = render_storage_location(
+            target, rel_path, _resolved_filename = render_storage_location(
                 files_root=files_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
             )
-            naming_metadata["resolved_filename"] = resolved_filename
             return ArtifactLocator.path(target, relative_path=rel_path)
 
         def write_local_file(context: OperationContext, locator: ArtifactLocator) -> None:
             """Copy or move the source file to the canonical path locator."""
             target = _path_from_locator(locator)
+            naming_metadata["resolved_filename"] = target.name
             target.parent.mkdir(parents=True, exist_ok=True)
             if chosen_operation == "copy":
                 context.rollback(

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -497,6 +497,7 @@ class Catalog:
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
+            self.hook_manager.before_record_write(hook_context)
             record = self._build_artifact_record(
                 record_type=record_type,
                 locator=canonical_locator,
@@ -509,7 +510,6 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
             )
-            self.hook_manager.before_record_write(hook_context)
             persisted = transaction.insert_staged_record(record)
             self.hook_manager.after_record_write(hook_context)
             if commit:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -19,6 +19,10 @@ from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import OperationState, UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata
+
+ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
+ArtifactWriter = Callable[[OperationContext, ArtifactLocator], None]
+DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 
 
 @dataclass(slots=True)
@@ -92,117 +96,76 @@ class Catalog:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
 
         timestamp = _utc_timestamp()
-        date_added = timestamp[:10]
-        draft_record = self._build_artifact_record(
-            record_type=resolved_record_type,
-            locator=ArtifactLocator(kind="opaque", value=""),
-            metadata=metadata,
-            storage_mode=chosen_operation,
-            original_path=source,
-            original_filename=source.name,
-            suffixes=source.suffixes,
-            time_added=timestamp,
-        )
+        files_root = self.root / self.spec.files_root
+        naming_metadata: MetadataDict = {
+            "record_schema": "default" if record_type is None else record_type,
+            "directory_template": directory_template,
+            "filename_template": filename_template,
+        }
+
+        def resolve_local_file_locator(context: OperationContext) -> ArtifactLocator:
+            """Resolve the managed-file storage path for this operation."""
+            naming_context = build_naming_context(
+                record_id=context.operation_id,
+                original_path=source,
+                metadata=context.user_metadata,
+                date_added=timestamp[:10],
+            )
+            target, rel_path, resolved_filename = render_storage_location(
+                files_root=files_root,
+                directory_template=directory_template,
+                filename_template=filename_template,
+                context=naming_context,
+            )
+            naming_metadata["resolved_filename"] = resolved_filename
+            return ArtifactLocator.path(target, relative_path=rel_path)
+
+        def write_local_file(context: OperationContext, locator: ArtifactLocator) -> None:
+            """Copy or move the source file to the canonical path locator."""
+            target = _path_from_locator(locator)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if chosen_operation == "copy":
+                context.rollback(
+                    lambda path=target: path.unlink(missing_ok=True),
+                    description=f"remove copied file {target}",
+                )
+                shutil.copy2(source, target)
+            else:
+                context.rollback(
+                    lambda source_path=source, target_path=target: _rollback_moved_file(
+                        source_path=source_path,
+                        target_path=target_path,
+                    ),
+                    description=f"restore moved file from {target} to {source}",
+                )
+                shutil.move(str(source), str(target))
+
+        def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
+            """Collect generic derived metadata from the written file."""
+            context.derived_metadata.update(extract_derived_metadata(_path_from_locator(locator)))
 
         with self.transaction() as transaction:
-            hook_context = OperationContext(
-                catalog_root=self.root,
-                operation_id=transaction.operation_id,
-                operation="add_file",
+            return self._run_add_operation(
+                transaction=transaction,
+                commit=True,
+                operation_type="add_file",
                 record_type=resolved_record_type,
-                user_metadata=metadata,
-                register_rollback=transaction.register_rollback,
-                source_path=source,
+                schema=schema,
+                schema_record_type=record_type,
+                metadata=metadata,
                 storage_mode=chosen_operation,
                 original_path=source,
                 original_filename=source.name,
-                suffixes=list(source.suffixes),
+                suffixes=source.suffixes,
+                derived_metadata={},
+                naming_metadata=naming_metadata,
+                time_added=timestamp,
+                source_path=source,
+                source_descriptor=str(source),
+                locator_factory=resolve_local_file_locator,
+                artifact_writer=write_local_file,
+                derived_metadata_collector=collect_file_metadata,
             )
-            try:
-                # Hooks can fill or normalise metadata before schema validation,
-                # which is the main extension point for domain-specific defaults.
-                self.hook_manager.before_validate_metadata(hook_context)
-                validation_report = self._metadata_validation_report(
-                    schema=schema,
-                    metadata=hook_context.user_metadata,
-                    record_type=record_type,
-                )
-                self.hook_manager.after_validate_metadata(hook_context, validation_report)
-                validation_report.raise_for_errors()
-
-                draft_record.user_metadata = dict(hook_context.user_metadata)
-                persisted_record = transaction.insert_staged_record(draft_record)
-                record_id = _require_record_id(persisted_record)
-
-                naming_context = build_naming_context(
-                    record_id=record_id,
-                    original_path=source,
-                    metadata=hook_context.user_metadata,
-                    date_added=date_added,
-                )
-                files_root = self.root / self.spec.files_root
-                target, rel_path, resolved_filename = render_storage_location(
-                    files_root=files_root,
-                    directory_template=directory_template,
-                    filename_template=filename_template,
-                    context=naming_context,
-                )
-                locator = ArtifactLocator.path(target, relative_path=rel_path)
-                hook_context.planned_locators.append(locator)
-                self.hook_manager.plan_locator(hook_context)
-                target.parent.mkdir(parents=True, exist_ok=True)
-
-                # File work happens inside UnitOfWork so hook or copy failures
-                # can use the same compensating rollback path as repository writes.
-                self.hook_manager.before_write_artifact(hook_context)
-                if chosen_operation == "copy":
-                    transaction.register_rollback(
-                        lambda path=target: path.unlink(missing_ok=True),
-                        description=f"remove copied file {target}",
-                    )
-                    shutil.copy2(source, target)
-                    storage_mode = "copy"
-                else:
-                    shutil.move(str(source), str(target))
-                    storage_mode = "move"
-                hook_context.storage_mode = storage_mode
-                self.hook_manager.after_write_artifact(hook_context)
-
-                # NOTE: derived metadata is not used for location and filename creation
-                hook_context.derived_metadata.update(extract_derived_metadata(target))
-                self.hook_manager.extract_metadata(hook_context)
-                derived_metadata = _metadata_with_hook_warnings(hook_context)
-                record = self._build_artifact_record(
-                    record_id=record_id,
-                    record_type=resolved_record_type,
-                    locator=locator,
-                    metadata=hook_context.user_metadata,
-                    storage_mode=storage_mode,
-                    original_path=source,
-                    original_filename=source.name,
-                    suffixes=source.suffixes,
-                    derived_metadata=derived_metadata,
-                    naming_metadata={
-                        "record_schema": "default" if record_type is None else record_type,
-                        "directory_template": directory_template,
-                        "filename_template": filename_template,
-                        "resolved_filename": resolved_filename,
-                    },
-                    time_added=timestamp,
-                )
-                self.repository.update(record)
-                self.hook_manager.before_commit(hook_context)
-                transaction.commit()
-                # After-commit hooks are best-effort: failures warn, but cannot
-                # turn an already-persisted record into an apparent API failure.
-                self.hook_manager.after_commit(hook_context)
-                return record
-            except Exception as exc:
-                self.hook_manager.on_error(hook_context, exc)
-                if transaction.state is not OperationState.COMMITTED:
-                    transaction.rollback(original_exception=exc)
-                    self.hook_manager.on_rollback(hook_context, exc)
-                raise
 
     def add_artifact(
         self,
@@ -236,6 +199,7 @@ class Catalog:
                 raise ValueError("Transaction is bound to a different catalog repository.")
             return self._add_artifact_in_transaction(
                 transaction=transaction,
+                commit=False,
                 record_type=record_type,
                 locator=locator,
                 metadata=metadata,
@@ -251,6 +215,7 @@ class Catalog:
         with self.transaction() as unit_of_work:
             return self._add_artifact_in_transaction(
                 transaction=unit_of_work,
+                commit=True,
                 record_type=record_type,
                 locator=locator,
                 metadata=metadata,
@@ -262,7 +227,6 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
                 schema=schema,
-                commit=True,
             )
 
     @contextmanager
@@ -441,6 +405,7 @@ class Catalog:
         self,
         *,
         transaction: UnitOfWork,
+        commit: bool,
         record_type: str,
         locator: ArtifactLocator,
         metadata: MetadataDict,
@@ -452,20 +417,62 @@ class Catalog:
         naming_metadata: MetadataDict | None,
         time_added: str | None,
         schema: RecordSchema,
-        commit: bool = False,
     ) -> CatalogRecord:
         """Add an artifact record within an active transaction."""
+        return self._run_add_operation(
+            transaction=transaction,
+            commit=commit,
+            operation_type="add_artifact",
+            record_type=record_type,
+            schema=schema,
+            schema_record_type=record_type,
+            metadata=metadata,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=suffixes,
+            derived_metadata=derived_metadata,
+            naming_metadata=naming_metadata,
+            time_added=time_added,
+            source_path=locator.as_path(),
+            source_descriptor=locator.value,
+            locator_factory=lambda context: locator,
+        )
+
+    def _run_add_operation(
+        self,
+        *,
+        transaction: UnitOfWork,
+        commit: bool,
+        operation_type: str,
+        record_type: str,
+        schema: RecordSchema,
+        schema_record_type: str | None,
+        metadata: MetadataDict,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        derived_metadata: MetadataDict,
+        naming_metadata: MetadataDict | None,
+        time_added: str | None,
+        source_path: Path | None,
+        source_descriptor: str | None,
+        locator_factory: ArtifactLocatorFactory,
+        artifact_writer: ArtifactWriter | None = None,
+        derived_metadata_collector: DerivedMetadataCollector | None = None,
+    ) -> CatalogRecord:
+        """Run the shared add operation lifecycle for file and record-only adds."""
         hook_context = OperationContext(
             catalog_root=self.root,
             operation_id=transaction.operation_id,
-            operation="add_artifact",
+            operation_type=operation_type,
             record_type=record_type,
             user_metadata=metadata,
             derived_metadata=derived_metadata,
-            planned_locators=[locator],
             register_rollback=transaction.register_rollback,
-            source_path=locator.as_path(),
-            source_descriptor=locator.value,
+            source_path=source_path,
+            source_descriptor=source_descriptor,
             storage_mode=storage_mode,
             original_path=original_path,
             original_filename=original_filename,
@@ -476,16 +483,22 @@ class Catalog:
             validation_report = self._metadata_validation_report(
                 schema=schema,
                 metadata=hook_context.user_metadata,
-                record_type=record_type,
+                record_type=schema_record_type,
             )
             self.hook_manager.after_validate_metadata(hook_context, validation_report)
             validation_report.raise_for_errors()
-            self.hook_manager.plan_locator(hook_context)
-            self.hook_manager.before_write_artifact(hook_context)
+            hook_context.planned_locators = [locator_factory(hook_context)]
+            self.hook_manager.resolve_artifact_locator(hook_context)
+            canonical_locator = _artifact_locator_from_context(hook_context)
+            hook_context.planned_locators[0] = canonical_locator
+            if artifact_writer is not None:
+                artifact_writer(hook_context, canonical_locator)
+            if derived_metadata_collector is not None:
+                derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
             record = self._build_artifact_record(
                 record_type=record_type,
-                locator=locator,
+                locator=canonical_locator,
                 metadata=hook_context.user_metadata,
                 storage_mode=storage_mode,
                 original_path=original_path,
@@ -495,13 +508,14 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
             )
+            self.hook_manager.before_record_write(hook_context)
             persisted = transaction.insert_staged_record(record)
-            self.hook_manager.after_write_artifact(hook_context)
+            self.hook_manager.after_record_write(hook_context)
             if commit:
                 self.hook_manager.before_commit(hook_context)
                 transaction.commit()
-                # See add_file(): after-commit hooks must not change success
-                # semantics once the transaction has committed.
+                # After-commit hooks are best-effort: failures warn, but cannot
+                # turn an already-persisted record into an apparent API failure.
                 self.hook_manager.after_commit(hook_context)
             return persisted
         except Exception as exc:
@@ -607,6 +621,32 @@ def _coerce_metadata_input(
     if isinstance(metadata, dict):
         return dict(metadata)
     raise TypeError(f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}")
+
+
+def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
+    """Return the canonical locator after locator-resolution hooks run."""
+    if not context.planned_locators:
+        raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
+    return context.planned_locators[0]
+
+
+def _path_from_locator(locator: ArtifactLocator) -> Path:
+    """Return a local path from a path-backed artifact locator."""
+    path = locator.as_path()
+    if path is None:
+        raise ValueError("Managed file operations require a path-backed artifact locator.")
+    return path
+
+
+def _rollback_moved_file(*, source_path: Path, target_path: Path) -> None:
+    """Restore a moved file when possible, otherwise remove the moved target."""
+    if not target_path.exists():
+        return
+    if not source_path.exists():
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(target_path), str(source_path))
+        return
+    target_path.unlink(missing_ok=True)
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -83,7 +83,7 @@ class Catalog:
         metadata_input = {} if metadata is None else metadata
         schema = self._select_schema(record_type, require_known=record_type is not None)
         schema_name = self._schema_name(record_type)
-        metadata = _coerce_metadata_input(metadata_input, schema=schema, schema_name=schema_name)
+        metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
         resolved_record_type = "managed_file" if record_type is None else record_type
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
         filename_template = _require_template(schema.filename_template, field_name="filename_template")
@@ -111,7 +111,7 @@ class Catalog:
                 operation="add_file",
                 record_type=resolved_record_type,
                 user_metadata=metadata,
-                register_rollback=lambda action: transaction.register_rollback(action),
+                register_rollback=transaction.register_rollback,
                 source_path=source,
                 storage_mode=chosen_operation,
                 original_path=source,
@@ -119,6 +119,8 @@ class Catalog:
                 suffixes=list(source.suffixes),
             )
             try:
+                # Hooks can fill or normalise metadata before schema validation,
+                # which is the main extension point for domain-specific defaults.
                 self.hook_manager.before_validate_metadata(hook_context)
                 validation_report = self._metadata_validation_report(
                     schema=schema,
@@ -150,6 +152,8 @@ class Catalog:
                 self.hook_manager.plan_locator(hook_context)
                 target.parent.mkdir(parents=True, exist_ok=True)
 
+                # File work happens inside UnitOfWork so hook or copy failures
+                # can use the same compensating rollback path as repository writes.
                 self.hook_manager.before_write_artifact(hook_context)
                 if chosen_operation == "copy":
                     transaction.register_rollback(
@@ -189,6 +193,8 @@ class Catalog:
                 self.repository.update(record)
                 self.hook_manager.before_commit(hook_context)
                 transaction.commit()
+                # After-commit hooks are best-effort: failures warn, but cannot
+                # turn an already-persisted record into an apparent API failure.
                 self.hook_manager.after_commit(hook_context)
                 return record
             except Exception as exc:
@@ -224,7 +230,7 @@ class Catalog:
         derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
         schema = self._select_schema(record_type, require_known=False)
         schema_name = self._schema_name(record_type)
-        metadata = _coerce_metadata_input(metadata_input, schema=schema, schema_name=schema_name)
+        metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
         if transaction is not None:
             if transaction.repository is not self.repository:
                 raise ValueError("Transaction is bound to a different catalog repository.")
@@ -457,7 +463,7 @@ class Catalog:
             user_metadata=metadata,
             derived_metadata=derived_metadata,
             planned_locators=[locator],
-            register_rollback=lambda action: transaction.register_rollback(action),
+            register_rollback=transaction.register_rollback,
             source_path=locator.as_path(),
             source_descriptor=locator.value,
             storage_mode=storage_mode,
@@ -494,10 +500,14 @@ class Catalog:
             if commit:
                 self.hook_manager.before_commit(hook_context)
                 transaction.commit()
+                # See add_file(): after-commit hooks must not change success
+                # semantics once the transaction has committed.
                 self.hook_manager.after_commit(hook_context)
             return persisted
         except Exception as exc:
             self.hook_manager.on_error(hook_context, exc)
+            # Caller-supplied transactions stay caller-owned. Internal
+            # transactions commit=True and roll back here before re-raising.
             if commit and transaction.state is not OperationState.COMMITTED:
                 transaction.rollback(original_exception=exc)
                 self.hook_manager.on_rollback(hook_context, exc)
@@ -591,13 +601,11 @@ def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
 def _coerce_metadata_input(
     metadata: object,
     *,
-    schema: RecordSchema,
     schema_name: str,
 ) -> MetadataDict:
     """Copy user metadata after preserving existing non-dictionary errors."""
     if isinstance(metadata, dict):
         return dict(metadata)
-    validate_metadata(metadata, schema, schema_name=schema_name).raise_for_errors()
     raise TypeError(f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}")
 
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -82,9 +82,8 @@ class Catalog:
         source = Path(path).expanduser().resolve()
         metadata_input = {} if metadata is None else metadata
         schema = self._select_schema(record_type, require_known=record_type is not None)
-        if not isinstance(metadata_input, dict):
-            self._validate_metadata(schema=schema, metadata=metadata_input, record_type=record_type)
-        metadata = dict(metadata_input)
+        schema_name = self._schema_name(record_type)
+        metadata = _coerce_metadata_input(metadata_input, schema=schema, schema_name=schema_name)
         resolved_record_type = "managed_file" if record_type is None else record_type
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
         filename_template = _require_template(schema.filename_template, field_name="filename_template")
@@ -224,9 +223,8 @@ class Catalog:
         metadata_input = {} if metadata is None else metadata
         derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
         schema = self._select_schema(record_type, require_known=False)
-        if not isinstance(metadata_input, dict):
-            self._validate_metadata(schema=schema, metadata=metadata_input, record_type=record_type)
-        metadata = dict(metadata_input)
+        schema_name = self._schema_name(record_type)
+        metadata = _coerce_metadata_input(metadata_input, schema=schema, schema_name=schema_name)
         if transaction is not None:
             if transaction.repository is not self.repository:
                 raise ValueError("Transaction is bound to a different catalog repository.")
@@ -500,7 +498,7 @@ class Catalog:
             return persisted
         except Exception as exc:
             self.hook_manager.on_error(hook_context, exc)
-            if transaction.state is not OperationState.COMMITTED:
+            if commit and transaction.state is not OperationState.COMMITTED:
                 transaction.rollback(original_exception=exc)
                 self.hook_manager.on_rollback(hook_context, exc)
             raise
@@ -537,10 +535,14 @@ class Catalog:
         record_type: str | None,
     ) -> ValidationReport:
         """Return validation report for the selected schema."""
-        schema_name = (
-            record_type if record_type is not None and record_type in self.spec.record_schemas else "default"
-        )
+        schema_name = self._schema_name(record_type)
         return validate_metadata(metadata, schema, schema_name=schema_name)
+
+    def _schema_name(self, record_type: str | None) -> str:
+        """Return the validation schema name for a record type."""
+        if record_type is not None and record_type in self.spec.record_schemas:
+            return record_type
+        return "default"
 
     def _has_metadata_fields(self) -> bool:
         """Return whether any default or named schema describes metadata fields."""
@@ -584,6 +586,19 @@ def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
         warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
         metadata["hook_warnings"] = warnings_metadata
     return metadata
+
+
+def _coerce_metadata_input(
+    metadata: object,
+    *,
+    schema: RecordSchema,
+    schema_name: str,
+) -> MetadataDict:
+    """Copy user metadata after preserving existing non-dictionary errors."""
+    if isinstance(metadata, dict):
+        return dict(metadata)
+    validate_metadata(metadata, schema, schema_name=schema_name).raise_for_errors()
+    raise TypeError(f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}")
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
 from ogcat.extractors import extract_derived_metadata
+from ogcat.hooks import HookManager, OperationContext
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict
 from ogcat.naming import build_naming_context, render_storage_location
+from ogcat.plugins import PluginRegistry
 from ogcat.repository import CatalogRepository
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.tinydb_repository import TinyDbCatalogRepository
-from ogcat.transactions import UnitOfWork
-from ogcat.validation import validate_metadata
+from ogcat.transactions import OperationState, UnitOfWork
+from ogcat.validation import ValidationReport, validate_metadata
 
 
 @dataclass(slots=True)
@@ -26,24 +28,48 @@ class Catalog:
     root: Path
     spec: CatalogSpec
     repository: CatalogRepository
+    hook_manager: HookManager = field(default_factory=HookManager)
 
     @classmethod
-    def create(cls, root: str | Path, spec: CatalogSpec) -> Catalog:
+    def create(
+        cls,
+        root: str | Path,
+        spec: CatalogSpec,
+        *,
+        plugins: PluginRegistry | None = None,
+        hooks: HookManager | None = None,
+    ) -> Catalog:
         """Create a new catalog directory and write its specification."""
         root_path = Path(root).expanduser().resolve()
         root_path.mkdir(parents=True, exist_ok=True)
         spec.write(root_path / "catalog.json")
         (root_path / spec.files_root).mkdir(parents=True, exist_ok=True)
         repository = _open_repository(root_path, spec)
-        return cls(root=root_path, spec=spec, repository=repository)
+        return cls(
+            root=root_path,
+            spec=spec,
+            repository=repository,
+            hook_manager=_coerce_hook_manager(plugins=plugins, hooks=hooks),
+        )
 
     @classmethod
-    def open(cls, root: str | Path) -> Catalog:
+    def open(
+        cls,
+        root: str | Path,
+        *,
+        plugins: PluginRegistry | None = None,
+        hooks: HookManager | None = None,
+    ) -> Catalog:
         """Open an existing catalog from disk."""
         root_path = Path(root).expanduser().resolve()
         spec = CatalogSpec.read(root_path / "catalog.json")
         repository = _open_repository(root_path, spec)
-        return cls(root=root_path, spec=spec, repository=repository)
+        return cls(
+            root=root_path,
+            spec=spec,
+            repository=repository,
+            hook_manager=_coerce_hook_manager(plugins=plugins, hooks=hooks),
+        )
 
     def add_file(
         self,
@@ -54,9 +80,11 @@ class Catalog:
     ) -> CatalogRecord:
         """Add a file to the catalog using managed copy or move."""
         source = Path(path).expanduser().resolve()
-        metadata = {} if metadata is None else metadata
+        metadata_input = {} if metadata is None else metadata
         schema = self._select_schema(record_type, require_known=record_type is not None)
-        self._validate_metadata(schema=schema, metadata=metadata, record_type=record_type)
+        if not isinstance(metadata_input, dict):
+            self._validate_metadata(schema=schema, metadata=metadata_input, record_type=record_type)
+        metadata = dict(metadata_input)
         resolved_record_type = "managed_file" if record_type is None else record_type
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
         filename_template = _require_template(schema.filename_template, field_name="filename_template")
@@ -78,59 +106,98 @@ class Catalog:
         )
 
         with self.transaction() as transaction:
-            persisted_record = transaction.insert_staged_record(draft_record)
-            record_id = _require_record_id(persisted_record)
-
-            context = build_naming_context(
-                record_id=record_id,
-                original_path=source,
-                metadata=metadata,
-                date_added=date_added,
-            )
-            files_root = self.root / self.spec.files_root
-            target, rel_path, resolved_filename = render_storage_location(
-                files_root=files_root,
-                directory_template=directory_template,
-                filename_template=filename_template,
-                context=context,
-            )
-            target.parent.mkdir(parents=True, exist_ok=True)
-
-            if chosen_operation == "copy":
-                transaction.register_rollback(
-                    lambda path=target: path.unlink(missing_ok=True),
-                    description=f"remove copied file {target}",
-                )
-                shutil.copy2(source, target)
-                storage_mode = "copy"
-            else:
-                shutil.move(str(source), str(target))
-                storage_mode = "move"
-
-            # NOTE: derived metadata is not used for location and filename creation
-            derived_metadata = extract_derived_metadata(target)
-            locator = ArtifactLocator.path(target, relative_path=rel_path)
-            record = self._build_artifact_record(
-                record_id=record_id,
+            hook_context = OperationContext(
+                catalog_root=self.root,
+                operation_id=transaction.operation_id,
+                operation="add_file",
                 record_type=resolved_record_type,
-                locator=locator,
-                metadata=metadata,
-                storage_mode=storage_mode,
+                user_metadata=metadata,
+                register_rollback=lambda action: transaction.register_rollback(action),
+                source_path=source,
+                storage_mode=chosen_operation,
                 original_path=source,
                 original_filename=source.name,
-                suffixes=source.suffixes,
-                derived_metadata=derived_metadata,
-                naming_metadata={
-                    "record_schema": "default" if record_type is None else record_type,
-                    "directory_template": directory_template,
-                    "filename_template": filename_template,
-                    "resolved_filename": resolved_filename,
-                },
-                time_added=timestamp,
+                suffixes=list(source.suffixes),
             )
-            self.repository.update(record)
-            transaction.commit()
-            return record
+            try:
+                self.hook_manager.before_validate_metadata(hook_context)
+                validation_report = self._metadata_validation_report(
+                    schema=schema,
+                    metadata=hook_context.user_metadata,
+                    record_type=record_type,
+                )
+                self.hook_manager.after_validate_metadata(hook_context, validation_report)
+                validation_report.raise_for_errors()
+
+                draft_record.user_metadata = dict(hook_context.user_metadata)
+                persisted_record = transaction.insert_staged_record(draft_record)
+                record_id = _require_record_id(persisted_record)
+
+                naming_context = build_naming_context(
+                    record_id=record_id,
+                    original_path=source,
+                    metadata=hook_context.user_metadata,
+                    date_added=date_added,
+                )
+                files_root = self.root / self.spec.files_root
+                target, rel_path, resolved_filename = render_storage_location(
+                    files_root=files_root,
+                    directory_template=directory_template,
+                    filename_template=filename_template,
+                    context=naming_context,
+                )
+                locator = ArtifactLocator.path(target, relative_path=rel_path)
+                hook_context.planned_locators.append(locator)
+                self.hook_manager.plan_locator(hook_context)
+                target.parent.mkdir(parents=True, exist_ok=True)
+
+                self.hook_manager.before_write_artifact(hook_context)
+                if chosen_operation == "copy":
+                    transaction.register_rollback(
+                        lambda path=target: path.unlink(missing_ok=True),
+                        description=f"remove copied file {target}",
+                    )
+                    shutil.copy2(source, target)
+                    storage_mode = "copy"
+                else:
+                    shutil.move(str(source), str(target))
+                    storage_mode = "move"
+                hook_context.storage_mode = storage_mode
+                self.hook_manager.after_write_artifact(hook_context)
+
+                # NOTE: derived metadata is not used for location and filename creation
+                hook_context.derived_metadata.update(extract_derived_metadata(target))
+                self.hook_manager.extract_metadata(hook_context)
+                derived_metadata = _metadata_with_hook_warnings(hook_context)
+                record = self._build_artifact_record(
+                    record_id=record_id,
+                    record_type=resolved_record_type,
+                    locator=locator,
+                    metadata=hook_context.user_metadata,
+                    storage_mode=storage_mode,
+                    original_path=source,
+                    original_filename=source.name,
+                    suffixes=source.suffixes,
+                    derived_metadata=derived_metadata,
+                    naming_metadata={
+                        "record_schema": "default" if record_type is None else record_type,
+                        "directory_template": directory_template,
+                        "filename_template": filename_template,
+                        "resolved_filename": resolved_filename,
+                    },
+                    time_added=timestamp,
+                )
+                self.repository.update(record)
+                self.hook_manager.before_commit(hook_context)
+                transaction.commit()
+                self.hook_manager.after_commit(hook_context)
+                return record
+            except Exception as exc:
+                self.hook_manager.on_error(hook_context, exc)
+                if transaction.state is not OperationState.COMMITTED:
+                    transaction.rollback(original_exception=exc)
+                    self.hook_manager.on_rollback(hook_context, exc)
+                raise
 
     def add_artifact(
         self,
@@ -154,32 +221,45 @@ class Catalog:
         delegates here. Pass a catalog transaction to stage the record as part
         of a larger best-effort unit of work.
         """
+        metadata_input = {} if metadata is None else metadata
+        derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
         schema = self._select_schema(record_type, require_known=False)
-        self._validate_metadata(
-            schema=schema,
-            metadata={} if metadata is None else metadata,
-            record_type=record_type,
-        )
-        record = self._build_artifact_record(
-            record_type=record_type,
-            locator=locator,
-            metadata=metadata,
-            storage_mode=storage_mode,
-            original_path=original_path,
-            original_filename=original_filename,
-            suffixes=suffixes,
-            derived_metadata=derived_metadata,
-            naming_metadata=naming_metadata,
-            time_added=time_added,
-        )
+        if not isinstance(metadata_input, dict):
+            self._validate_metadata(schema=schema, metadata=metadata_input, record_type=record_type)
+        metadata = dict(metadata_input)
         if transaction is not None:
             if transaction.repository is not self.repository:
                 raise ValueError("Transaction is bound to a different catalog repository.")
-            return transaction.insert_staged_record(record)
+            return self._add_artifact_in_transaction(
+                transaction=transaction,
+                record_type=record_type,
+                locator=locator,
+                metadata=metadata,
+                storage_mode=storage_mode,
+                original_path=original_path,
+                original_filename=original_filename,
+                suffixes=suffixes,
+                derived_metadata=derived_metadata,
+                naming_metadata=naming_metadata,
+                time_added=time_added,
+                schema=schema,
+            )
         with self.transaction() as unit_of_work:
-            persisted = unit_of_work.insert_staged_record(record)
-            unit_of_work.commit()
-            return persisted
+            return self._add_artifact_in_transaction(
+                transaction=unit_of_work,
+                record_type=record_type,
+                locator=locator,
+                metadata=metadata,
+                storage_mode=storage_mode,
+                original_path=original_path,
+                original_filename=original_filename,
+                suffixes=suffixes,
+                derived_metadata=derived_metadata,
+                naming_metadata=naming_metadata,
+                time_added=time_added,
+                schema=schema,
+                commit=True,
+            )
 
     @contextmanager
     def transaction(self) -> Iterator[UnitOfWork]:
@@ -353,6 +433,78 @@ class Catalog:
             naming_metadata={} if naming_metadata is None else dict(naming_metadata),
         )
 
+    def _add_artifact_in_transaction(
+        self,
+        *,
+        transaction: UnitOfWork,
+        record_type: str,
+        locator: ArtifactLocator,
+        metadata: MetadataDict,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        derived_metadata: MetadataDict,
+        naming_metadata: MetadataDict | None,
+        time_added: str | None,
+        schema: RecordSchema,
+        commit: bool = False,
+    ) -> CatalogRecord:
+        """Add an artifact record within an active transaction."""
+        hook_context = OperationContext(
+            catalog_root=self.root,
+            operation_id=transaction.operation_id,
+            operation="add_artifact",
+            record_type=record_type,
+            user_metadata=metadata,
+            derived_metadata=derived_metadata,
+            planned_locators=[locator],
+            register_rollback=lambda action: transaction.register_rollback(action),
+            source_path=locator.as_path(),
+            source_descriptor=locator.value,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=[] if suffixes is None else list(suffixes),
+        )
+        try:
+            self.hook_manager.before_validate_metadata(hook_context)
+            validation_report = self._metadata_validation_report(
+                schema=schema,
+                metadata=hook_context.user_metadata,
+                record_type=record_type,
+            )
+            self.hook_manager.after_validate_metadata(hook_context, validation_report)
+            validation_report.raise_for_errors()
+            self.hook_manager.plan_locator(hook_context)
+            self.hook_manager.before_write_artifact(hook_context)
+            self.hook_manager.extract_metadata(hook_context)
+            record = self._build_artifact_record(
+                record_type=record_type,
+                locator=locator,
+                metadata=hook_context.user_metadata,
+                storage_mode=storage_mode,
+                original_path=original_path,
+                original_filename=original_filename,
+                suffixes=suffixes,
+                derived_metadata=_metadata_with_hook_warnings(hook_context),
+                naming_metadata=naming_metadata,
+                time_added=time_added,
+            )
+            persisted = transaction.insert_staged_record(record)
+            self.hook_manager.after_write_artifact(hook_context)
+            if commit:
+                self.hook_manager.before_commit(hook_context)
+                transaction.commit()
+                self.hook_manager.after_commit(hook_context)
+            return persisted
+        except Exception as exc:
+            self.hook_manager.on_error(hook_context, exc)
+            if transaction.state is not OperationState.COMMITTED:
+                transaction.rollback(original_exception=exc)
+                self.hook_manager.on_rollback(hook_context, exc)
+            raise
+
     def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
         """Select the schema that applies to a record."""
         if record_type is None:
@@ -371,10 +523,24 @@ class Catalog:
         record_type: str | None,
     ) -> None:
         """Apply validation for the selected schema."""
+        self._metadata_validation_report(
+            schema=schema,
+            metadata=metadata,
+            record_type=record_type,
+        ).raise_for_errors()
+
+    def _metadata_validation_report(
+        self,
+        *,
+        schema: RecordSchema,
+        metadata: object,
+        record_type: str | None,
+    ) -> ValidationReport:
+        """Return validation report for the selected schema."""
         schema_name = (
             record_type if record_type is not None and record_type in self.spec.record_schemas else "default"
         )
-        validate_metadata(metadata, schema, schema_name=schema_name).raise_for_errors()
+        return validate_metadata(metadata, schema, schema_name=schema_name)
 
     def _has_metadata_fields(self) -> bool:
         """Return whether any default or named schema describes metadata fields."""
@@ -394,6 +560,30 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     if spec.db_backend != "tinydb":
         raise ValueError(f"Unsupported db_backend: {spec.db_backend}")
     return TinyDbCatalogRepository(root / spec.db_path)
+
+
+def _coerce_hook_manager(
+    *,
+    plugins: PluginRegistry | None,
+    hooks: HookManager | None,
+) -> HookManager:
+    """Resolve optional plugin or hook registration inputs."""
+    if hooks is not None and plugins is not None:
+        raise ValueError("Pass either plugins or hooks, not both.")
+    if hooks is not None:
+        return hooks
+    if plugins is not None:
+        return plugins.hook_manager()
+    return HookManager()
+
+
+def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
+    """Return derived metadata with non-fatal hook warnings included."""
+    metadata = dict(context.derived_metadata)
+    if context.warnings:
+        warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
+        metadata["hook_warnings"] = warnings_metadata
+    return metadata
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -257,10 +257,19 @@ class HookManager:
                 hook.before_commit(context)
 
     def after_commit(self, context: OperationContext) -> None:
-        """Dispatch ``after_commit`` hooks."""
+        """Dispatch ``after_commit`` hooks without failing committed work."""
         for hook in self._hooks:
             if isinstance(hook, AfterCommitHook):
-                hook.after_commit(context)
+                try:
+                    hook.after_commit(context)
+                except Exception as exc:
+                    context.add_warning(
+                        HookWarning(
+                            hook_name=type(hook).__name__,
+                            message=f"after_commit hook failed: {type(exc).__name__}: {exc}",
+                            code="hook.after_commit_failed",
+                        )
+                    )
 
     def on_error(self, context: OperationContext, error: BaseException) -> None:
         """Dispatch error hooks, preserving the original operation failure."""

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -1,0 +1,298 @@
+"""Lifecycle hook protocols and context objects for catalog operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from ogcat.models import ArtifactLocator, MetadataDict
+from ogcat.transactions import RollbackAction
+from ogcat.validation import ValidationReport
+
+
+@dataclass(slots=True)
+class HookWarning:
+    """A non-fatal hook warning.
+
+    Args:
+        hook_name: Name of the hook or plugin reporting the warning.
+        message: Human-readable warning message.
+        code: Stable machine-readable warning code.
+    """
+
+    hook_name: str
+    message: str
+    code: str = "hook.warning"
+
+    def to_metadata(self) -> MetadataDict:
+        """Convert the warning to JSON-compatible metadata."""
+        return {
+            "hook_name": self.hook_name,
+            "message": self.message,
+            "code": self.code,
+        }
+
+
+@dataclass(slots=True)
+class OperationContext:
+    """Mutable context passed to catalog lifecycle hooks.
+
+    Args:
+        catalog_root: Root path of the catalog.
+        operation_id: Identifier shared with the transaction.
+        operation: Catalog operation name, such as ``"add_file"``.
+        record_type: Record type being created.
+        user_metadata: User-supplied metadata, mutable by hooks before validation.
+        derived_metadata: Derived metadata collected during the operation.
+        planned_locators: Locators planned or supplied for the operation.
+        register_rollback: Function hooks can call to participate in rollback.
+        source_path: Optional local source path.
+        source_descriptor: Optional non-path source description.
+        storage_mode: Optional storage mode, such as ``"copy"`` or ``"move"``.
+        original_path: Optional original path or URI.
+        original_filename: Optional original filename.
+        suffixes: Source suffixes associated with the artifact.
+    """
+
+    catalog_root: Path
+    operation_id: str
+    operation: str
+    record_type: str
+    user_metadata: MetadataDict
+    derived_metadata: MetadataDict = field(default_factory=dict)
+    planned_locators: list[ArtifactLocator] = field(default_factory=list)
+    register_rollback: Callable[[RollbackAction | Callable[[], None]], RollbackAction] | None = None
+    source_path: Path | None = None
+    source_descriptor: str | None = None
+    storage_mode: str | None = None
+    original_path: str | Path | None = None
+    original_filename: str | None = None
+    suffixes: list[str] = field(default_factory=list)
+    warnings: list[HookWarning] = field(default_factory=list)
+
+    def add_warning(self, warning: HookWarning | str, *, hook_name: str = "hook") -> None:
+        """Record a non-fatal warning for this operation."""
+        if isinstance(warning, HookWarning):
+            self.warnings.append(warning)
+            return
+        self.warnings.append(HookWarning(hook_name=hook_name, message=warning))
+
+    def rollback(
+        self,
+        action: RollbackAction | Callable[[], None],
+        *,
+        description: str | None = None,
+    ) -> RollbackAction:
+        """Register a rollback action through the active catalog transaction."""
+        if self.register_rollback is None:
+            raise RuntimeError("No active rollback registration is available.")
+        if callable(action) and not hasattr(action, "undo"):
+            resolved_description = description or getattr(action, "__name__", "rollback action")
+            return self.register_rollback(_DescribedRollbackAction(resolved_description, action))
+        return self.register_rollback(action)
+
+
+@dataclass(frozen=True, slots=True)
+class _DescribedRollbackAction:
+    """Rollback action wrapper used when hooks provide a plain callable."""
+
+    description: str
+    callback: Callable[[], None]
+
+    def undo(self) -> None:
+        """Run the wrapped rollback callback."""
+        self.callback()
+
+
+@runtime_checkable
+class BeforeValidateMetadataHook(Protocol):
+    """Hook called before schema metadata validation."""
+
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        """Inspect or mutate metadata before validation."""
+        ...
+
+
+@runtime_checkable
+class AfterValidateMetadataHook(Protocol):
+    """Hook called after schema metadata validation."""
+
+    def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+        """Inspect validation results."""
+        ...
+
+
+@runtime_checkable
+class PlanLocatorHook(Protocol):
+    """Hook called after a locator has been planned or supplied."""
+
+    def plan_locator(self, context: OperationContext) -> None:
+        """Inspect or extend planned locators."""
+        ...
+
+
+@runtime_checkable
+class BeforeWriteArtifactHook(Protocol):
+    """Hook called before file or record write work."""
+
+    def before_write_artifact(self, context: OperationContext) -> None:
+        """Run before the artifact is written or staged."""
+        ...
+
+
+@runtime_checkable
+class AfterWriteArtifactHook(Protocol):
+    """Hook called after file or record write work."""
+
+    def after_write_artifact(self, context: OperationContext) -> None:
+        """Run after the artifact is written or staged."""
+        ...
+
+
+@runtime_checkable
+class ExtractMetadataHook(Protocol):
+    """Hook called during derived metadata extraction."""
+
+    def extract_metadata(self, context: OperationContext) -> MetadataDict | None:
+        """Return derived metadata to merge into the operation context."""
+        ...
+
+
+@runtime_checkable
+class BeforeCommitHook(Protocol):
+    """Hook called before committing the catalog transaction."""
+
+    def before_commit(self, context: OperationContext) -> None:
+        """Run before transaction commit."""
+        ...
+
+
+@runtime_checkable
+class AfterCommitHook(Protocol):
+    """Hook called after committing the catalog transaction."""
+
+    def after_commit(self, context: OperationContext) -> None:
+        """Run after transaction commit."""
+        ...
+
+
+@runtime_checkable
+class RollbackHook(Protocol):
+    """Hook called when an operation fails and rolls back."""
+
+    def on_rollback(self, context: OperationContext, error: BaseException) -> None:
+        """Run after rollback has been requested for a failed operation."""
+        ...
+
+
+@runtime_checkable
+class ErrorHook(Protocol):
+    """Hook called when an operation fails."""
+
+    def on_error(self, context: OperationContext, error: BaseException) -> None:
+        """Run when an operation fails."""
+        ...
+
+
+class HookManager:
+    """Deterministic dispatcher for registered catalog hooks."""
+
+    def __init__(self, hooks: Iterable[object] = ()) -> None:
+        self._hooks = list(hooks)
+
+    @property
+    def hooks(self) -> tuple[object, ...]:
+        """Registered hooks in dispatch order."""
+        return tuple(self._hooks)
+
+    def register(self, hook: object) -> object:
+        """Register a hook object and return it for decorator-style usage."""
+        self._hooks.append(hook)
+        return hook
+
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        """Dispatch ``before_validate_metadata`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, BeforeValidateMetadataHook):
+                hook.before_validate_metadata(context)
+
+    def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+        """Dispatch ``after_validate_metadata`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, AfterValidateMetadataHook):
+                hook.after_validate_metadata(context, report)
+
+    def plan_locator(self, context: OperationContext) -> None:
+        """Dispatch ``plan_locator`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, PlanLocatorHook):
+                hook.plan_locator(context)
+
+    def before_write_artifact(self, context: OperationContext) -> None:
+        """Dispatch ``before_write_artifact`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, BeforeWriteArtifactHook):
+                hook.before_write_artifact(context)
+
+    def after_write_artifact(self, context: OperationContext) -> None:
+        """Dispatch ``after_write_artifact`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, AfterWriteArtifactHook):
+                hook.after_write_artifact(context)
+
+    def extract_metadata(self, context: OperationContext) -> None:
+        """Dispatch metadata extraction hooks and merge returned metadata."""
+        for hook in self._hooks:
+            if isinstance(hook, ExtractMetadataHook):
+                extracted = hook.extract_metadata(context)
+                if extracted is not None:
+                    context.derived_metadata.update(extracted)
+
+    def before_commit(self, context: OperationContext) -> None:
+        """Dispatch ``before_commit`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, BeforeCommitHook):
+                hook.before_commit(context)
+
+    def after_commit(self, context: OperationContext) -> None:
+        """Dispatch ``after_commit`` hooks."""
+        for hook in self._hooks:
+            if isinstance(hook, AfterCommitHook):
+                hook.after_commit(context)
+
+    def on_error(self, context: OperationContext, error: BaseException) -> None:
+        """Dispatch error hooks, preserving the original operation failure."""
+        for hook in self._hooks:
+            if isinstance(hook, ErrorHook):
+                try:
+                    hook.on_error(context, error)
+                except Exception as exc:
+                    error.add_note(f"error hook failed: {type(exc).__name__}: {exc}")
+
+    def on_rollback(self, context: OperationContext, error: BaseException) -> None:
+        """Dispatch rollback hooks, preserving the original operation failure."""
+        for hook in self._hooks:
+            if isinstance(hook, RollbackHook):
+                try:
+                    hook.on_rollback(context, error)
+                except Exception as exc:
+                    error.add_note(f"rollback hook failed: {type(exc).__name__}: {exc}")
+
+
+__all__ = [
+    "AfterCommitHook",
+    "AfterValidateMetadataHook",
+    "AfterWriteArtifactHook",
+    "BeforeCommitHook",
+    "BeforeValidateMetadataHook",
+    "BeforeWriteArtifactHook",
+    "ErrorHook",
+    "ExtractMetadataHook",
+    "HookManager",
+    "HookWarning",
+    "OperationContext",
+    "PlanLocatorHook",
+    "RollbackHook",
+]

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -35,6 +36,19 @@ class HookWarning:
         }
 
 
+class RollbackRegistrar(Protocol):
+    """Function signature used to register rollback work with a transaction."""
+
+    def __call__(
+        self,
+        action: RollbackAction | Callable[[], None],
+        *,
+        description: str | None = None,
+    ) -> RollbackAction:
+        """Register a rollback action."""
+        ...
+
+
 @dataclass(slots=True)
 class OperationContext:
     """Mutable context passed to catalog lifecycle hooks.
@@ -47,7 +61,8 @@ class OperationContext:
         user_metadata: User-supplied metadata, mutable by hooks before validation.
         derived_metadata: Derived metadata collected during the operation.
         planned_locators: Locators planned or supplied for the operation.
-        register_rollback: Function hooks can call to participate in rollback.
+        register_rollback: Low-level rollback registrar. Hook authors should
+            normally call ``context.rollback(...)`` instead.
         source_path: Optional local source path.
         source_descriptor: Optional non-path source description.
         storage_mode: Optional storage mode, such as ``"copy"`` or ``"move"``.
@@ -63,7 +78,7 @@ class OperationContext:
     user_metadata: MetadataDict
     derived_metadata: MetadataDict = field(default_factory=dict)
     planned_locators: list[ArtifactLocator] = field(default_factory=list)
-    register_rollback: Callable[[RollbackAction | Callable[[], None]], RollbackAction] | None = None
+    register_rollback: RollbackRegistrar | None = None
     source_path: Path | None = None
     source_descriptor: str | None = None
     storage_mode: str | None = None
@@ -89,21 +104,8 @@ class OperationContext:
         if self.register_rollback is None:
             raise RuntimeError("No active rollback registration is available.")
         if callable(action) and not hasattr(action, "undo"):
-            resolved_description = description or getattr(action, "__name__", "rollback action")
-            return self.register_rollback(_DescribedRollbackAction(resolved_description, action))
-        return self.register_rollback(action)
-
-
-@dataclass(frozen=True, slots=True)
-class _DescribedRollbackAction:
-    """Rollback action wrapper used when hooks provide a plain callable."""
-
-    description: str
-    callback: Callable[[], None]
-
-    def undo(self) -> None:
-        """Run the wrapped rollback callback."""
-        self.callback()
+            return self.register_rollback(action, description=description)
+        return self.register_rollback(action, description=description)
 
 
 @runtime_checkable
@@ -263,13 +265,13 @@ class HookManager:
                 try:
                     hook.after_commit(context)
                 except Exception as exc:
-                    context.add_warning(
-                        HookWarning(
-                            hook_name=type(hook).__name__,
-                            message=f"after_commit hook failed: {type(exc).__name__}: {exc}",
-                            code="hook.after_commit_failed",
-                        )
+                    warning = HookWarning(
+                        hook_name=type(hook).__name__,
+                        message=f"after_commit hook failed: {type(exc).__name__}: {exc}",
+                        code="hook.after_commit_failed",
                     )
+                    context.add_warning(warning)
+                    warnings.warn(warning.message, RuntimeWarning, stacklevel=2)
 
     def on_error(self, context: OperationContext, error: BaseException) -> None:
         """Dispatch error hooks, preserving the original operation failure."""
@@ -304,4 +306,5 @@ __all__ = [
     "OperationContext",
     "PlanLocatorHook",
     "RollbackHook",
+    "RollbackRegistrar",
 ]

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -53,10 +53,16 @@ class RollbackRegistrar(Protocol):
 class OperationContext:
     """Mutable context passed to catalog lifecycle hooks.
 
+    Hooks exert their effect by mutating documented fields on this object,
+    raising an exception, or registering rollback work. `user_metadata` may be
+    mutated before validation. `planned_locators` may be changed during
+    `resolve_artifact_locator`; the first locator is treated as canonical.
+    `derived_metadata` may be updated during metadata extraction.
+
     Args:
         catalog_root: Root path of the catalog.
         operation_id: Identifier shared with the transaction.
-        operation: Catalog operation name, such as ``"add_file"``.
+        operation_type: Catalog operation name, such as ``"add_file"``.
         record_type: Record type being created.
         user_metadata: User-supplied metadata, mutable by hooks before validation.
         derived_metadata: Derived metadata collected during the operation.
@@ -73,7 +79,7 @@ class OperationContext:
 
     catalog_root: Path
     operation_id: str
-    operation: str
+    operation_type: str
     record_type: str
     user_metadata: MetadataDict
     derived_metadata: MetadataDict = field(default_factory=dict)
@@ -103,8 +109,6 @@ class OperationContext:
         """Register a rollback action through the active catalog transaction."""
         if self.register_rollback is None:
             raise RuntimeError("No active rollback registration is available.")
-        if callable(action) and not hasattr(action, "undo"):
-            return self.register_rollback(action, description=description)
         return self.register_rollback(action, description=description)
 
 
@@ -127,29 +131,29 @@ class AfterValidateMetadataHook(Protocol):
 
 
 @runtime_checkable
-class PlanLocatorHook(Protocol):
-    """Hook called after a locator has been planned or supplied."""
+class ResolveArtifactLocatorHook(Protocol):
+    """Hook called after an artifact locator has been proposed."""
 
-    def plan_locator(self, context: OperationContext) -> None:
-        """Inspect or extend planned locators."""
+    def resolve_artifact_locator(self, context: OperationContext) -> None:
+        """Inspect, replace, or extend planned artifact locators."""
         ...
 
 
 @runtime_checkable
-class BeforeWriteArtifactHook(Protocol):
-    """Hook called before file or record write work."""
+class BeforeRecordWriteHook(Protocol):
+    """Hook called before writing the catalog record."""
 
-    def before_write_artifact(self, context: OperationContext) -> None:
-        """Run before the artifact is written or staged."""
+    def before_record_write(self, context: OperationContext) -> None:
+        """Run before the catalog record is written."""
         ...
 
 
 @runtime_checkable
-class AfterWriteArtifactHook(Protocol):
-    """Hook called after file or record write work."""
+class AfterRecordWriteHook(Protocol):
+    """Hook called after writing the catalog record."""
 
-    def after_write_artifact(self, context: OperationContext) -> None:
-        """Run after the artifact is written or staged."""
+    def after_record_write(self, context: OperationContext) -> None:
+        """Run after the catalog record is written."""
         ...
 
 
@@ -226,23 +230,23 @@ class HookManager:
             if isinstance(hook, AfterValidateMetadataHook):
                 hook.after_validate_metadata(context, report)
 
-    def plan_locator(self, context: OperationContext) -> None:
-        """Dispatch ``plan_locator`` hooks."""
+    def resolve_artifact_locator(self, context: OperationContext) -> None:
+        """Dispatch ``resolve_artifact_locator`` hooks."""
         for hook in self._hooks:
-            if isinstance(hook, PlanLocatorHook):
-                hook.plan_locator(context)
+            if isinstance(hook, ResolveArtifactLocatorHook):
+                hook.resolve_artifact_locator(context)
 
-    def before_write_artifact(self, context: OperationContext) -> None:
-        """Dispatch ``before_write_artifact`` hooks."""
+    def before_record_write(self, context: OperationContext) -> None:
+        """Dispatch ``before_record_write`` hooks."""
         for hook in self._hooks:
-            if isinstance(hook, BeforeWriteArtifactHook):
-                hook.before_write_artifact(context)
+            if isinstance(hook, BeforeRecordWriteHook):
+                hook.before_record_write(context)
 
-    def after_write_artifact(self, context: OperationContext) -> None:
-        """Dispatch ``after_write_artifact`` hooks."""
+    def after_record_write(self, context: OperationContext) -> None:
+        """Dispatch ``after_record_write`` hooks."""
         for hook in self._hooks:
-            if isinstance(hook, AfterWriteArtifactHook):
-                hook.after_write_artifact(context)
+            if isinstance(hook, AfterRecordWriteHook):
+                hook.after_record_write(context)
 
     def extract_metadata(self, context: OperationContext) -> None:
         """Dispatch metadata extraction hooks and merge returned metadata."""
@@ -295,16 +299,16 @@ class HookManager:
 __all__ = [
     "AfterCommitHook",
     "AfterValidateMetadataHook",
-    "AfterWriteArtifactHook",
+    "AfterRecordWriteHook",
     "BeforeCommitHook",
     "BeforeValidateMetadataHook",
-    "BeforeWriteArtifactHook",
+    "BeforeRecordWriteHook",
     "ErrorHook",
     "ExtractMetadataHook",
     "HookManager",
     "HookWarning",
     "OperationContext",
-    "PlanLocatorHook",
+    "ResolveArtifactLocatorHook",
     "RollbackHook",
     "RollbackRegistrar",
 ]

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -275,7 +275,11 @@ class HookManager:
                         code="hook.after_commit_failed",
                     )
                     context.add_warning(warning)
-                    warnings.warn(warning.message, RuntimeWarning, stacklevel=2)
+                    warnings.warn(
+                        f"{warning.hook_name}: {warning.message}",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
 
     def on_error(self, context: OperationContext, error: BaseException) -> None:
         """Dispatch error hooks, preserving the original operation failure."""

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -117,6 +117,7 @@ def ensure_unique_path(path: Path) -> Path:
 def build_naming_context(
     *,
     record_id: str,
+    operation_id: str | None = None,
     original_path: Path,
     metadata: Mapping[str, object],
     date_added: str,
@@ -127,6 +128,8 @@ def build_naming_context(
     original_stem, original_suffix = _split_name_and_suffixes(source_name)
 
     context["id"] = record_id
+    context["uuid"] = operation_id or record_id
+    context["operation_id"] = operation_id or record_id
     context["date_added"] = date_added
     context["year_added"] = date_added[:4]
     context["original_filename"] = source_name

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -10,6 +10,20 @@ from typing import Any
 _TEMPLATE_PATTERN = re.compile(r"\{([^{}]+)\}")
 _SLUG_SEPARATOR_PATTERN = re.compile(r"[\s_]+")
 _COMPRESSED_SUFFIXES = {".gz", ".bz2", ".xz", ".zip", ".zst"}
+_RESERVED_TEMPLATE_FIELDS = frozenset(
+    {
+        "date_added",
+        "id",
+        "operation_id",
+        "original_filename",
+        "original_stem",
+        "original_suffix",
+        "title_slug",
+        "uuid",
+        "year_added",
+        "year_month_or_original_stem",
+    }
+)
 
 
 def _normalise_segment(value: str) -> str:
@@ -123,6 +137,11 @@ def build_naming_context(
     date_added: str,
 ) -> dict[str, object]:
     """Build a simple naming context for template rendering."""
+    clashing_fields = sorted(field for field in metadata if field in _RESERVED_TEMPLATE_FIELDS)
+    if clashing_fields:
+        joined = ", ".join(clashing_fields)
+        raise ValueError(f"Metadata cannot use reserved template field(s): {joined}")
+
     context: dict[str, object] = {**metadata}
     source_name = original_path.name
     original_stem, original_suffix = _split_name_and_suffixes(source_name)

--- a/src/ogcat/plugins.py
+++ b/src/ogcat/plugins.py
@@ -1,0 +1,31 @@
+"""Simple plugin registry for catalog lifecycle hooks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ogcat.hooks import HookManager
+
+
+class PluginRegistry:
+    """Registry for direct Python hook registration."""
+
+    def __init__(self, hooks: Iterable[object] = ()) -> None:
+        self._hooks: list[object] = list(hooks)
+
+    @property
+    def hooks(self) -> tuple[object, ...]:
+        """Registered hooks in insertion order."""
+        return tuple(self._hooks)
+
+    def register(self, hook: object) -> object:
+        """Register a hook object and return it for decorator-style usage."""
+        self._hooks.append(hook)
+        return hook
+
+    def hook_manager(self) -> HookManager:
+        """Build a hook manager from the currently registered hooks."""
+        return HookManager(self._hooks)
+
+
+__all__ = ["PluginRegistry"]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -291,6 +291,26 @@ def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path
     assert _stored_path(record).name == "floatyear.nc"
 
 
+@pytest.mark.parametrize("field_name", ["id", "uuid", "operation_id"])
+def test_add_file_rejects_metadata_that_clobbers_reserved_template_fields(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "reserved.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(ValueError, match=f"Metadata cannot use reserved template field\\(s\\): {field_name}"):
+        catalog.add_file(source, metadata={field_name: "user-value"})
+
+    assert catalog.repository.all() == []
+    assert list((root / "files").rglob("reserved.nc")) == []
+
+
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -479,7 +479,7 @@ def test_add_file_removes_partial_target_when_copy_fails(
     assert list((root / "files").rglob("*.nc")) == []
 
 
-def test_add_file_removes_copied_target_when_record_update_fails(
+def test_add_file_removes_copied_target_when_record_write_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -491,12 +491,12 @@ def test_add_file_removes_copied_target_when_record_update_fails(
     root = tmp_path / "catalog"
     catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
 
-    def fail_update(record: CatalogRecord) -> None:
-        raise OSError("simulated update failure")
+    def fail_insert(record: CatalogRecord) -> CatalogRecord:
+        raise OSError("simulated record write failure")
 
-    monkeypatch.setattr(catalog.repository, "update", fail_update)
+    monkeypatch.setattr(catalog.repository, "insert", fail_insert)
 
-    with pytest.raises(OSError, match="simulated update failure"):
+    with pytest.raises(OSError, match="simulated record write failure"):
         catalog.add_file(source)
 
     assert source.exists()
@@ -529,7 +529,7 @@ def test_add_file_removes_copied_target_when_metadata_extraction_fails(
     assert list((root / "files").rglob("metadata.nc")) == []
 
 
-def test_add_file_does_not_delete_moved_file_when_record_update_fails(
+def test_add_file_restores_moved_file_when_record_write_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -541,18 +541,17 @@ def test_add_file_does_not_delete_moved_file_when_record_update_fails(
     root = tmp_path / "catalog"
     catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
 
-    def fail_update(record: CatalogRecord) -> None:
-        raise OSError("simulated update failure")
+    def fail_insert(record: CatalogRecord) -> CatalogRecord:
+        raise OSError("simulated record write failure")
 
-    monkeypatch.setattr(catalog.repository, "update", fail_update)
+    monkeypatch.setattr(catalog.repository, "insert", fail_insert)
 
-    with pytest.raises(OSError, match="simulated update failure"):
+    with pytest.raises(OSError, match="simulated record write failure"):
         catalog.add_file(source, operation="move")
 
-    moved_files = list((root / "files").rglob("moved.nc"))
-    assert len(moved_files) == 1
-    assert moved_files[0].read_text(encoding="utf-8") == "dummy"
-    assert not source.exists()
+    assert list((root / "files").rglob("moved.nc")) == []
+    assert source.exists()
+    assert source.read_text(encoding="utf-8") == "dummy"
     assert catalog.describe()["record_count"] == 0
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,6 +14,7 @@ from ogcat import (
     RecordSchema,
 )
 from ogcat.hooks import OperationContext
+from ogcat.transactions import OperationState
 from ogcat.validation import ValidationReport
 
 
@@ -195,3 +196,59 @@ def test_add_artifact_uses_hook_context_and_persists_metadata_mutations(tmp_path
     assert calls == ["add_artifact", "external_reference"]
     assert record.user_metadata["title"] == "External data"
     assert record.derived_metadata["locator_kind"] == "uri"
+
+
+def test_after_commit_hook_failure_does_not_fail_add_file(tmp_path: Path) -> None:
+    class FailingAfterCommitHook:
+        def after_commit(self, context: OperationContext) -> None:
+            raise RuntimeError("post-commit notification failed")
+
+    registry = PluginRegistry([FailingAfterCommitHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "committed.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    record = catalog.add_file(source)
+
+    assert record.id is not None
+    assert catalog.get(record.id) == record
+    assert Path(record.stored_abspath or "").exists()
+
+
+def test_after_commit_hook_failure_does_not_fail_add_artifact(tmp_path: Path) -> None:
+    class FailingAfterCommitHook:
+        def after_commit(self, context: OperationContext) -> None:
+            raise RuntimeError("post-commit notification failed")
+
+    registry = PluginRegistry([FailingAfterCommitHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+    )
+
+    assert record.id is not None
+    assert catalog.get(record.id) == record
+
+
+def test_add_artifact_does_not_auto_rollback_caller_owned_transaction(tmp_path: Path) -> None:
+    class FailingAfterWriteHook:
+        def after_write_artifact(self, context: OperationContext) -> None:
+            raise RuntimeError("external transaction hook failure")
+
+    registry = PluginRegistry([FailingAfterWriteHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with catalog.transaction() as transaction:
+        with pytest.raises(RuntimeError, match="external transaction hook failure"):
+            catalog.add_artifact(
+                record_type="external_reference",
+                locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+                transaction=transaction,
+            )
+
+        assert transaction.state is OperationState.STAGED
+        assert len(catalog.repository.all()) == 1
+        transaction.rollback()
+        assert catalog.repository.all() == []

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogSpec,
+    HookWarning,
+    MetadataFieldDescription,
+    PluginRegistry,
+    RecordSchema,
+)
+from ogcat.hooks import OperationContext
+from ogcat.validation import ValidationReport
+
+
+def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(context.operation)
+
+    registry = PluginRegistry()
+    registry.register(Hook())
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog.add_file(source)
+
+    assert calls == ["add_file"]
+
+
+def test_hooks_run_in_registration_order(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class OrderedHook:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(f"{self.name}:before_validate_metadata")
+
+        def plan_locator(self, context: OperationContext) -> None:
+            calls.append(f"{self.name}:plan_locator")
+
+        def before_commit(self, context: OperationContext) -> None:
+            calls.append(f"{self.name}:before_commit")
+
+    registry = PluginRegistry([OrderedHook("first"), OrderedHook("second")])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "ordered.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog.add_file(source)
+
+    assert calls == [
+        "first:before_validate_metadata",
+        "second:before_validate_metadata",
+        "first:plan_locator",
+        "second:plan_locator",
+        "first:before_commit",
+        "second:before_commit",
+    ]
+
+
+def test_before_validate_hook_can_mutate_metadata_for_validation_and_naming(tmp_path: Path) -> None:
+    class FilenameMetadataHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            assert context.source_path is not None
+            context.user_metadata["title"] = context.source_path.stem
+
+    registry = PluginRegistry([FilenameMetadataHook()])
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                filename_template="{title}{original_suffix}",
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="title",
+                        description="Title derived from filename.",
+                        required=True,
+                    )
+                ],
+            ),
+        ),
+        plugins=registry,
+    )
+    source = tmp_path / "from-hook.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    record = catalog.add_file(source)
+
+    assert record.user_metadata["title"] == "from-hook"
+    assert Path(record.stored_abspath or "").name == "from-hook.nc"
+
+
+def test_hook_failure_rolls_back_staged_record_and_copied_file(tmp_path: Path) -> None:
+    rollback_calls: list[str] = []
+
+    class FailingHook:
+        def after_write_artifact(self, context: OperationContext) -> None:
+            context.rollback(lambda: rollback_calls.append("external"), description="external cleanup")
+            raise RuntimeError("simulated hook failure")
+
+    registry = PluginRegistry([FailingHook()])
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "failure.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="simulated hook failure"):
+        catalog.add_file(source)
+
+    assert rollback_calls == ["external"]
+    assert catalog.repository.all() == []
+    assert list((root / "files").rglob("failure.nc")) == []
+    assert source.exists()
+
+
+def test_metadata_extraction_hook_can_warn_without_failing(tmp_path: Path) -> None:
+    class WarningExtractorHook:
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            context.add_warning(
+                HookWarning(
+                    hook_name="filename",
+                    message="filename metadata was incomplete",
+                    code="filename.incomplete",
+                )
+            )
+            return {"filename_stem": context.source_path.stem if context.source_path is not None else None}
+
+    registry = PluginRegistry([WarningExtractorHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "warning.txt"
+    source.write_text("dummy", encoding="utf-8")
+
+    record = catalog.add_file(source)
+
+    assert record.derived_metadata["filename_stem"] == "warning"
+    assert record.derived_metadata["hook_warnings"] == [
+        {
+            "hook_name": "filename",
+            "message": "filename metadata was incomplete",
+            "code": "filename.incomplete",
+        }
+    ]
+
+
+def test_add_artifact_uses_hook_context_and_persists_metadata_mutations(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class ArtifactHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            context.user_metadata["title"] = "External data"
+            calls.append(context.operation)
+
+        def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+            assert report.ok
+            assert context.planned_locators == [ArtifactLocator(kind="uri", value="s3://bucket/data.zarr")]
+            calls.append(context.record_type)
+
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            return {"locator_kind": context.planned_locators[0].kind}
+
+    registry = PluginRegistry([ArtifactHook()])
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="artifacts",
+            default_schema=RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="title",
+                        description="Title supplied by hook.",
+                        required=True,
+                    )
+                ]
+            ),
+        ),
+        plugins=registry,
+    )
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+    )
+
+    assert calls == ["add_artifact", "external_reference"]
+    assert record.user_metadata["title"] == "External data"
+    assert record.derived_metadata["locator_kind"] == "uri"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -23,7 +23,7 @@ def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
 
     class Hook:
         def before_validate_metadata(self, context: OperationContext) -> None:
-            calls.append(context.operation)
+            calls.append(context.operation_type)
 
     registry = PluginRegistry()
     registry.register(Hook())
@@ -46,8 +46,11 @@ def test_hooks_run_in_registration_order(tmp_path: Path) -> None:
         def before_validate_metadata(self, context: OperationContext) -> None:
             calls.append(f"{self.name}:before_validate_metadata")
 
-        def plan_locator(self, context: OperationContext) -> None:
-            calls.append(f"{self.name}:plan_locator")
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            calls.append(f"{self.name}:resolve_artifact_locator")
+
+        def before_record_write(self, context: OperationContext) -> None:
+            calls.append(f"{self.name}:before_record_write")
 
         def before_commit(self, context: OperationContext) -> None:
             calls.append(f"{self.name}:before_commit")
@@ -62,8 +65,10 @@ def test_hooks_run_in_registration_order(tmp_path: Path) -> None:
     assert calls == [
         "first:before_validate_metadata",
         "second:before_validate_metadata",
-        "first:plan_locator",
-        "second:plan_locator",
+        "first:resolve_artifact_locator",
+        "second:resolve_artifact_locator",
+        "first:before_record_write",
+        "second:before_record_write",
         "first:before_commit",
         "second:before_commit",
     ]
@@ -102,11 +107,51 @@ def test_before_validate_hook_can_mutate_metadata_for_validation_and_naming(tmp_
     assert Path(record.stored_abspath or "").name == "from-hook.nc"
 
 
+def test_resolve_artifact_locator_replacement_controls_add_file_target(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    replacement = root / "files" / "custom" / "replacement.nc"
+
+    class ReplacementLocatorHook:
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            context.planned_locators[0] = ArtifactLocator.path(
+                replacement,
+                relative_path="files/custom/replacement.nc",
+            )
+
+    registry = PluginRegistry([ReplacementLocatorHook()])
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "replace-me.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    record = catalog.add_file(source)
+
+    assert Path(record.stored_abspath or "") == replacement
+    assert replacement.read_text(encoding="utf-8") == "dummy"
+
+
+def test_resolve_artifact_locator_removal_fails_clearly(tmp_path: Path) -> None:
+    class RemovingLocatorHook:
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            context.planned_locators.clear()
+
+    registry = PluginRegistry([RemovingLocatorHook()])
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "missing-locator.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="removed the planned artifact locator"):
+        catalog.add_file(source)
+
+    assert catalog.repository.all() == []
+    assert not list((root / "files").rglob("missing-locator.nc"))
+
+
 def test_hook_failure_rolls_back_staged_record_and_copied_file(tmp_path: Path) -> None:
     rollback_calls: list[str] = []
 
     class FailingHook:
-        def after_write_artifact(self, context: OperationContext) -> None:
+        def before_record_write(self, context: OperationContext) -> None:
             context.rollback(lambda: rollback_calls.append("external"), description="external cleanup")
             raise RuntimeError("simulated hook failure")
 
@@ -160,12 +205,15 @@ def test_add_artifact_uses_hook_context_and_persists_metadata_mutations(tmp_path
     class ArtifactHook:
         def before_validate_metadata(self, context: OperationContext) -> None:
             context.user_metadata["title"] = "External data"
-            calls.append(context.operation)
+            calls.append(context.operation_type)
 
         def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
             assert report.ok
-            assert context.planned_locators == [ArtifactLocator(kind="uri", value="s3://bucket/data.zarr")]
             calls.append(context.record_type)
+
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            assert context.planned_locators == [ArtifactLocator(kind="uri", value="s3://bucket/data.zarr")]
+            calls.append(context.planned_locators[0].kind)
 
         def extract_metadata(self, context: OperationContext) -> dict[str, object]:
             return {"locator_kind": context.planned_locators[0].kind}
@@ -193,9 +241,54 @@ def test_add_artifact_uses_hook_context_and_persists_metadata_mutations(tmp_path
         locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
     )
 
-    assert calls == ["add_artifact", "external_reference"]
+    assert calls == ["add_artifact", "external_reference", "uri"]
     assert record.user_metadata["title"] == "External data"
     assert record.derived_metadata["locator_kind"] == "uri"
+
+
+def test_add_artifact_persists_resolved_locator(tmp_path: Path) -> None:
+    class ReplacementLocatorHook:
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            context.planned_locators[0] = ArtifactLocator(kind="uri", value="s3://bucket/replacement.zarr")
+
+    registry = PluginRegistry([ReplacementLocatorHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/original.zarr"),
+    )
+
+    assert record.locator == ArtifactLocator(kind="uri", value="s3://bucket/replacement.zarr")
+
+
+def test_record_write_hooks_fire_for_add_file_and_add_artifact(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class RecordWriteHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            calls.append(f"before:{context.operation_type}")
+
+        def after_record_write(self, context: OperationContext) -> None:
+            calls.append(f"after:{context.operation_type}")
+
+    registry = PluginRegistry([RecordWriteHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), plugins=registry)
+    source = tmp_path / "record-write.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog.add_file(source)
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+    )
+
+    assert calls == [
+        "before:add_file",
+        "after:add_file",
+        "before:add_artifact",
+        "after:add_artifact",
+    ]
 
 
 def test_after_commit_hook_failure_does_not_fail_add_file(tmp_path: Path) -> None:
@@ -236,7 +329,7 @@ def test_after_commit_hook_failure_does_not_fail_add_artifact(tmp_path: Path) ->
 
 def test_add_artifact_does_not_auto_rollback_caller_owned_transaction(tmp_path: Path) -> None:
     class FailingAfterWriteHook:
-        def after_write_artifact(self, context: OperationContext) -> None:
+        def after_record_write(self, context: OperationContext) -> None:
             raise RuntimeError("external transaction hook failure")
 
     registry = PluginRegistry([FailingAfterWriteHook()])

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -291,6 +291,24 @@ def test_record_write_hooks_fire_for_add_file_and_add_artifact(tmp_path: Path) -
     ]
 
 
+def test_before_record_write_metadata_mutation_is_persisted(tmp_path: Path) -> None:
+    class RecordMetadataHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            context.user_metadata["record_phase"] = context.operation_type
+            context.derived_metadata["record_hook"] = True
+
+    registry = PluginRegistry([RecordMetadataHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+    )
+
+    assert record.user_metadata["record_phase"] == "add_artifact"
+    assert record.derived_metadata["record_hook"] is True
+
+
 def test_after_commit_hook_failure_does_not_fail_add_file(tmp_path: Path) -> None:
     class FailingAfterCommitHook:
         def after_commit(self, context: OperationContext) -> None:
@@ -301,7 +319,7 @@ def test_after_commit_hook_failure_does_not_fail_add_file(tmp_path: Path) -> Non
     source = tmp_path / "committed.nc"
     source.write_text("dummy", encoding="utf-8")
 
-    with pytest.warns(RuntimeWarning, match="post-commit notification failed"):
+    with pytest.warns(RuntimeWarning, match="FailingAfterCommitHook: .*post-commit notification failed"):
         record = catalog.add_file(source)
 
     assert record.id is not None
@@ -317,7 +335,7 @@ def test_after_commit_hook_failure_does_not_fail_add_artifact(tmp_path: Path) ->
     registry = PluginRegistry([FailingAfterCommitHook()])
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
 
-    with pytest.warns(RuntimeWarning, match="post-commit notification failed"):
+    with pytest.warns(RuntimeWarning, match="FailingAfterCommitHook: .*post-commit notification failed"):
         record = catalog.add_artifact(
             record_type="external_reference",
             locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -208,7 +208,8 @@ def test_after_commit_hook_failure_does_not_fail_add_file(tmp_path: Path) -> Non
     source = tmp_path / "committed.nc"
     source.write_text("dummy", encoding="utf-8")
 
-    record = catalog.add_file(source)
+    with pytest.warns(RuntimeWarning, match="post-commit notification failed"):
+        record = catalog.add_file(source)
 
     assert record.id is not None
     assert catalog.get(record.id) == record
@@ -223,10 +224,11 @@ def test_after_commit_hook_failure_does_not_fail_add_artifact(tmp_path: Path) ->
     registry = PluginRegistry([FailingAfterCommitHook()])
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
 
-    record = catalog.add_artifact(
-        record_type="external_reference",
-        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
-    )
+    with pytest.warns(RuntimeWarning, match="post-commit notification failed"):
+        record = catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+        )
 
     assert record.id is not None
     assert catalog.get(record.id) == record

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -57,19 +57,19 @@ def test_search_prefers_top_level_fields_when_names_are_ambiguous(tmp_path: Path
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     record = catalog.add_file(
         source,
-        metadata={"catalog": "user-catalog", "id": "user-id", "title": "Ambiguous record"},
+        metadata={"catalog": "user-catalog", "time_added": "user-time", "title": "Ambiguous record"},
     )
     record.derived_metadata["catalog"] = "derived-catalog"
-    record.derived_metadata["id"] = "derived-id"
+    record.derived_metadata["time_added"] = "derived-time"
     catalog.repository.update(record)
 
     by_catalog = catalog.search(where={"catalog": "fluxes"})
-    by_record_id = catalog.search(where={"id": record.id})
+    by_time_added = catalog.search(where={"time_added": record.time_added})
 
     assert [r.id for r in by_catalog] == [record.id]
-    assert [r.id for r in by_record_id] == [record.id]
+    assert [r.id for r in by_time_added] == [record.id]
     assert catalog.search(where={"catalog": "user-catalog"}) == []
-    assert catalog.search(where={"id": "user-id"}) == []
+    assert catalog.search(where={"time_added": "user-time"}) == []
 
 
 def test_search_prefers_user_metadata_before_derived_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a minimal lifecycle hook system with mutable operation context, rollback registration, and ordered dispatch.
- Wire hook execution into `Catalog.add_file()` and `Catalog.add_artifact()` without changing the extractor protocol or importing OpenGHG.
- Add direct Python plugin registration and focused tests for ordering, metadata mutation, rollback, and warning-only extraction.

Closes #7 

## Testing
- Added unit tests covering direct registration, hook ordering, metadata mutation, rollback on hook failure, warning-only metadata extraction, and artifact hook flow.
- Ran the full test suite locally: `132 passed, 1 skipped`.