### PR TITLE
Update artifact writer lifecycle and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ In this hook model, `add_artifact()` records an artifact locator but does not wr
 Pass an `OperationSource` and artifact writer to `add_artifact()` when a plugin or helper should
 materialise data before the record is written. `add_file()` is the bundled local-file operation that
 uses the same writer path to copy or move data before writing the record.
+See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
+extraction examples.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ catalog = Catalog.create("example-catalog", spec, plugins=plugins)
 See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for hook lifecycle,
 rollback, and transaction examples.
 
-In this hook model, `add_artifact()` records an artifact locator but does not write artifact data.
-Pass an `OperationSource` and artifact writer to `add_artifact()` when a plugin or helper should
-materialise data before the record is written. `add_file()` is the bundled local-file operation that
-uses the same writer path to copy or move data before writing the record.
+In this hook model, `add_artifact()` records an artifact locator but does not write artifact data by
+default. Pass an `OperationSource` and artifact writer to `add_artifact()` when a plugin or helper
+should materialise data before the record is written. `add_file()` is the bundled local-file
+operation that uses the same writer path to copy or move data before writing the record.
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for h
 rollback, and transaction examples.
 
 In this hook model, `add_artifact()` records an artifact locator but does not write artifact data.
-`add_file()` is the bundled local-file operation that copies or moves data before writing the record.
+Pass an `OperationSource` and artifact writer to `add_artifact()` when a plugin or helper should
+materialise data before the record is written. `add_file()` is the bundled local-file operation that
+uses the same writer path to copy or move data before writing the record.
 
 ## CLI
 

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -100,6 +100,106 @@ class ExternalIndexPlugin:
 Rollback actions run in reverse registration order. They are best-effort compensating actions, not
 database transactions.
 
+## Writing Artifacts From Plugins
+
+Artifact writers materialise data before the catalog record is written. They receive the active
+`OperationContext`, an `OperationSource`, and the resolved target `ArtifactLocator`. Writers should
+create the artifact, register rollback for anything they created, and add writer-derived metadata to
+`context.derived_metadata`.
+
+`add_artifact()` remains record-only unless a writer is explicitly supplied:
+
+```python
+from pathlib import Path
+
+from ogcat import ArtifactLocator, Catalog, OperationSource
+from ogcat.hooks import OperationContext
+
+
+class TextWriter:
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        target_path = target.as_path()
+        if target_path is None:
+            raise ValueError("text writer requires a path locator")
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
+        context.rollback(lambda: target_path.unlink(missing_ok=True), description="remove text artifact")
+        context.derived_metadata["byte_count"] = target_path.stat().st_size
+
+
+catalog = Catalog.open("example-catalog")
+record = catalog.add_artifact(
+    record_type="generated_text",
+    locator=ArtifactLocator.path(Path("example-catalog/files/generated/example.txt")),
+    source=OperationSource(kind="text", descriptor="in-memory text", metadata={"text": "hello"}),
+    artifact_writer=TextWriter(),
+)
+```
+
+Writers are the right place for artifact creation such as copying, extracting, parsing, or
+materialising data. Record hooks still surround catalog metadata and record persistence:
+`before_record_write` and `after_record_write` should not perform data writes unless the hook object
+is intentionally being used as an artifact writer.
+
+### Unzip Writer Example
+
+An unzip-style writer can take a zip file source, write an extracted directory artifact, and record
+what it extracted:
+
+```python
+import shutil
+import zipfile
+from pathlib import Path
+
+from ogcat import ArtifactLocator, Catalog, OperationSource
+from ogcat.hooks import OperationContext
+
+
+class UnzipWriter:
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        if source.kind != "zip_file" or source.path is None:
+            raise ValueError("unzip writer requires OperationSource(kind='zip_file', path=...)")
+        target_dir = target.as_path()
+        if target_dir is None:
+            raise ValueError("unzip writer requires a path locator")
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(source.path) as archive:
+            archive.extractall(target_dir)
+            names = sorted(archive.namelist())
+
+        context.rollback(
+            lambda: shutil.rmtree(target_dir, ignore_errors=True),
+            description=f"remove extracted directory {target_dir}",
+        )
+        context.derived_metadata["extracted_file_count"] = len(names)
+        context.derived_metadata["extracted_names"] = names
+
+
+catalog = Catalog.open("example-catalog")
+record = catalog.add_artifact(
+    record_type="zip_directory",
+    locator=ArtifactLocator.path(Path("example-catalog/files/extracted/example")),
+    source=OperationSource(
+        kind="zip_file",
+        path=Path("incoming/example.zip"),
+        descriptor="incoming/example.zip",
+    ),
+    artifact_writer=UnzipWriter(),
+)
+```
+
 ## Composed Transactions
 
 Callers can pass a `UnitOfWork` to compose multiple catalog operations. In this mode the caller owns
@@ -147,8 +247,11 @@ rollback work:
 
 - mutate `user_metadata` before validation to add defaults or normalise caller input;
 - mutate `planned_locators` during `resolve_artifact_locator`; the first locator is canonical;
+- inspect `source` during artifact writing and metadata extraction;
 - return or add `derived_metadata` during `extract_metadata`;
 - call `context.rollback(...)` after creating external side effects.
 
 The context includes the catalog root, operation id, operation type, record type, user metadata,
 derived metadata, planned locators, source information, storage mode, and rollback registration.
+`context.source_path` and `context.source_descriptor` remain compatibility shims over
+`context.source.path` and `context.source.descriptor`.

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -17,11 +17,11 @@ Terminology matters:
 - an **operation** coordinates validation, locator resolution, optional artifact work, record writes,
   hooks, and rollback.
 
-`Catalog.add_artifact(...)` is record-only in this version: it records a locator for an artifact, but
-does not write artifact data. `Catalog.add_file(...)` is a bundled local-file operation: it resolves a
-path locator, copies or moves the source file, extracts generic metadata, and writes the record.
-Future data-from-memory writes should be modeled as explicit operations or artifact writers rather
-than as record-write hooks.
+`Catalog.add_artifact(...)` is record-only by default: it records a locator for an artifact, but does
+not write artifact data unless an artifact writer is explicitly supplied. `Catalog.add_file(...)` is a
+bundled local-file operation: it resolves a path locator, copies or moves the source file, extracts
+generic metadata, and writes the record. Future data-from-memory writes should be modeled as explicit
+operations or artifact writers rather than as record-write hooks.
 
 ## Direct Registration
 
@@ -146,6 +146,10 @@ Writers are the right place for artifact creation such as copying, extracting, p
 materialising data. Record hooks still surround catalog metadata and record persistence:
 `before_record_write` and `after_record_write` should not perform data writes unless the hook object
 is intentionally being used as an artifact writer.
+
+`add_artifacts()` is equivalent to calling `add_artifact()` once per item. Each item runs the normal
+hook, writer, and commit lifecycle independently; if a later item fails, earlier successful items
+remain committed.
 
 ### Unzip Writer Example
 

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -175,9 +175,19 @@ class UnzipWriter:
             raise ValueError("unzip writer requires a path locator")
 
         target_dir.mkdir(parents=True, exist_ok=True)
+        target_root = target_dir.resolve()
         with zipfile.ZipFile(source.path) as archive:
-            archive.extractall(target_dir)
             names = sorted(archive.namelist())
+            for member in archive.infolist():
+                destination = (target_dir / member.filename).resolve()
+                if destination != target_root and target_root not in destination.parents:
+                    raise ValueError(f"zip member escapes target directory: {member.filename}")
+                if member.is_dir():
+                    destination.mkdir(parents=True, exist_ok=True)
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(member) as source_file, destination.open("wb") as target_file:
+                    shutil.copyfileobj(source_file, target_file)
 
         context.rollback(
             lambda: shutil.rmtree(target_dir, ignore_errors=True),

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -105,40 +105,29 @@ database transactions.
 Artifact writers materialise data before the catalog record is written. They receive the active
 `OperationContext`, an `OperationSource`, and the resolved target `ArtifactLocator`. Writers should
 create the artifact, register rollback for anything they created, and add writer-derived metadata to
-`context.derived_metadata`.
+`context.derived_metadata`. `ogcat.writers` includes small helper writers for examples and lightweight
+workflows; they are intentionally minimal wrappers, not a full pipeline system.
 
 `add_artifact()` remains record-only unless a writer is explicitly supplied:
 
 ```python
 from pathlib import Path
 
-from ogcat import ArtifactLocator, Catalog, OperationSource
-from ogcat.hooks import OperationContext
+from ogcat import ArtifactLocator, Catalog, memory_source, memory_writer
 
 
-class TextWriter:
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        target_path = target.as_path()
-        if target_path is None:
-            raise ValueError("text writer requires a path locator")
-
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
-        context.rollback(lambda: target_path.unlink(missing_ok=True), description="remove text artifact")
-        context.derived_metadata["byte_count"] = target_path.stat().st_size
+def write_text(data: object, target: Path) -> dict[str, object]:
+    text = str(data)
+    target.write_text(text, encoding="utf-8")
+    return {"byte_count": target.stat().st_size}
 
 
 catalog = Catalog.open("example-catalog")
 record = catalog.add_artifact(
     record_type="generated_text",
     locator=ArtifactLocator.path(Path("example-catalog/files/generated/example.txt")),
-    source=OperationSource(kind="text", descriptor="in-memory text", metadata={"text": "hello"}),
-    artifact_writer=TextWriter(),
+    source=memory_source("hello", kind="text", descriptor="in-memory text"),
+    artifact_writer=memory_writer(write_text, target_kind="file", source_kind="text"),
 )
 ```
 
@@ -151,66 +140,46 @@ is intentionally being used as an artifact writer.
 hook, writer, and commit lifecycle independently; if a later item fails, earlier successful items
 remain committed.
 
+The same wrapper pattern works for path-backed transforms:
+
+```python
+from pathlib import Path
+
+from ogcat import ArtifactLocator, Catalog, path_source, path_writer
+
+
+def transform_netcdf(source: Path, target: Path) -> dict[str, object]:
+    # For example: open with xarray, transform, and write a new NetCDF file.
+    target.write_bytes(source.read_bytes())
+    return {"transform": "copy-placeholder"}
+
+
+catalog = Catalog.open("example-catalog")
+record = catalog.add_artifact(
+    record_type="processed_flux",
+    locator=ArtifactLocator.path(Path("example-catalog/files/processed/output.nc")),
+    source=path_source("incoming/input.nc", kind="netcdf_file"),
+    artifact_writer=path_writer(transform_netcdf, target_kind="file", source_kind="netcdf_file"),
+)
+```
+
 ### Unzip Writer Example
 
 An unzip-style writer can take a zip file source, write an extracted directory artifact, and record
-what it extracted:
+what it extracted. The bundled example validates archive member paths before writing so entries such
+as `../escape.txt` cannot leave the target directory:
 
 ```python
-import shutil
-import zipfile
 from pathlib import Path
 
-from ogcat import ArtifactLocator, Catalog, OperationSource
-from ogcat.hooks import OperationContext
-
-
-class UnzipWriter:
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        if source.kind != "zip_file" or source.path is None:
-            raise ValueError("unzip writer requires OperationSource(kind='zip_file', path=...)")
-        target_dir = target.as_path()
-        if target_dir is None:
-            raise ValueError("unzip writer requires a path locator")
-
-        target_dir.mkdir(parents=True, exist_ok=True)
-        target_root = target_dir.resolve()
-        with zipfile.ZipFile(source.path) as archive:
-            names = sorted(archive.namelist())
-            for member in archive.infolist():
-                destination = (target_dir / member.filename).resolve()
-                if destination != target_root and target_root not in destination.parents:
-                    raise ValueError(f"zip member escapes target directory: {member.filename}")
-                if member.is_dir():
-                    destination.mkdir(parents=True, exist_ok=True)
-                    continue
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                with archive.open(member) as source_file, destination.open("wb") as target_file:
-                    shutil.copyfileobj(source_file, target_file)
-
-        context.rollback(
-            lambda: shutil.rmtree(target_dir, ignore_errors=True),
-            description=f"remove extracted directory {target_dir}",
-        )
-        context.derived_metadata["extracted_file_count"] = len(names)
-        context.derived_metadata["extracted_names"] = names
-
+from ogcat import ArtifactLocator, Catalog, UnzipArtifactWriter, path_source
 
 catalog = Catalog.open("example-catalog")
 record = catalog.add_artifact(
     record_type="zip_directory",
     locator=ArtifactLocator.path(Path("example-catalog/files/extracted/example")),
-    source=OperationSource(
-        kind="zip_file",
-        path=Path("incoming/example.zip"),
-        descriptor="incoming/example.zip",
-    ),
-    artifact_writer=UnzipWriter(),
+    source=path_source("incoming/example.zip", kind="zip_file"),
+    artifact_writer=UnzipArtifactWriter(),
 )
 ```
 

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,7 +1,7 @@
 """Public package interface for ogcat."""
 
 from ogcat.catalog import Catalog
-from ogcat.hooks import HookManager, HookWarning, OperationContext
+from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.plugins import PluginRegistry
 from ogcat.spec import CatalogSpec, RecordSchema
@@ -17,6 +17,7 @@ from ogcat.validation import (
 
 __all__ = [
     "ArtifactLocator",
+    "ArtifactWriter",
     "Catalog",
     "CatalogRecord",
     "CatalogSpec",
@@ -25,6 +26,7 @@ __all__ = [
     "MetadataFieldDescription",
     "OperationState",
     "OperationContext",
+    "OperationSource",
     "PluginRegistry",
     "RollbackFailure",
     "RecordSchema",

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -14,6 +14,15 @@ from ogcat.validation import (
     validate_schema,
     validate_spec,
 )
+from ogcat.writers import (
+    FunctionArtifactWriter,
+    UnzipArtifactWriter,
+    memory_source,
+    memory_writer,
+    path_source,
+    path_writer,
+    source_writer,
+)
 
 __all__ = [
     "ArtifactLocator",
@@ -21,6 +30,7 @@ __all__ = [
     "Catalog",
     "CatalogRecord",
     "CatalogSpec",
+    "FunctionArtifactWriter",
     "HookManager",
     "HookWarning",
     "MetadataFieldDescription",
@@ -31,10 +41,16 @@ __all__ = [
     "RollbackFailure",
     "RecordSchema",
     "UnitOfWork",
+    "UnzipArtifactWriter",
     "ValidationIssue",
     "ValidationReport",
     "validate_metadata",
     "validate_record",
     "validate_schema",
     "validate_spec",
+    "memory_source",
+    "memory_writer",
+    "path_source",
+    "path_writer",
+    "source_writer",
 ]

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -724,9 +724,9 @@ def _optional_artifact_writer(value: object) -> ArtifactWriter | None:
     """Return an optional artifact writer for artifact batch forwarding."""
     if value is None:
         return None
-    if hasattr(value, "write"):
+    if callable(getattr(value, "write", None)):
         return cast(ArtifactWriter, value)
-    raise TypeError(f"artifact_writer must provide write(), got {type(value).__name__}")
+    raise TypeError(f"artifact_writer must provide a callable write() method, got {type(value).__name__}")
 
 
 def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -180,6 +180,7 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=False)
         schema_name = self._schema_name(record_type)
         metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
+        validated_source = _optional_operation_source(source)
         validated_artifact_writer = _validate_artifact_writer(artifact_writer)
         if transaction is not None:
             if transaction.repository is not self.repository:
@@ -197,7 +198,7 @@ class Catalog:
                 derived_metadata=derived_metadata,
                 naming_metadata=naming_metadata,
                 time_added=time_added,
-                source=source,
+                source=validated_source,
                 artifact_writer=validated_artifact_writer,
                 schema=schema,
             )
@@ -215,7 +216,7 @@ class Catalog:
                 derived_metadata=derived_metadata,
                 naming_metadata=naming_metadata,
                 time_added=time_added,
-                source=source,
+                source=validated_source,
                 artifact_writer=validated_artifact_writer,
                 schema=schema,
             )

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -180,6 +180,7 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=False)
         schema_name = self._schema_name(record_type)
         metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
+        validated_artifact_writer = _validate_artifact_writer(artifact_writer)
         if transaction is not None:
             if transaction.repository is not self.repository:
                 raise ValueError("Transaction is bound to a different catalog repository.")
@@ -197,7 +198,7 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
                 source=source,
-                artifact_writer=artifact_writer,
+                artifact_writer=validated_artifact_writer,
                 schema=schema,
             )
         with self.transaction() as unit_of_work:
@@ -215,7 +216,7 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
                 source=source,
-                artifact_writer=artifact_writer,
+                artifact_writer=validated_artifact_writer,
                 schema=schema,
             )
 
@@ -238,7 +239,8 @@ class Catalog:
 
         Each item should provide the same keyword-style fields accepted by
         `add_artifact()`. Items are added one at a time so hooks and artifact
-        writers run consistently for each record.
+        writers run consistently for each record. Earlier items remain
+        committed if a later item fails.
         """
         validated_items = [_validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)]
 
@@ -699,7 +701,7 @@ def _optional_metadata(value: object) -> MetadataDict | None:
         return None
     if isinstance(value, dict):
         return dict(value)
-    raise TypeError(f"metadata fields must be dictionaries, got {type(value).__name__}")
+    raise TypeError(f"optional metadata value must be a dictionary, got {type(value).__name__}")
 
 
 def _optional_string_list(value: object) -> list[str] | None:
@@ -722,6 +724,11 @@ def _optional_operation_source(value: object) -> OperationSource | None:
 
 def _optional_artifact_writer(value: object) -> ArtifactWriter | None:
     """Return an optional artifact writer for artifact batch forwarding."""
+    return _validate_artifact_writer(value)
+
+
+def _validate_artifact_writer(value: object) -> ArtifactWriter | None:
+    """Return an artifact writer when the optional value implements the writer protocol."""
     if value is None:
         return None
     if callable(getattr(value, "write", None)):

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -8,9 +8,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.hooks import HookManager, OperationContext
+from ogcat.hooks import ArtifactWriter, HookManager, OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.plugins import PluginRegistry
@@ -21,7 +22,6 @@ from ogcat.transactions import OperationState, UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata
 
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
-ArtifactWriter = Callable[[OperationContext, ArtifactLocator], None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 
 
@@ -120,31 +120,15 @@ class Catalog:
             )
             return ArtifactLocator.path(target, relative_path=rel_path)
 
-        def write_local_file(context: OperationContext, locator: ArtifactLocator) -> None:
-            """Copy or move the source file to the canonical path locator."""
-            target = _path_from_locator(locator)
-            naming_metadata["resolved_filename"] = target.name
-            target.parent.mkdir(parents=True, exist_ok=True)
-            if chosen_operation == "copy":
-                context.rollback(
-                    lambda path=target: path.unlink(missing_ok=True),
-                    description=f"remove copied file {target}",
-                )
-                shutil.copy2(source, target)
-            else:
-                context.rollback(
-                    lambda source_path=source, target_path=target: _rollback_moved_file(
-                        source_path=source_path,
-                        target_path=target_path,
-                    ),
-                    description=f"restore moved file from {target} to {source}",
-                )
-                shutil.move(str(source), str(target))
-
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
             """Collect generic derived metadata from the written file."""
             context.derived_metadata.update(extract_derived_metadata(_path_from_locator(locator)))
 
+        source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
+        writer = _LocalFileArtifactWriter(
+            operation=chosen_operation,
+            naming_metadata=naming_metadata,
+        )
         with self.transaction() as transaction:
             return self._run_add_operation(
                 transaction=transaction,
@@ -161,10 +145,9 @@ class Catalog:
                 derived_metadata={},
                 naming_metadata=naming_metadata,
                 time_added=timestamp,
-                source_path=source,
-                source_descriptor=str(source),
+                source=source_description,
                 locator_factory=resolve_local_file_locator,
-                artifact_writer=write_local_file,
+                artifact_writer=writer,
                 derived_metadata_collector=collect_file_metadata,
             )
 
@@ -181,6 +164,8 @@ class Catalog:
         derived_metadata: MetadataDict | None = None,
         naming_metadata: MetadataDict | None = None,
         time_added: str | None = None,
+        source: OperationSource | None = None,
+        artifact_writer: ArtifactWriter | None = None,
         transaction: UnitOfWork | None = None,
     ) -> CatalogRecord:
         """Add an artifact record without performing any file operation.
@@ -211,6 +196,8 @@ class Catalog:
                 derived_metadata=derived_metadata,
                 naming_metadata=naming_metadata,
                 time_added=time_added,
+                source=source,
+                artifact_writer=artifact_writer,
                 schema=schema,
             )
         with self.transaction() as unit_of_work:
@@ -227,6 +214,8 @@ class Catalog:
                 derived_metadata=derived_metadata,
                 naming_metadata=naming_metadata,
                 time_added=time_added,
+                source=source,
+                artifact_writer=artifact_writer,
                 schema=schema,
             )
 
@@ -248,8 +237,8 @@ class Catalog:
         """Add multiple artifact records.
 
         Each item should provide the same keyword-style fields accepted by
-        `add_artifact()`. This keeps the public artifact API small while allowing
-        batch-oriented callers to avoid one-at-a-time repository writes.
+        `add_artifact()`. Items are added one at a time so hooks and artifact
+        writers run consistently for each record.
         """
         validated_items = [_validate_artifact_batch_item(item, index) for index, item in enumerate(artifacts)]
 
@@ -263,41 +252,36 @@ class Catalog:
                 raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
 
             record_type = str(validated["record_type"])
-            metadata = validated.get("metadata")  # type: ignore[assignment]
-            schema = self._select_schema(record_type, require_known=False)
             try:
-                self._validate_metadata(
-                    schema=schema,
-                    metadata={} if metadata is None else metadata,  # type: ignore[arg-type]
-                    record_type=record_type,
+                records.append(
+                    self.add_artifact(
+                        record_type=record_type,
+                        locator=locator,
+                        metadata=validated.get("metadata"),  # type: ignore[arg-type]
+                        storage_mode=(
+                            None if validated.get("storage_mode") is None else str(validated["storage_mode"])
+                        ),
+                        original_path=validated.get("original_path"),  # type: ignore[arg-type]
+                        original_filename=(
+                            None
+                            if validated.get("original_filename") is None
+                            else str(validated["original_filename"])
+                        ),
+                        suffixes=_optional_string_list(validated.get("suffixes")),
+                        derived_metadata=_optional_metadata(validated.get("derived_metadata")),
+                        naming_metadata=_optional_metadata(validated.get("naming_metadata")),
+                        time_added=(
+                            None if validated.get("time_added") is None else str(validated["time_added"])
+                        ),
+                        source=_optional_operation_source(validated.get("source")),
+                        artifact_writer=_optional_artifact_writer(validated.get("artifact_writer")),
+                    )
                 )
             except TypeError as exc:
                 raise TypeError(f"artifact batch item {index}: {exc}") from exc
             except ValueError as exc:
                 raise ValueError(f"artifact batch item {index}: {exc}") from exc
-            records.append(
-                self._build_artifact_record(
-                    record_type=record_type,
-                    locator=locator,
-                    metadata=metadata,  # type: ignore[arg-type]
-                    storage_mode=(
-                        None if validated.get("storage_mode") is None else str(validated["storage_mode"])
-                    ),
-                    original_path=validated.get("original_path"),  # type: ignore[arg-type]
-                    original_filename=(
-                        None
-                        if validated.get("original_filename") is None
-                        else str(validated["original_filename"])
-                    ),
-                    suffixes=validated.get("suffixes"),  # type: ignore[arg-type]
-                    derived_metadata=validated.get("derived_metadata"),  # type: ignore[arg-type]
-                    naming_metadata=validated.get("naming_metadata"),  # type: ignore[arg-type]
-                    time_added=(
-                        None if validated.get("time_added") is None else str(validated["time_added"])
-                    ),
-                )
-            )
-        return self.repository.insert_many(records)
+        return records
 
     def search(
         self,
@@ -417,9 +401,16 @@ class Catalog:
         derived_metadata: MetadataDict,
         naming_metadata: MetadataDict | None,
         time_added: str | None,
+        source: OperationSource | None,
+        artifact_writer: ArtifactWriter | None,
         schema: RecordSchema,
     ) -> CatalogRecord:
         """Add an artifact record within an active transaction."""
+        operation_source = source or OperationSource(
+            kind="external",
+            path=locator.as_path(),
+            descriptor=locator.value,
+        )
         return self._run_add_operation(
             transaction=transaction,
             commit=commit,
@@ -435,9 +426,9 @@ class Catalog:
             derived_metadata=derived_metadata,
             naming_metadata=naming_metadata,
             time_added=time_added,
-            source_path=locator.as_path(),
-            source_descriptor=locator.value,
+            source=operation_source,
             locator_factory=lambda context: locator,
+            artifact_writer=artifact_writer,
         )
 
     def _run_add_operation(
@@ -457,8 +448,7 @@ class Catalog:
         derived_metadata: MetadataDict,
         naming_metadata: MetadataDict | None,
         time_added: str | None,
-        source_path: Path | None,
-        source_descriptor: str | None,
+        source: OperationSource,
         locator_factory: ArtifactLocatorFactory,
         artifact_writer: ArtifactWriter | None = None,
         derived_metadata_collector: DerivedMetadataCollector | None = None,
@@ -472,8 +462,7 @@ class Catalog:
             user_metadata=metadata,
             derived_metadata=derived_metadata,
             register_rollback=transaction.register_rollback,
-            source_path=source_path,
-            source_descriptor=source_descriptor,
+            source=source,
             storage_mode=storage_mode,
             original_path=original_path,
             original_filename=original_filename,
@@ -493,7 +482,7 @@ class Catalog:
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
             if artifact_writer is not None:
-                artifact_writer(hook_context, canonical_locator)
+                artifact_writer.write(hook_context, hook_context.source, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
@@ -613,6 +602,44 @@ def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
     return metadata
 
 
+@dataclass(slots=True)
+class _LocalFileArtifactWriter:
+    """Artifact writer for the bundled managed local-file operation."""
+
+    operation: str
+    naming_metadata: MetadataDict
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Copy or move a local source file to the target path locator."""
+        if source.path is None:
+            raise ValueError("Local file writer requires a path-backed operation source.")
+
+        target_path = _path_from_locator(target)
+        self.naming_metadata["resolved_filename"] = target_path.name
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.operation == "copy":
+            context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description=f"remove copied file {target_path}",
+            )
+            shutil.copy2(source.path, target_path)
+            return
+
+        context.rollback(
+            lambda source_path=source.path, target_path=target_path: _rollback_moved_file(
+                source_path=source_path,
+                target_path=target_path,
+            ),
+            description=f"restore moved file from {target_path} to {source.path}",
+        )
+        shutil.move(str(source.path), str(target_path))
+
+
 def _coerce_metadata_input(
     metadata: object,
     *,
@@ -664,6 +691,42 @@ def _coerce_artifact_locator(value: object) -> ArtifactLocator:
     if isinstance(value, dict):
         return ArtifactLocator.from_dict(value)
     raise TypeError("artifact locator must be an ArtifactLocator or locator dictionary")
+
+
+def _optional_metadata(value: object) -> MetadataDict | None:
+    """Return optional metadata for artifact batch forwarding."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return dict(value)
+    raise TypeError(f"metadata fields must be dictionaries, got {type(value).__name__}")
+
+
+def _optional_string_list(value: object) -> list[str] | None:
+    """Return an optional list of strings for artifact batch forwarding."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    raise TypeError(f"suffixes must be a list, got {type(value).__name__}")
+
+
+def _optional_operation_source(value: object) -> OperationSource | None:
+    """Return an optional operation source for artifact batch forwarding."""
+    if value is None:
+        return None
+    if isinstance(value, OperationSource):
+        return value
+    raise TypeError(f"source must be an OperationSource, got {type(value).__name__}")
+
+
+def _optional_artifact_writer(value: object) -> ArtifactWriter | None:
+    """Return an optional artifact writer for artifact batch forwarding."""
+    if value is None:
+        return None
+    if hasattr(value, "write"):
+        return cast(ArtifactWriter, value)
+    raise TypeError(f"artifact_writer must provide write(), got {type(value).__name__}")
 
 
 def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]:

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -50,6 +50,36 @@ class RollbackRegistrar(Protocol):
 
 
 @dataclass(slots=True)
+class OperationSource:
+    """Description of the artifact source for a catalog operation.
+
+    Args:
+        kind: Short source kind, such as ``"local_file"`` or ``"external"``.
+        path: Optional local source path.
+        descriptor: Optional non-path source description or URI.
+        metadata: Source-specific JSON-compatible metadata.
+    """
+
+    kind: str
+    path: Path | None = None
+    descriptor: str | None = None
+    metadata: MetadataDict = field(default_factory=dict)
+
+
+class ArtifactWriter(Protocol):
+    """Plugin-facing writer that materialises artifact data before record write."""
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Write artifact data from source to target."""
+        ...
+
+
+@dataclass(slots=True)
 class OperationContext:
     """Mutable context passed to catalog lifecycle hooks.
 
@@ -69,8 +99,7 @@ class OperationContext:
         planned_locators: Locators planned or supplied for the operation.
         register_rollback: Low-level rollback registrar. Hook authors should
             normally call ``context.rollback(...)`` instead.
-        source_path: Optional local source path.
-        source_descriptor: Optional non-path source description.
+        source: Artifact source description for this operation.
         storage_mode: Optional storage mode, such as ``"copy"`` or ``"move"``.
         original_path: Optional original path or URI.
         original_filename: Optional original filename.
@@ -85,13 +114,32 @@ class OperationContext:
     derived_metadata: MetadataDict = field(default_factory=dict)
     planned_locators: list[ArtifactLocator] = field(default_factory=list)
     register_rollback: RollbackRegistrar | None = None
-    source_path: Path | None = None
-    source_descriptor: str | None = None
+    source: OperationSource = field(default_factory=lambda: OperationSource(kind="unknown"))
     storage_mode: str | None = None
     original_path: str | Path | None = None
     original_filename: str | None = None
     suffixes: list[str] = field(default_factory=list)
     warnings: list[HookWarning] = field(default_factory=list)
+
+    @property
+    def source_path(self) -> Path | None:
+        """Optional local source path, kept for compatibility with existing hooks."""
+        return self.source.path
+
+    @source_path.setter
+    def source_path(self, value: Path | None) -> None:
+        """Set the optional local source path on the operation source."""
+        self.source.path = value
+
+    @property
+    def source_descriptor(self) -> str | None:
+        """Optional source description, kept for compatibility with existing hooks."""
+        return self.source.descriptor
+
+    @source_descriptor.setter
+    def source_descriptor(self, value: str | None) -> None:
+        """Set the optional source description on the operation source."""
+        self.source.descriptor = value
 
     def add_warning(self, warning: HookWarning | str, *, hook_name: str = "hook") -> None:
         """Record a non-fatal warning for this operation."""
@@ -304,6 +352,7 @@ __all__ = [
     "AfterCommitHook",
     "AfterValidateMetadataHook",
     "AfterRecordWriteHook",
+    "ArtifactWriter",
     "BeforeCommitHook",
     "BeforeValidateMetadataHook",
     "BeforeRecordWriteHook",
@@ -312,6 +361,7 @@ __all__ = [
     "HookManager",
     "HookWarning",
     "OperationContext",
+    "OperationSource",
     "ResolveArtifactLocatorHook",
     "RollbackHook",
     "RollbackRegistrar",

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -58,12 +58,14 @@ class OperationSource:
         path: Optional local source path.
         descriptor: Optional non-path source description or URI.
         metadata: Source-specific JSON-compatible metadata.
+        payload: Optional in-memory Python object for writer helpers.
     """
 
     kind: str
     path: Path | None = None
     descriptor: str | None = None
     metadata: MetadataDict = field(default_factory=dict)
+    payload: object | None = None
 
 
 class ArtifactWriter(Protocol):

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -183,8 +183,9 @@ class UnzipArtifactWriter:
         )
         target_root = target_dir.resolve()
         with zipfile.ZipFile(source.path) as archive:
-            names = sorted(archive.namelist())
-            for member in archive.infolist():
+            members = archive.infolist()
+            names = sorted(member.filename for member in members if not member.is_dir())
+            for member in members:
                 destination = (target_dir / member.filename).resolve()
                 if destination != target_root and target_root not in destination.parents:
                     raise ValueError(f"zip member escapes target directory: {member.filename}")

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -1,0 +1,244 @@
+"""Small artifact writer helpers for examples and lightweight workflows."""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from ogcat.hooks import OperationContext, OperationSource
+from ogcat.models import ArtifactLocator, JsonValue, MetadataDict
+
+TargetKind: TypeAlias = Literal["file", "directory"]
+SourceWriteFunction: TypeAlias = Callable[[OperationSource, Path], MetadataDict | None]
+MemoryWriteFunction: TypeAlias = Callable[[object, Path], MetadataDict | None]
+PathWriteFunction: TypeAlias = Callable[[Path, Path], MetadataDict | None]
+
+
+def memory_source(
+    data: object,
+    *,
+    kind: str = "memory",
+    descriptor: str | None = None,
+    metadata: MetadataDict | None = None,
+) -> OperationSource:
+    """Build an operation source carrying an in-memory Python object.
+
+    Args:
+        data: In-memory object to pass to a memory writer.
+        kind: Source kind used for writer validation.
+        descriptor: Optional human-readable source description.
+        metadata: Optional JSON-compatible source metadata.
+
+    Returns:
+        An operation source with ``payload`` set to ``data``.
+    """
+    return OperationSource(
+        kind=kind,
+        descriptor=descriptor,
+        metadata={} if metadata is None else dict(metadata),
+        payload=data,
+    )
+
+
+def path_source(
+    path: str | Path,
+    *,
+    kind: str = "path",
+    descriptor: str | None = None,
+    metadata: MetadataDict | None = None,
+) -> OperationSource:
+    """Build an operation source carrying a local path.
+
+    Args:
+        path: Local source path.
+        kind: Source kind used for writer validation.
+        descriptor: Optional human-readable source description. Defaults to the
+            resolved source path string.
+        metadata: Optional JSON-compatible source metadata.
+
+    Returns:
+        An operation source with ``path`` set to the resolved local path.
+    """
+    source_path = Path(path).expanduser().resolve()
+    return OperationSource(
+        kind=kind,
+        path=source_path,
+        descriptor=descriptor or str(source_path),
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionArtifactWriter:
+    """Artifact writer adapter around a small Python function.
+
+    The wrapped function receives an ``OperationSource`` and a local target
+    path. It should write either a single file or a directory, matching
+    ``target_kind``. If it returns metadata, the metadata is merged into
+    ``context.derived_metadata``.
+
+    Args:
+        write_function: Function that writes artifact data.
+        target_kind: Whether the target locator should be treated as a file or
+            directory.
+        source_kind: Optional required source kind.
+    """
+
+    write_function: SourceWriteFunction
+    target_kind: TargetKind
+    source_kind: str | None = None
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Write artifact data and register rollback for the created target."""
+        if self.source_kind is not None and source.kind != self.source_kind:
+            raise ValueError(f"writer requires source kind {self.source_kind!r}, got {source.kind!r}")
+
+        target_path = _target_path(target)
+        _prepare_empty_target(target_path, self.target_kind)
+        context.rollback(
+            lambda path=target_path, target_kind=self.target_kind: _remove_target(path, target_kind),
+            description=f"remove written {self.target_kind} artifact {target_path}",
+        )
+        metadata = self.write_function(source, target_path)
+        if metadata is not None:
+            context.derived_metadata.update(metadata)
+
+
+def source_writer(
+    write_function: SourceWriteFunction,
+    *,
+    target_kind: TargetKind,
+    source_kind: str | None = None,
+) -> FunctionArtifactWriter:
+    """Wrap a function that writes from an ``OperationSource`` to a target path."""
+    return FunctionArtifactWriter(
+        write_function=write_function,
+        target_kind=target_kind,
+        source_kind=source_kind,
+    )
+
+
+def memory_writer(
+    write_function: MemoryWriteFunction,
+    *,
+    target_kind: TargetKind,
+    source_kind: str = "memory",
+) -> FunctionArtifactWriter:
+    """Wrap a function that writes an in-memory payload to a target path."""
+
+    def write_from_memory(source: OperationSource, target: Path) -> MetadataDict | None:
+        """Write the source payload to the target path."""
+        return write_function(source.payload, target)
+
+    return source_writer(write_from_memory, target_kind=target_kind, source_kind=source_kind)
+
+
+def path_writer(
+    write_function: PathWriteFunction,
+    *,
+    target_kind: TargetKind,
+    source_kind: str = "path",
+) -> FunctionArtifactWriter:
+    """Wrap a function that writes from a source path to a target path."""
+
+    def write_from_path(source: OperationSource, target: Path) -> MetadataDict | None:
+        """Write the source path to the target path."""
+        if source.path is None:
+            raise ValueError("path writer requires source.path")
+        return write_function(source.path, target)
+
+    return source_writer(write_from_path, target_kind=target_kind, source_kind=source_kind)
+
+
+@dataclass(frozen=True, slots=True)
+class UnzipArtifactWriter:
+    """Example writer that safely extracts a zip file into a directory target."""
+
+    source_kind: str = "zip_file"
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Extract a zip source into the target directory."""
+        if source.kind != self.source_kind or source.path is None:
+            raise ValueError(f"unzip writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+
+        target_dir = _target_path(target)
+        _prepare_empty_target(target_dir, "directory")
+        context.rollback(
+            lambda path=target_dir: shutil.rmtree(path, ignore_errors=True),
+            description=f"remove extracted directory {target_dir}",
+        )
+        target_root = target_dir.resolve()
+        with zipfile.ZipFile(source.path) as archive:
+            names = sorted(archive.namelist())
+            for member in archive.infolist():
+                destination = (target_dir / member.filename).resolve()
+                if destination != target_root and target_root not in destination.parents:
+                    raise ValueError(f"zip member escapes target directory: {member.filename}")
+                if member.is_dir():
+                    destination.mkdir(parents=True, exist_ok=True)
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(member) as source_file, destination.open("wb") as target_file:
+                    shutil.copyfileobj(source_file, target_file)
+
+        extracted_names: list[JsonValue] = list(names)
+        context.derived_metadata["extracted_file_count"] = len(names)
+        context.derived_metadata["extracted_names"] = extracted_names
+
+
+def _target_path(locator: ArtifactLocator) -> Path:
+    """Return a path-backed locator target."""
+    target_path = locator.as_path()
+    if target_path is None:
+        raise ValueError("artifact writer requires a path-backed target locator")
+    return target_path
+
+
+def _prepare_empty_target(target_path: Path, target_kind: TargetKind) -> None:
+    """Prepare a target that this writer can safely remove on rollback."""
+    if target_path.exists():
+        raise FileExistsError(f"target {target_path} already exists")
+    if target_kind == "file":
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        return
+    if target_kind == "directory":
+        target_path.mkdir(parents=True, exist_ok=False)
+        return
+    raise ValueError(f"Unsupported target kind: {target_kind}")
+
+
+def _remove_target(target_path: Path, target_kind: TargetKind) -> None:
+    """Remove a file or directory target created by a helper writer."""
+    if target_kind == "file":
+        target_path.unlink(missing_ok=True)
+        return
+    shutil.rmtree(target_path, ignore_errors=True)
+
+
+__all__ = [
+    "FunctionArtifactWriter",
+    "MemoryWriteFunction",
+    "PathWriteFunction",
+    "SourceWriteFunction",
+    "TargetKind",
+    "UnzipArtifactWriter",
+    "memory_source",
+    "memory_writer",
+    "path_source",
+    "path_writer",
+    "source_writer",
+]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -825,3 +825,28 @@ def test_add_artifacts_rejects_id_fields_in_batch_input(tmp_path: Path, id_key: 
         assert "artifact batch item 0" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Expected id rejection for batch input")
+
+
+def test_add_artifacts_rejects_non_callable_artifact_writer(tmp_path: Path) -> None:
+    class InvalidWriter:
+        write = "not callable"
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"artifact batch item 0: artifact_writer must provide a callable write\(\) method, "
+            "got InvalidWriter"
+        ),
+    ):
+        catalog.add_artifacts(
+            [
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+                    "artifact_writer": InvalidWriter(),
+                },
+            ]
+        )

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -845,6 +845,18 @@ def test_add_artifact_rejects_non_callable_artifact_writer(tmp_path: Path) -> No
         )
 
 
+def test_add_artifact_rejects_invalid_source(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(TypeError, match="source must be an OperationSource, got str"):
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator.path("/tmp/data/first.nc"),
+            source="not a source",  # type: ignore[arg-type]
+        )
+
+
 def test_add_artifacts_rejects_non_callable_artifact_writer(tmp_path: Path) -> None:
     class InvalidWriter:
         write = "not callable"

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -827,6 +827,24 @@ def test_add_artifacts_rejects_id_fields_in_batch_input(tmp_path: Path, id_key: 
         raise AssertionError("Expected id rejection for batch input")
 
 
+def test_add_artifact_rejects_non_callable_artifact_writer(tmp_path: Path) -> None:
+    class InvalidWriter:
+        write = "not callable"
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(
+        TypeError,
+        match=r"artifact_writer must provide a callable write\(\) method, got InvalidWriter",
+    ):
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator.path("/tmp/data/first.nc"),
+            artifact_writer=InvalidWriter(),  # type: ignore[arg-type]
+        )
+
+
 def test_add_artifacts_rejects_non_callable_artifact_writer(tmp_path: Path) -> None:
     class InvalidWriter:
         write = "not callable"
@@ -850,3 +868,47 @@ def test_add_artifacts_rejects_non_callable_artifact_writer(tmp_path: Path) -> N
                 },
             ]
         )
+
+
+def test_add_artifacts_keeps_earlier_commits_when_later_item_fails(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="artifacts",
+            record_schemas={
+                "external_reference": RecordSchema(
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="title",
+                            description="Short title.",
+                            required=True,
+                        )
+                    ]
+                )
+            },
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="artifact batch item 1: Missing required metadata for schema external_reference: title",
+    ):
+        catalog.add_artifacts(
+            [
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/first.nc"),
+                    "metadata": {"title": "First"},
+                },
+                {
+                    "record_type": "external_reference",
+                    "locator": ArtifactLocator.path("/tmp/data/second.nc"),
+                    "metadata": {},
+                },
+            ]
+        )
+
+    records = catalog.repository.all()
+    assert len(records) == 1
+    assert records[0].user_metadata["title"] == "First"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -13,7 +15,8 @@ from ogcat import (
     PluginRegistry,
     RecordSchema,
 )
-from ogcat.hooks import OperationContext
+from ogcat.hooks import OperationContext, OperationSource
+from ogcat.models import JsonValue
 from ogcat.transactions import OperationState
 from ogcat.validation import ValidationReport
 
@@ -246,6 +249,32 @@ def test_add_artifact_uses_hook_context_and_persists_metadata_mutations(tmp_path
     assert record.derived_metadata["locator_kind"] == "uri"
 
 
+def test_operation_context_source_compatibility_properties_are_mutable(tmp_path: Path) -> None:
+    source_paths: list[Path | None] = []
+    descriptors: list[str | None] = []
+
+    class SourceCompatibilityHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            context.source_path = tmp_path / "replacement.txt"
+            context.source_descriptor = "replacement descriptor"
+
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            source_paths.append(context.source.path)
+            descriptors.append(context.source.descriptor)
+            return {}
+
+    registry = PluginRegistry([SourceCompatibilityHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+    )
+
+    assert source_paths == [tmp_path / "replacement.txt"]
+    assert descriptors == ["replacement descriptor"]
+
+
 def test_add_artifact_persists_resolved_locator(tmp_path: Path) -> None:
     class ReplacementLocatorHook:
         def resolve_artifact_locator(self, context: OperationContext) -> None:
@@ -365,3 +394,183 @@ def test_add_artifact_does_not_auto_rollback_caller_owned_transaction(tmp_path: 
         assert len(catalog.repository.all()) == 1
         transaction.rollback()
         assert catalog.repository.all() == []
+
+
+def test_add_artifacts_runs_hooks_for_each_item(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class BatchHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(f"{context.operation_type}:{context.source_descriptor}")
+            context.user_metadata["seen_by_hook"] = context.source_descriptor or "missing"
+
+    registry = PluginRegistry([BatchHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value="s3://bucket/first.zarr"),
+            },
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value="s3://bucket/second.zarr"),
+            },
+        ]
+    )
+
+    assert calls == [
+        "add_artifact:s3://bucket/first.zarr",
+        "add_artifact:s3://bucket/second.zarr",
+    ]
+    assert [record.user_metadata["seen_by_hook"] for record in records] == [
+        "s3://bucket/first.zarr",
+        "s3://bucket/second.zarr",
+    ]
+
+
+def test_add_artifact_is_record_only_without_writer(tmp_path: Path) -> None:
+    target = tmp_path / "artifact.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=OperationSource(kind="text", descriptor="in-memory text"),
+    )
+
+    assert record.locator == ArtifactLocator.path(target)
+    assert not target.exists()
+
+
+def test_plugin_writer_receives_source_and_target_and_persists_metadata(tmp_path: Path) -> None:
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            assert source.kind == "text"
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
+            context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove text")
+            context.derived_metadata["writer_source_kind"] = source.kind
+            context.derived_metadata["writer_target_name"] = target_path.name
+
+    target = tmp_path / "out" / "artifact.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=OperationSource(kind="text", descriptor="text payload", metadata={"text": "hello"}),
+        artifact_writer=TextWriter(),
+    )
+
+    assert target.read_text(encoding="utf-8") == "hello"
+    assert record.derived_metadata["writer_source_kind"] == "text"
+    assert record.derived_metadata["writer_target_name"] == "artifact.txt"
+
+
+def test_plugin_writer_rollback_removes_created_artifact_after_hook_failure(tmp_path: Path) -> None:
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text("created", encoding="utf-8")
+            context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove text")
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("record hook failed")
+
+    target = tmp_path / "out" / "artifact.txt"
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with pytest.raises(RuntimeError, match="record hook failed"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            source=OperationSource(kind="text", descriptor="text payload"),
+            artifact_writer=TextWriter(),
+        )
+
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_unzip_style_writer_persists_directory_metadata_and_rolls_back(tmp_path: Path) -> None:
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            if context.user_metadata.get("fail"):
+                raise RuntimeError("fail after unzip")
+
+    class UnzipWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            if source.path is None:
+                raise ValueError("zip source path is required")
+            target_path = target.as_path()
+            if target_path is None:
+                raise ValueError("zip target path is required")
+
+            target_path.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(source.path) as archive:
+                archive.extractall(target_path)
+                names = sorted(archive.namelist())
+
+            context.rollback(
+                lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+                description=f"remove extracted directory {target_path}",
+            )
+            context.derived_metadata["file_count"] = len(names)
+            extracted_names: list[JsonValue] = list(names)
+            context.derived_metadata["extracted_names"] = extracted_names
+
+    archive_path = tmp_path / "source.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("a.txt", "alpha")
+        archive.writestr("nested/b.txt", "bravo")
+
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+    writer = UnzipWriter()
+    extracted = tmp_path / "extracted"
+
+    record = catalog.add_artifact(
+        record_type="zip_directory",
+        locator=ArtifactLocator.path(extracted),
+        source=OperationSource(kind="zip_file", path=archive_path, descriptor=str(archive_path)),
+        artifact_writer=writer,
+    )
+
+    assert (extracted / "a.txt").read_text(encoding="utf-8") == "alpha"
+    assert record.derived_metadata["file_count"] == 2
+    assert record.derived_metadata["extracted_names"] == ["a.txt", "nested/b.txt"]
+
+    failing_target = tmp_path / "failing-extracted"
+    with pytest.raises(RuntimeError, match="fail after unzip"):
+        catalog.add_artifact(
+            record_type="zip_directory",
+            locator=ArtifactLocator.path(failing_target),
+            metadata={"fail": True},
+            source=OperationSource(kind="zip_file", path=archive_path, descriptor=str(archive_path)),
+            artifact_writer=writer,
+        )
+
+    assert not failing_target.exists()

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogSpec,
+    OperationSource,
+    PluginRegistry,
+    UnzipArtifactWriter,
+    memory_source,
+    memory_writer,
+    path_source,
+    path_writer,
+    source_writer,
+)
+from ogcat.hooks import OperationContext
+from ogcat.models import MetadataDict
+
+
+def test_memory_writer_writes_file_and_persists_metadata(tmp_path: Path) -> None:
+    def write_text(data: object, target: Path) -> MetadataDict:
+        text = str(data)
+        target.write_text(text, encoding="utf-8")
+        return {"byte_count": target.stat().st_size}
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    target = tmp_path / "outputs" / "generated.txt"
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("hello", kind="text", descriptor="inline text"),
+        artifact_writer=memory_writer(write_text, target_kind="file", source_kind="text"),
+    )
+
+    assert target.read_text(encoding="utf-8") == "hello"
+    assert record.derived_metadata["byte_count"] == 5
+
+
+def test_path_writer_writes_directory_and_rolls_back_on_hook_failure(tmp_path: Path) -> None:
+    def copy_tree(source: Path, target: Path) -> MetadataDict:
+        (target / "copied.txt").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        return {"copied": True}
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop after write")
+
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    target = tmp_path / "directory-target"
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with pytest.raises(RuntimeError, match="stop after write"):
+        catalog.add_artifact(
+            record_type="processed_directory",
+            locator=ArtifactLocator.path(target),
+            source=path_source(source, kind="local_text"),
+            artifact_writer=path_writer(copy_tree, target_kind="directory", source_kind="local_text"),
+        )
+
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_source_writer_receives_full_operation_source(tmp_path: Path) -> None:
+    def write_source(source: OperationSource, target: Path) -> MetadataDict:
+        assert source.path is None
+        assert source.payload == {"value": 3}
+        target.write_text(str(source.metadata["label"]), encoding="utf-8")
+        return {"source_kind": source.kind}
+
+    target = tmp_path / "source-writer.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source(
+            {"value": 3},
+            kind="structured",
+            descriptor="structured payload",
+            metadata={"label": "example"},
+        ),
+        artifact_writer=source_writer(write_source, target_kind="file", source_kind="structured"),
+    )
+
+    assert target.read_text(encoding="utf-8") == "example"
+    assert record.derived_metadata["source_kind"] == "structured"
+
+
+def test_unzip_artifact_writer_extracts_metadata(tmp_path: Path) -> None:
+    archive_path = tmp_path / "source.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("a.txt", "alpha")
+        archive.writestr("nested/b.txt", "bravo")
+
+    target = tmp_path / "unzipped"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="zip_directory",
+        locator=ArtifactLocator.path(target),
+        source=path_source(archive_path, kind="zip_file"),
+        artifact_writer=UnzipArtifactWriter(),
+    )
+
+    assert (target / "a.txt").read_text(encoding="utf-8") == "alpha"
+    assert (target / "nested" / "b.txt").read_text(encoding="utf-8") == "bravo"
+    assert record.derived_metadata["extracted_file_count"] == 2
+    assert record.derived_metadata["extracted_names"] == ["a.txt", "nested/b.txt"]
+
+
+def test_unzip_artifact_writer_rejects_path_traversal(tmp_path: Path) -> None:
+    archive_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../escape.txt", "nope")
+
+    target = tmp_path / "unzipped"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(ValueError, match="zip member escapes target directory"):
+        catalog.add_artifact(
+            record_type="zip_directory",
+            locator=ArtifactLocator.path(target),
+            source=path_source(archive_path, kind="zip_file"),
+            artifact_writer=UnzipArtifactWriter(),
+        )
+
+    assert not target.exists()
+    assert not (tmp_path / "escape.txt").exists()


### PR DESCRIPTION
## Summary
- Add public `OperationSource` and `ArtifactWriter` types and thread source state through `OperationContext`
- Refactor catalog add operations to use the shared writer path, keep `add_artifact()` record-only by default, and make `add_artifacts()` run the full lifecycle per item
- Expand hook/plugin docs with artifact writer guidance, including a concrete unzip example

## Testing
- Added unit coverage for batch hook execution, explicit writers, rollback behavior, compatibility properties, and unzip-style extraction
- Ran the full Python test suite locally: `149 passed, 1 skipped`
- Linting, formatting checks, and type checking passed