### PR TITLE
Add schema editing and field discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,9 @@ For compatibility, managed local files still keep `stored_abspath` and `stored_r
 fields remain the simple path-facing surface for today's workflows while the locator model opens a
 path toward external references, directory-like stores, and future transform targets.
 
-`catalog.json` stores a broad `default_schema` plus optional named `record_schemas`, so a catalog
-can document expected metadata and naming behavior without adding domain-specific framework code.
+`catalog.json` stores schemas in `record_schemas` and identifies the fallback with
+`default_record_schema`, so a catalog can document expected metadata and naming behavior without
+adding domain-specific framework code.
 
 ## Current Limitations
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,8 +79,27 @@ ogcat info --catalog <root>
 
 ### ``ogcat fields``
 
-Print declared metadata fields from the catalog spec.
+Print declared metadata fields from the catalog spec, or inspect fields found
+in stored records.
 
 ```
-ogcat fields --catalog <root> [--record-type TYPE] [--json]
+ogcat fields --catalog <root> [--record-type TYPE] [--stored] [--values FIELD] [--json]
 ```
+
+``--stored`` lists field paths currently present in records, including nested
+metadata paths such as ``user_metadata.site.code``. ``--values FIELD`` prints
+unique scalar values for one field.
+
+### ``ogcat spec``
+
+Update small, safe parts of ``catalog.json``.
+
+```
+ogcat spec add-schema NAME --catalog <root> --schema-json JSON_OR_PATH [--overwrite]
+ogcat spec set-default-schema NAME --catalog <root>
+ogcat spec set FIELD=VALUE ... --catalog <root>
+```
+
+``ogcat spec set`` supports simple fields such as ``catalog_name``,
+``default_operation``, and ``field_resolution_order``. ``files_root`` changes
+are rejected because they require a dedicated file migration operation.

--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -19,6 +19,23 @@ record = catalog.add_file(
 Keys and values must be JSON-serialisable (strings, numbers, booleans, lists,
 or nested dictionaries).
 
+List values can be searched with contains/list-membership filters:
+
+```python
+matches = catalog.search(contains={"tags": "paris"})
+```
+
+The equivalent CLI forms are:
+
+```bash
+ogcat search --catalog ./my-catalog tags:paris
+ogcat search --catalog ./my-catalog --contains tags=paris
+```
+
+When list metadata is used in a naming template, list items are joined with
+hyphens before path-safe normalisation, so `["a", "b", "c"]` renders as
+`a-b-c`.
+
 ## Record schemas
 
 A *record schema* declares which metadata fields a catalog expects.  Schemas
@@ -99,3 +116,10 @@ ogcat fields --catalog ./my-catalog --json
 ```
 
 This prints the declared metadata fields from the catalog spec.
+
+To discover fields actually present in stored records, use:
+
+```bash
+ogcat fields --catalog ./my-catalog --stored
+ogcat fields --catalog ./my-catalog --values species
+```

--- a/docs/design-note-record-schemas.md
+++ b/docs/design-note-record-schemas.md
@@ -1,19 +1,19 @@
 # Typed Record Schemas
 
-`ogcat` keeps schemas deliberately small. A catalog has one explicit
-`default_schema` for broad, heterogeneous ingest and an optional
-`record_schemas` mapping keyed by record type. Each `RecordSchema` can describe
-metadata fields, a directory template, a filename template, and a short
-description.
+`ogcat` keeps schemas deliberately small. A catalog stores all schemas in a
+`record_schemas` mapping and uses `default_record_schema` to identify the
+broad, heterogeneous ingest fallback. Each `RecordSchema` can describe metadata
+fields, a directory template, a filename template, and a short description.
 
 Metadata field descriptions can also carry lightweight type names. These are
 serialised as human-readable schema hints for now; they are not enforced by the
 catalog core.
 
-`default_schema` is the source of truth for broad catalog behavior. Earlier MVP
-top-level fields such as `metadata_fields`, `directory_template`, and
-`filename_template` were removed before any real catalog migration burden existed,
-which keeps `CatalogSpec` smaller and avoids parallel compatibility state.
+The configured `default_record_schema` is the source of truth for broad catalog
+behavior. Earlier MVP top-level fields such as `metadata_fields`,
+`directory_template`, `filename_template`, and `default_schema` were removed
+before any real catalog migration burden existed, which keeps `CatalogSpec`
+smaller and avoids parallel compatibility state.
 
 For this first pass, record type and schema name are the same concept only where
 a named schema exists. `Catalog.add_file(..., record_type="flux")` selects the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ Today each record assumes a stored file path. A next step would be to separate "
 
 ### Typed or Per-Record Schemas
 
-Current direction: keep a broad `default_schema` plus optional named schemas for record types.
+Current direction: keep a broad default record schema plus optional named schemas for record types.
 
 Schemas remain lightweight: they describe expected metadata fields and naming templates, and only
 required-field presence is validated at ingest. Rich type validation, automatic dispatch, and

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -569,7 +569,13 @@ class Catalog:
             order = updates["field_resolution_order"]
             if not isinstance(order, list):
                 raise TypeError("field_resolution_order must be a list.")
-            updates["field_resolution_order"] = [str(item) for item in order]
+            field_resolution_order = [str(item) for item in order]
+            supported_namespaces = {"top_level", "user_metadata", "derived_metadata"}
+            invalid_namespaces = sorted(set(field_resolution_order) - supported_namespaces)
+            if invalid_namespaces:
+                joined = ", ".join(invalid_namespaces)
+                raise ValueError(f"Unsupported field_resolution_order value(s): {joined}")
+            updates["field_resolution_order"] = field_resolution_order
 
         self._replace_spec(**updates)
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -21,7 +21,7 @@ from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import OperationState, UnitOfWork
-from ogcat.validation import ValidationReport, validate_metadata
+from ogcat.validation import ValidationReport, validate_metadata, validate_spec
 
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
@@ -478,6 +478,14 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=record_type is not None)
         return [field_description.to_dict() for field_description in schema.metadata_fields]
 
+    def list_record_fields(self) -> list[str]:
+        """Return discoverable field paths present in stored records."""
+        return self.record_set(self.repository.all()).field_paths()
+
+    def unique_values(self, field: str) -> list[JsonValue]:
+        """Return unique scalar values present for a field across stored records."""
+        return self.record_set(self.repository.all()).unique_values(field)
+
     def get_schema(self, record_type: str | None = None) -> dict[str, object]:
         """Return a serialisable schema description."""
         return self._select_schema(record_type, require_known=record_type is not None).to_dict()
@@ -496,6 +504,74 @@ class Catalog:
         if record is None:
             return None
         return record.path()
+
+    def add_record_schema(
+        self,
+        name: str,
+        schema: RecordSchema | dict[str, object],
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        """Add or replace a record schema in the catalog spec.
+
+        Args:
+            name: Record schema name.
+            schema: Schema object or serialised schema dictionary.
+            overwrite: Whether an existing schema may be replaced.
+
+        Raises:
+            ValueError: If the schema already exists and ``overwrite`` is false,
+                or if the resulting spec is invalid.
+            TypeError: If ``schema`` is not a valid schema object.
+        """
+        schema_name = str(name).strip()
+        if not schema_name:
+            raise ValueError("Record schema name cannot be empty.")
+        if schema_name in self.spec.record_schemas and not overwrite:
+            raise ValueError(f"Record schema already exists: {schema_name}")
+        if isinstance(schema, RecordSchema):
+            record_schema = schema
+        elif isinstance(schema, dict):
+            record_schema = RecordSchema.from_dict(schema)
+        else:
+            raise TypeError("schema must be a RecordSchema or dictionary.")
+
+        record_schemas = dict(self.spec.record_schemas)
+        record_schemas[schema_name] = record_schema
+        self._replace_spec(record_schemas=record_schemas)
+
+    def set_default_record_schema(self, name: str) -> None:
+        """Set the default record schema by name."""
+        schema_name = str(name).strip()
+        if schema_name not in self.spec.record_schemas:
+            raise ValueError(f"Unknown record schema: {schema_name}")
+        self._replace_spec(default_record_schema=schema_name, default_schema=None)
+
+    def update_spec(self, **fields: object) -> None:
+        """Update simple catalog spec fields and persist ``catalog.json``.
+
+        Supported fields are ``catalog_name``, ``default_operation``, and
+        ``field_resolution_order``. ``files_root`` changes require a dedicated
+        migration operation and are intentionally rejected here.
+        """
+        if "files_root" in fields:
+            raise ValueError("Changing files_root requires a file-root migration operation.")
+        allowed_fields = {"catalog_name", "default_operation", "field_resolution_order"}
+        unknown_fields = sorted(field for field in fields if field not in allowed_fields)
+        if unknown_fields:
+            joined = ", ".join(unknown_fields)
+            raise ValueError(f"Unsupported catalog spec field(s): {joined}")
+
+        updates = dict(fields)
+        if "default_operation" in updates and updates["default_operation"] not in {"copy", "move"}:
+            raise ValueError("default_operation must be 'copy' or 'move'.")
+        if "field_resolution_order" in updates:
+            order = updates["field_resolution_order"]
+            if not isinstance(order, list):
+                raise TypeError("field_resolution_order must be a list.")
+            updates["field_resolution_order"] = [str(item) for item in order]
+
+        self._replace_spec(**updates)
 
     def _build_artifact_record(
         self,
@@ -709,13 +785,31 @@ class Catalog:
         """Return the validation schema name for a record type."""
         if record_type is not None and record_type in self.spec.record_schemas:
             return record_type
-        return "default"
+        return self.spec.default_record_schema
 
     def _has_metadata_fields(self) -> bool:
         """Return whether any default or named schema describes metadata fields."""
-        if self.spec.get_schema().metadata_fields:
-            return True
         return any(schema.metadata_fields for schema in self.spec.record_schemas.values())
+
+    def _replace_spec(self, **updates: object) -> None:
+        """Replace the active spec after validation and persist it."""
+        payload = {
+            "catalog_name": self.spec.catalog_name,
+            "db_backend": self.spec.db_backend,
+            "db_path": self.spec.db_path,
+            "files_root": self.spec.files_root,
+            "default_operation": self.spec.default_operation,
+            "field_resolution_order": list(self.spec.field_resolution_order),
+            "default_record_schema": self.spec.default_record_schema,
+            "default_schema": None,
+            "record_schemas": dict(self.spec.record_schemas),
+        }
+        payload.update(updates)
+        next_spec = CatalogSpec(**payload)  # type: ignore[arg-type]
+        validation_report = validate_spec(next_spec)
+        validation_report.raise_for_errors()
+        next_spec.write(self.root / "catalog.json")
+        self.spec = next_spec
 
 
 def _utc_timestamp() -> str:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -141,11 +141,11 @@ def _parse_search_value(raw_value: str) -> Any:
 def _parse_schema_json(value: str) -> RecordSchema:
     """Parse a schema from a JSON string or JSON file path."""
     stripped = value.strip()
-    candidate_path = Path(value).expanduser()
+    candidate_path = Path(stripped).expanduser()
     if not stripped.startswith("{") and candidate_path.exists():
         raw_schema = candidate_path.read_text(encoding="utf-8")
     else:
-        raw_schema = value
+        raw_schema = stripped
     try:
         payload = json.loads(raw_schema)
     except json.JSONDecodeError as exc:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -18,12 +18,14 @@ from ogcat.catalog import Catalog
 from ogcat.models import CatalogRecord
 from ogcat.record_set import DEFAULT_RECORDSET_FIELDS, CatalogRecordSet
 from ogcat.search import SearchQuery
-from ogcat.spec import CatalogSpec
+from ogcat.spec import CatalogSpec, RecordSchema
 
 app = typer.Typer(
     help="Lightweight artifact catalog with managed file ingest.",
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+spec_app = typer.Typer(help="Inspect and update catalog specifications.")
+app.add_typer(spec_app, name="spec")
 console = Console()
 error_console = Console(stderr=True)
 DEFAULT_SEARCH_LIMIT = 50
@@ -134,6 +136,37 @@ def _parse_search_value(raw_value: str) -> Any:
         return json.loads(raw_value)
     except json.JSONDecodeError:
         return raw_value
+
+
+def _parse_schema_json(value: str) -> RecordSchema:
+    """Parse a schema from a JSON string or JSON file path."""
+    stripped = value.strip()
+    candidate_path = Path(value).expanduser()
+    if not stripped.startswith("{") and candidate_path.exists():
+        raw_schema = candidate_path.read_text(encoding="utf-8")
+    else:
+        raw_schema = value
+    try:
+        payload = json.loads(raw_schema)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter("--schema-json must be a JSON object or path to a JSON file.") from exc
+    if not isinstance(payload, dict):
+        raise typer.BadParameter("--schema-json must describe one JSON object.")
+    try:
+        return RecordSchema.from_dict(payload)
+    except (TypeError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _parse_spec_update_item(item: str) -> tuple[str, Any]:
+    """Parse one catalog spec update item from KEY=VALUE."""
+    if "=" not in item:
+        raise typer.BadParameter(f"Expected FIELD=VALUE: {item}")
+    key, raw_value = item.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise typer.BadParameter(f"Spec field cannot be empty: {item}")
+    return key, _parse_search_value(raw_value)
 
 
 def _parse_search_expression(item: str) -> SearchQuery:
@@ -574,13 +607,52 @@ def fields(
         str | None,
         typer.Option("--record-type", help="Named record schema whose fields should be shown."),
     ] = None,
+    stored: Annotated[
+        bool,
+        typer.Option("--stored", help="Show field paths present in stored records."),
+    ] = False,
+    values: Annotated[
+        str | None,
+        typer.Option("--values", help="Show unique scalar values for a field."),
+    ] = None,
     json_mode: Annotated[
         bool,
         typer.Option("--json", help="Print metadata field descriptions as JSON."),
     ] = False,
 ) -> None:
-    """List important metadata fields from the catalog spec."""
+    """List schema-declared fields or fields present in stored records."""
     active_catalog = _open_catalog_or_fail(catalog)
+    if values is not None and stored:
+        raise typer.BadParameter("Use either --stored or --values, not both.")
+    if values is not None:
+        unique_values = active_catalog.unique_values(values)
+        if json_mode:
+            _print_json(unique_values)
+            return
+        if not unique_values:
+            console.print(f"No scalar values found for field: {values}")
+            return
+        table = Table(title=f"unique values for {values}")
+        table.add_column("value")
+        for value in unique_values:
+            table.add_row("" if value is None else json.dumps(value) if not isinstance(value, str) else value)
+        console.print(table)
+        return
+    if stored:
+        stored_fields = active_catalog.list_record_fields()
+        if json_mode:
+            _print_json(stored_fields)
+            return
+        if not stored_fields:
+            console.print("No records are stored in this catalog.")
+            return
+        table = Table(title="stored record fields")
+        table.add_column("field")
+        for field in stored_fields:
+            table.add_row(field)
+        console.print(table)
+        return
+
     try:
         metadata_fields = active_catalog.list_metadata_fields(record_type=record_type)
     except ValueError as exc:
@@ -614,3 +686,60 @@ def fields(
         )
 
     console.print(table)
+
+
+@spec_app.command("add-schema")
+def spec_add_schema(
+    name: Annotated[str, typer.Argument(help="Record schema name.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    schema_json: Annotated[
+        str,
+        typer.Option("--schema-json", help="Schema JSON object or path to a JSON file."),
+    ] = "",
+    overwrite: Annotated[
+        bool,
+        typer.Option("--overwrite", help="Replace an existing schema."),
+    ] = False,
+) -> None:
+    """Add or replace a record schema in catalog.json."""
+    if not schema_json:
+        raise typer.BadParameter("Provide --schema-json.")
+    active_catalog = _open_catalog_or_fail(catalog)
+    schema = _parse_schema_json(schema_json)
+    try:
+        active_catalog.add_record_schema(name, schema, overwrite=overwrite)
+    except (TypeError, ValueError) as exc:
+        _fail(str(exc))
+    console.print(f"Updated record schema: {name}")
+
+
+@spec_app.command("set-default-schema")
+def spec_set_default_schema(
+    name: Annotated[str, typer.Argument(help="Record schema name.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+) -> None:
+    """Set the default record schema in catalog.json."""
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        active_catalog.set_default_record_schema(name)
+    except ValueError as exc:
+        _fail(str(exc))
+    console.print(f"Default record schema set to: {name}")
+
+
+@spec_app.command("set")
+def spec_set(
+    items: Annotated[list[str], typer.Argument(help="Spec field updates as FIELD=VALUE.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+) -> None:
+    """Set simple catalog spec fields in catalog.json."""
+    updates: dict[str, Any] = {}
+    for item in items:
+        key, value = _parse_spec_update_item(item)
+        updates[key] = value
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        active_catalog.update_spec(**updates)
+    except (TypeError, ValueError) as exc:
+        _fail(str(exc))
+    console.print("Updated catalog spec.")

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -79,6 +79,8 @@ def _stringify_template_value(value: object) -> str:
     """Stringify template values without exposing Python repr details."""
     if value is None:
         return ""
+    if isinstance(value, list):
+        return "-".join(_stringify_template_value(item) for item in value if item is not None)
     return str(value)
 
 

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -147,7 +147,8 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
                     if isinstance(value, dict):
                         fields.update(_nested_field_paths(value, prefix=field))
                     continue
-                fields.add(field)
+                if _is_discoverable_value(value):
+                    fields.add(field)
                 if isinstance(value, dict):
                     fields.update(_nested_field_paths(value, prefix=field))
             for namespace in _METADATA_NAMESPACES:
@@ -215,10 +216,16 @@ def _nested_field_paths(mapping: dict[str, JsonValue], *, prefix: str) -> set[st
     fields: set[str] = set()
     for key, value in mapping.items():
         path = f"{prefix}.{key}"
-        fields.add(path)
+        if _is_discoverable_value(value):
+            fields.add(path)
         if isinstance(value, dict):
             fields.update(_nested_field_paths(value, prefix=path))
     return fields
+
+
+def _is_discoverable_value(value: object) -> bool:
+    """Return whether a field value should appear in field discovery."""
+    return bool(value)
 
 
 def _is_scalar_json_value(value: object) -> bool:

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -143,18 +143,10 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
                 fields.add("locator.uri")
             record_dict = record.to_dict()
             for field, value in record_dict.items():
-                if field in _METADATA_NAMESPACES:
-                    if isinstance(value, dict):
-                        fields.update(_nested_field_paths(value, prefix=field))
-                    continue
                 if _is_discoverable_value(value):
                     fields.add(field)
                 if isinstance(value, dict):
                     fields.update(_nested_field_paths(value, prefix=field))
-            for namespace in _METADATA_NAMESPACES:
-                metadata = record_dict.get(namespace)
-                if isinstance(metadata, dict):
-                    fields.update(_nested_field_paths(metadata, prefix=namespace))
         return sorted(fields)
 
     def unique_values(self, field: str) -> list[JsonValue]:
@@ -166,7 +158,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
                 continue
             key = json.dumps(resolved.value, sort_keys=True)
             values[key] = resolved.value
-        return [values[key] for key in sorted(values)]
+        return list(values.values())
 
     def preview(
         self,

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -11,9 +11,10 @@ from typing import Any, overload
 from rich.table import Table
 
 from ogcat.models import CatalogRecord, JsonValue
-from ogcat.search import flatten_lookup
+from ogcat.search import flatten_lookup, resolve_field
 
 DEFAULT_RECORDSET_FIELDS = ("id", "title", "product", "species", "path")
+_METADATA_NAMESPACES = ("user_metadata", "derived_metadata", "naming_metadata")
 
 
 def resolve_record_field(
@@ -132,6 +133,40 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
             for record in records
         ]
 
+    def field_paths(self) -> list[str]:
+        """Return discoverable field paths present in this record set."""
+        fields: set[str] = set()
+        for record in self._records:
+            if record.path() is not None:
+                fields.add("path")
+            if record.locator.kind == "uri":
+                fields.add("locator.uri")
+            record_dict = record.to_dict()
+            for field, value in record_dict.items():
+                if field in _METADATA_NAMESPACES:
+                    if isinstance(value, dict):
+                        fields.update(_nested_field_paths(value, prefix=field))
+                    continue
+                fields.add(field)
+                if isinstance(value, dict):
+                    fields.update(_nested_field_paths(value, prefix=field))
+            for namespace in _METADATA_NAMESPACES:
+                metadata = record_dict.get(namespace)
+                if isinstance(metadata, dict):
+                    fields.update(_nested_field_paths(metadata, prefix=namespace))
+        return sorted(fields)
+
+    def unique_values(self, field: str) -> list[JsonValue]:
+        """Return unique scalar values present for a field."""
+        values: dict[str, JsonValue] = {}
+        for record in self._records:
+            resolved = resolve_field(record, field, resolution_order=self._resolution_order)
+            if not resolved.found or not _is_scalar_json_value(resolved.value):
+                continue
+            key = json.dumps(resolved.value, sort_keys=True)
+            values[key] = resolved.value
+        return [values[key] for key in sorted(values)]
+
     def preview(
         self,
         *,
@@ -173,3 +208,19 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
     def __rich__(self) -> Table:
         """Return a Rich preview for terminals and notebooks."""
         return self.preview()
+
+
+def _nested_field_paths(mapping: dict[str, JsonValue], *, prefix: str) -> set[str]:
+    """Return dotted field paths for a nested JSON mapping."""
+    fields: set[str] = set()
+    for key, value in mapping.items():
+        path = f"{prefix}.{key}"
+        fields.add(path)
+        if isinstance(value, dict):
+            fields.update(_nested_field_paths(value, prefix=path))
+    return fields
+
+
+def _is_scalar_json_value(value: object) -> bool:
+    """Return whether a value is safe to include in unique-value summaries."""
+    return value is None or isinstance(value, str | int | float | bool)

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -124,6 +124,10 @@ class CatalogSpec:
         record_schemas = _coerce_record_schema_mapping(self.record_schemas)
         default_schema = _coerce_record_schema(self.default_schema, field_name="default_schema")
         if default_schema is not None:
+            if self.default_record_schema in record_schemas:
+                raise ValueError(
+                    "Pass either default_schema or record_schemas[default_record_schema], not both."
+                )
             record_schemas[self.default_record_schema] = default_schema
         elif self.default_record_schema not in record_schemas:
             record_schemas[self.default_record_schema] = _default_record_schema()

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -99,7 +99,8 @@ class CatalogSpec:
         files_root: Managed file root relative to the catalog root.
         default_operation: Default managed-file operation.
         field_resolution_order: Namespace order for flattened search fields.
-        default_schema: Fallback schema.
+        default_record_schema: Name of the fallback schema in ``record_schemas``.
+        default_schema: Optional constructor convenience for the fallback schema.
         record_schemas: Named schemas for record types.
     """
 
@@ -111,16 +112,32 @@ class CatalogSpec:
     field_resolution_order: list[str] = field(
         default_factory=lambda: ["top_level", "user_metadata", "derived_metadata"]
     )
-    default_schema: RecordSchema = field(default_factory=lambda: _default_record_schema())
+    default_record_schema: str = "default"
+    default_schema: RecordSchema | dict[str, object] | None = None
     record_schemas: dict[str, RecordSchema] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Fill required defaults on the broad fallback schema."""
-        self.record_schemas = _coerce_record_schema_mapping(self.record_schemas)
+        """Fill required defaults on the configured fallback schema."""
+        self.default_record_schema = str(self.default_record_schema)
+        record_schemas = _coerce_record_schema_mapping(self.record_schemas)
         default_schema = _coerce_record_schema(self.default_schema, field_name="default_schema")
-        self.default_schema = (default_schema or _default_record_schema()).with_fallbacks(
-            _default_record_schema()
-        )
+        if default_schema is not None:
+            record_schemas[self.default_record_schema] = default_schema
+        elif self.default_record_schema not in record_schemas:
+            record_schemas[self.default_record_schema] = _default_record_schema()
+
+        record_schemas[self.default_record_schema] = record_schemas[
+            self.default_record_schema
+        ].with_fallbacks(_default_record_schema())
+        self.record_schemas = {
+            self.default_record_schema: record_schemas[self.default_record_schema],
+            **{
+                schema_name: schema
+                for schema_name, schema in record_schemas.items()
+                if schema_name != self.default_record_schema
+            },
+        }
+        self.default_schema = self.record_schemas[self.default_record_schema]
 
     def to_dict(self) -> dict[str, object]:
         """Convert the spec to a serialisable dictionary."""
@@ -131,7 +148,7 @@ class CatalogSpec:
             "files_root": self.files_root,
             "default_operation": self.default_operation,
             "field_resolution_order": list(self.field_resolution_order),
-            "default_schema": self.default_schema.to_dict(),
+            "default_record_schema": self.default_record_schema,
             "record_schemas": {
                 record_type: schema.to_dict() for record_type, schema in self.record_schemas.items()
             },
@@ -140,7 +157,6 @@ class CatalogSpec:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> CatalogSpec:
         """Build a spec from a dictionary."""
-        default_schema = _coerce_record_schema(data.get("default_schema"), field_name="default_schema")
         record_schemas = _coerce_record_schema_mapping(data.get("record_schemas"))
 
         return cls(
@@ -157,7 +173,7 @@ class CatalogSpec:
                 )
             ]
             or ["top_level", "user_metadata", "derived_metadata"],
-            default_schema=default_schema or _default_record_schema(),
+            default_record_schema=str(data.get("default_record_schema", "default")),
             record_schemas=record_schemas,
         )
 
@@ -171,10 +187,12 @@ class CatalogSpec:
             ValueError: If a non-default record type has no schema.
         """
         if record_type is None:
-            return self.default_schema
+            return self.record_schemas[self.default_record_schema]
         if record_type not in self.record_schemas:
             raise ValueError(f"Unknown record schema: {record_type}")
-        return self.record_schemas[record_type].with_fallbacks(self.default_schema)
+        return self.record_schemas[record_type].with_fallbacks(
+            self.record_schemas[self.default_record_schema]
+        )
 
     def list_record_schemas(self) -> list[str]:
         """Return available named record schema names."""

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -118,7 +118,9 @@ class CatalogSpec:
 
     def __post_init__(self) -> None:
         """Fill required defaults on the configured fallback schema."""
-        self.default_record_schema = str(self.default_record_schema)
+        self.default_record_schema = str(self.default_record_schema).strip()
+        if not self.default_record_schema:
+            raise ValueError("default_record_schema cannot be empty.")
         record_schemas = _coerce_record_schema_mapping(self.record_schemas)
         default_schema = _coerce_record_schema(self.default_schema, field_name="default_schema")
         if default_schema is not None:

--- a/src/ogcat/validation.py
+++ b/src/ogcat/validation.py
@@ -151,7 +151,6 @@ def validate_schema(
 def validate_spec(spec: CatalogSpec) -> ValidationReport:
     """Validate schema validation hints across a catalog spec."""
     report = ValidationReport()
-    report.extend(validate_schema(spec.default_schema, schema_name="default", base_path="default_schema"))
     for schema_name, schema in spec.record_schemas.items():
         report.extend(
             validate_schema(
@@ -256,8 +255,12 @@ def validate_record(
     if spec is None:
         return report
 
-    schema_name = record.record_type if record.record_type in spec.record_schemas else "default"
-    schema = spec.get_schema(record.record_type) if schema_name != "default" else spec.get_schema()
+    if record.record_type in spec.record_schemas:
+        schema_name = record.record_type
+        schema = spec.get_schema(record.record_type)
+    else:
+        schema_name = spec.default_record_schema
+        schema = spec.get_schema()
     metadata_report = validate_metadata(
         record.user_metadata,
         schema,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -291,6 +291,29 @@ def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path
     assert _stored_path(record).name == "floatyear.nc"
 
 
+def test_add_file_uses_readable_list_metadata_in_naming_templates(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "tagged.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{tags}",
+                filename_template="{tags}{original_suffix}",
+            ),
+        ),
+    )
+
+    record = catalog.add_file(source, metadata={"tags": ["a", "b", "c"]})
+
+    assert _stored_path(record) == root / "files" / "a-b-c" / "a-b-c.nc"
+
+
 @pytest.mark.parametrize("field_name", ["id", "uuid", "operation_id"])
 def test_add_file_rejects_metadata_that_clobbers_reserved_template_fields(
     tmp_path: Path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,6 +574,40 @@ def test_spec_cli_adds_schema_sets_default_and_updates_simple_fields(tmp_path: P
     assert reopened.spec.field_resolution_order == ["user_metadata", "top_level"]
 
 
+def test_spec_cli_add_schema_accepts_file_path_with_outer_whitespace(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"metadata_fields": []}', encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "spec",
+            "add-schema",
+            "paper",
+            "--catalog",
+            str(catalog.root),
+            "--schema-json",
+            f"  {schema_path}  ",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "paper" in Catalog.open(catalog.root).list_record_schemas()
+
+
+def test_spec_cli_rejects_unknown_field_resolution_order_value(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    result = runner.invoke(
+        app,
+        ["spec", "set", 'field_resolution_order=["user_metadata","unknown"]', "--catalog", str(catalog.root)],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported field_resolution_order value(s): unknown" in strip_ansi(result.stderr)
+
+
 def test_spec_cli_rejects_files_root_update(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,6 +509,23 @@ def test_fields_json_output(tmp_path: Path) -> None:
     assert payload[0]["required"] is True
 
 
+def test_fields_stored_and_values_output(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+
+    stored_result = runner.invoke(app, ["fields", "--catalog", str(catalog.root), "--stored", "--json"])
+    values_result = runner.invoke(
+        app,
+        ["fields", "--catalog", str(catalog.root), "--values", "species", "--json"],
+    )
+
+    assert stored_result.exit_code == 0
+    stored_payload = json.loads(strip_ansi(stored_result.stdout))
+    assert "user_metadata.species" in stored_payload
+    assert "path" in stored_payload
+    assert values_result.exit_code == 0
+    assert json.loads(strip_ansi(values_result.stdout)) == ["CO2"]
+
+
 def test_fields_human_output_handles_missing_field_descriptions(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path, with_fields=False)
 
@@ -516,6 +533,57 @@ def test_fields_human_output_handles_missing_field_descriptions(tmp_path: Path) 
 
     assert result.exit_code == 0
     assert "No metadata fields are defined in this catalog." in strip_ansi(result.stdout)
+
+
+def test_spec_cli_adds_schema_sets_default_and_updates_simple_fields(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    schema_json = json.dumps(
+        {
+            "metadata_fields": [
+                {"name": "title", "description": "Short title.", "required": True},
+            ]
+        }
+    )
+
+    add_result = runner.invoke(
+        app,
+        ["spec", "add-schema", "paper", "--catalog", str(catalog.root), "--schema-json", schema_json],
+    )
+    default_result = runner.invoke(
+        app,
+        ["spec", "set-default-schema", "paper", "--catalog", str(catalog.root)],
+    )
+    set_result = runner.invoke(
+        app,
+        [
+            "spec",
+            "set",
+            "catalog_name=library",
+            'field_resolution_order=["user_metadata","top_level"]',
+            "--catalog",
+            str(catalog.root),
+        ],
+    )
+
+    reopened = Catalog.open(catalog.root)
+    assert add_result.exit_code == 0
+    assert default_result.exit_code == 0
+    assert set_result.exit_code == 0
+    assert reopened.spec.default_record_schema == "paper"
+    assert reopened.spec.catalog_name == "library"
+    assert reopened.spec.field_resolution_order == ["user_metadata", "top_level"]
+
+
+def test_spec_cli_rejects_files_root_update(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    result = runner.invoke(
+        app,
+        ["spec", "set", "files_root=renamed-files", "--catalog", str(catalog.root)],
+    )
+
+    assert result.exit_code == 1
+    assert "Changing files_root requires a file-root migration operation." in strip_ansi(result.stderr)
 
 
 def test_add_accepts_multiple_metadata_items_after_single_meta_flag(tmp_path: Path) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -255,6 +255,19 @@ def test_catalog_spec_rejects_empty_default_record_schema() -> None:
         raise AssertionError("Expected ValueError for empty default_record_schema")
 
 
+def test_catalog_spec_rejects_conflicting_default_schema_inputs() -> None:
+    try:
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(description="Constructor default."),
+            record_schemas={"default": RecordSchema(description="Mapping default.")},
+        )
+    except ValueError as exc:
+        assert "Pass either default_schema or record_schemas[default_record_schema], not both." in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for conflicting default schema inputs")
+
+
 def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tmp_path: Path) -> None:
     root = tmp_path / "fluxes"
     spec = CatalogSpec(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -246,6 +246,15 @@ def test_catalog_spec_get_schema_raises_value_error_for_unknown_schema() -> None
         raise AssertionError("Expected ValueError for unknown record schema")
 
 
+def test_catalog_spec_rejects_empty_default_record_schema() -> None:
+    try:
+        CatalogSpec(catalog_name="files", default_record_schema="  ")
+    except ValueError as exc:
+        assert "default_record_schema cannot be empty." in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected ValueError for empty default_record_schema")
+
+
 def test_catalog_describe_and_list_metadata_fields_return_serialisable_values(tmp_path: Path) -> None:
     root = tmp_path / "fluxes"
     spec = CatalogSpec(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,7 +48,9 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
     assert "metadata_fields" not in serialized
     assert "directory_template" not in serialized
     assert "filename_template" not in serialized
-    assert serialized["default_schema"]["metadata_fields"] == [
+    assert "default_schema" not in serialized
+    assert serialized["default_record_schema"] == "default"
+    assert serialized["record_schemas"]["default"]["metadata_fields"] == [
         {
             "name": "species",
             "description": "Gas species name used for grouping and search.",
@@ -98,9 +100,39 @@ def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
     serialized = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
     reloaded = CatalogSpec.read(root / "catalog.json")
 
-    assert serialized["default_schema"]["description"] == "Generic fallback schema for heterogeneous files."
+    assert "default_schema" not in serialized
+    assert serialized["default_record_schema"] == "default"
+    assert (
+        serialized["record_schemas"]["default"]["description"]
+        == "Generic fallback schema for heterogeneous files."
+    )
     assert serialized["record_schemas"]["flux"]["metadata_fields"][0]["required"] is True
     assert reloaded == spec
+
+
+def test_catalog_spec_supports_custom_default_record_schema(tmp_path: Path) -> None:
+    root = tmp_path / "fluxes"
+    spec = CatalogSpec(
+        catalog_name="fluxes",
+        default_record_schema="generic",
+        record_schemas={
+            "generic": RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(name="title", description="Short title.", required=True),
+                ],
+            ),
+            "flux": RecordSchema(filename_template="{species}{original_suffix}"),
+        },
+    )
+
+    Catalog.create(root, spec)
+    serialized = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+    reloaded = CatalogSpec.read(root / "catalog.json")
+
+    assert serialized["default_record_schema"] == "generic"
+    assert "default_schema" not in serialized
+    assert reloaded.get_schema().required_field_names() == ["title"]
+    assert reloaded.get_schema("flux").directory_template == "{year_added}/{original_stem}"
 
 
 def test_metadata_field_description_serialises_type_information() -> None:
@@ -136,6 +168,7 @@ def test_catalog_spec_does_not_mutate_default_schema_input() -> None:
 
     assert schema.directory_template is None
     assert schema.filename_template is None
+    assert isinstance(spec.default_schema, RecordSchema)
     assert spec.default_schema.directory_template == "{year_added}/{original_stem}"
     assert spec.default_schema.filename_template == "{title_slug|original_stem}{original_suffix}"
 
@@ -146,7 +179,7 @@ def test_catalog_spec_normalises_constructor_record_schema_keys() -> None:
         record_schemas={1: RecordSchema(metadata_fields=[])},  # type: ignore[dict-item]
     )
 
-    assert spec.list_record_schemas() == ["1"]
+    assert spec.list_record_schemas() == ["1", "default"]
     assert spec.get_schema("1").directory_template == "{year_added}/{original_stem}"
 
 
@@ -179,9 +212,11 @@ def test_catalog_spec_accepts_default_schema_dict_at_constructor_boundary() -> N
         },  # type: ignore[arg-type]
     )
 
+    assert isinstance(spec.default_schema, RecordSchema)
     assert spec.default_schema.directory_template == "{year_added}/{original_stem}"
     assert spec.default_schema.metadata_fields[0].name == "title"
     assert spec.default_schema.metadata_fields[0].required is True
+    assert spec.record_schemas["default"] == spec.default_schema
 
 
 def test_catalog_spec_rejects_invalid_default_schema_at_constructor_boundary() -> None:
@@ -269,9 +304,9 @@ def test_catalog_schema_helpers_return_serialisable_values(tmp_path: Path) -> No
         ),
     )
 
-    assert catalog.list_record_schemas() == ["flux"]
+    assert catalog.list_record_schemas() == ["default", "flux"]
     assert catalog.describe()["has_metadata_fields"] is True
-    assert catalog.describe()["record_schemas"] == ["flux"]
+    assert catalog.describe()["record_schemas"] == ["default", "flux"]
     assert catalog.get_schema("flux")["metadata_fields"] == [
         {
             "name": "species",
@@ -281,6 +316,38 @@ def test_catalog_schema_helpers_return_serialisable_values(tmp_path: Path) -> No
         }
     ]
     assert catalog.list_metadata_fields("flux")[0]["name"] == "species"
+
+
+def test_catalog_spec_mutation_helpers_persist_updates(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    catalog.add_record_schema(
+        "paper",
+        RecordSchema(
+            metadata_fields=[
+                MetadataFieldDescription(name="title", description="Short title.", required=True),
+            ]
+        ),
+    )
+    catalog.set_default_record_schema("paper")
+    catalog.update_spec(catalog_name="library", default_operation="move")
+    reopened = Catalog.open(catalog.root)
+
+    assert reopened.spec.default_record_schema == "paper"
+    assert reopened.spec.catalog_name == "library"
+    assert reopened.spec.default_operation == "move"
+    assert reopened.list_metadata_fields()[0]["name"] == "title"
+
+
+def test_catalog_update_spec_rejects_files_root_without_migration(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    try:
+        catalog.update_spec(files_root="renamed-files")
+    except ValueError as exc:
+        assert "Changing files_root requires a file-root migration operation." in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected files_root update to be rejected")
 
 
 def test_record_schema_fallbacks_preserve_empty_templates() -> None:

--- a/tests/test_record_set.py
+++ b/tests/test_record_set.py
@@ -113,6 +113,28 @@ def test_record_set_discovers_fields_and_unique_scalar_values(tmp_path: Path) ->
     assert records.unique_values("tags") == []
 
 
+def test_record_set_field_discovery_skips_falsey_values(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "", "count": 0, "enabled": False, "site": {"code": None}},
+    )
+
+    fields = catalog.search(as_record_set=True).field_paths()
+
+    assert "locator.uri" in fields
+    assert "stored_abspath" not in fields
+    assert "stored_relpath" not in fields
+    assert "storage_mode" not in fields
+    assert "original_path" not in fields
+    assert "suffixes" not in fields
+    assert "user_metadata.species" not in fields
+    assert "user_metadata.count" not in fields
+    assert "user_metadata.enabled" not in fields
+    assert "user_metadata.site.code" not in fields
+
+
 def test_catalog_exposes_stored_field_discovery(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
 

--- a/tests/test_record_set.py
+++ b/tests/test_record_set.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from rich.table import Table
 
 import ogcat.record_set as record_set_module
-from ogcat import Catalog, CatalogRecordSet, CatalogSpec
+from ogcat import ArtifactLocator, Catalog, CatalogRecordSet, CatalogSpec
 
 
 def _create_catalog(tmp_path: Path) -> Catalog:
@@ -92,3 +92,29 @@ def test_record_set_rich_preview_returns_table(tmp_path: Path) -> None:
 
     assert isinstance(preview, Table)
     assert [column.header for column in preview.columns] == ["id", "species"]
+
+
+def test_record_set_discovers_fields_and_unique_scalar_values(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"species": "CH4", "tags": ["baseline"], "site": {"code": "MHD"}},
+    )
+
+    records = catalog.search(as_record_set=True)
+
+    assert "id" in records.field_paths()
+    assert "path" in records.field_paths()
+    assert "locator.uri" in records.field_paths()
+    assert "user_metadata.species" in records.field_paths()
+    assert "user_metadata.site.code" in records.field_paths()
+    assert records.unique_values("species") == ["CH4", "CO2"]
+    assert records.unique_values("tags") == []
+
+
+def test_catalog_exposes_stored_field_discovery(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+
+    assert "derived_metadata.netcdf.dims.time" in catalog.list_record_fields()
+    assert catalog.unique_values("derived_metadata.netcdf.dims.time") == [12]

--- a/tests/test_record_set.py
+++ b/tests/test_record_set.py
@@ -109,8 +109,24 @@ def test_record_set_discovers_fields_and_unique_scalar_values(tmp_path: Path) ->
     assert "locator.uri" in records.field_paths()
     assert "user_metadata.species" in records.field_paths()
     assert "user_metadata.site.code" in records.field_paths()
-    assert records.unique_values("species") == ["CH4", "CO2"]
+    assert records.unique_values("species") == ["CO2", "CH4"]
     assert records.unique_values("tags") == []
+
+
+def test_record_set_unique_values_preserves_first_seen_order(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator(kind="uri", value=f"s3://bucket/{value}.zarr"),
+                "metadata": {"priority": value},
+            }
+            for value in [2, 12, 2]
+        ]
+    )
+
+    assert catalog.search(as_record_set=True).unique_values("priority") == [2, 12]
 
 
 def test_record_set_field_discovery_skips_falsey_values(tmp_path: Path) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -190,7 +190,7 @@ def test_validate_spec_reports_unsupported_type_labels() -> None:
 
     assert not report.ok
     assert [issue.path for issue in report.errors] == [
-        "default_schema.metadata_fields.0.type.0",
+        "record_schemas.default.metadata_fields.0.type.0",
         "record_schemas.flux.metadata_fields.0.type.0",
     ]
     assert {issue.code for issue in report.errors} == {"schema.unsupported_type"}


### PR DESCRIPTION
## Summary
- Simplify `CatalogSpec` serialization to use `default_record_schema` plus `record_schemas`.
- Add stored-field discovery, unique-value lookup, and list-friendly naming behavior.
- Extend `ogcat fields` and add `ogcat spec` commands for safe spec updates.
- Update docs and tests to match the new schema shape and CLI surface.

Closes #36, #46, #47.

Some progress on #48.

## Testing
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pyright`
- `uv run pytest`