### PR TITLE
Add storage planning and fsspec-aware locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,14 @@ operation that uses the same writer path to copy or move data before writing the
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
 
-Use `catalog.plan_artifact(...)` to dry-run a planned target before writing. The returned
-`StoragePlan` is available to hooks and artifact writers as `context.storage_plan`; for older
-`add_artifact(locator=..., artifact_writer=...)` flows, ogcat derives a plan from the writer's
-declared `target_kind` and `write_mode` when available. Domain logic can create directory-like
-artifacts such as NetCDF collections or `.zarr` stores while ogcat core records only generic locators
-and metadata. Artifact writers remain the place where filesystem work and rollback registration
-happen.
+Use `catalog.plan_artifact_storage(...)` to dry-run a planned target before writing. The returned
+`StoragePlan` contains the locator, write intent, and resolved naming outputs; pass record metadata
+explicitly when calling `add_artifact(storage_plan=...)`. The plan is available to hooks and artifact
+writers as `context.storage_plan`; for older `add_artifact(locator=..., artifact_writer=...)` flows,
+ogcat derives a plan from the writer's declared `target_kind` and `write_mode` when available.
+Domain logic can create directory-like artifacts such as NetCDF collections or `.zarr` stores while
+ogcat core records only generic locators and metadata. Artifact writers remain the place where
+filesystem work and rollback registration happen.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,12 @@ See `ogcat.writers` for small helper wrappers around in-memory data, path-backed
 extraction examples.
 
 Use `catalog.plan_artifact(...)` to dry-run a planned target before writing. The returned
-`StoragePlan` is also available to hooks and artifact writers as `context.storage_plan`, so domain
-logic can create directory-like artifacts such as NetCDF collections or `.zarr` stores while ogcat
-core records only generic locators and metadata. Artifact writers remain the place where filesystem
-work and rollback registration happen.
+`StoragePlan` is available to hooks and artifact writers as `context.storage_plan`; for older
+`add_artifact(locator=..., artifact_writer=...)` flows, ogcat derives a plan from the writer's
+declared `target_kind` and `write_mode` when available. Domain logic can create directory-like
+artifacts such as NetCDF collections or `.zarr` stores while ogcat core records only generic locators
+and metadata. Artifact writers remain the place where filesystem work and rollback registration
+happen.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Optional netCDF metadata extraction:
 uv sync --extra netcdf
 ```
 
+Optional fsspec-backed storage URLs:
+
+```bash
+uv sync --extra fsspec
+```
+
 ## Python API
 
 Create a catalog, add a file, and search by metadata:
@@ -146,6 +152,11 @@ should materialise data before the record is written. `add_file()` is the bundle
 operation that uses the same writer path to copy or move data before writing the record.
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
+
+Use `catalog.plan_artifact(...)` to dry-run a planned target before writing. The returned
+`StoragePlan` is also available to hooks and artifact writers as `context.storage_plan`, so domain
+logic can create directory-like artifacts such as NetCDF collections or `.zarr` stores while ogcat
+core records only generic locators and metadata.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ extraction examples.
 Use `catalog.plan_artifact(...)` to dry-run a planned target before writing. The returned
 `StoragePlan` is also available to hooks and artifact writers as `context.storage_plan`, so domain
 logic can create directory-like artifacts such as NetCDF collections or `.zarr` stores while ogcat
-core records only generic locators and metadata.
+core records only generic locators and metadata. Artifact writers remain the place where filesystem
+work and rollback registration happen.
 
 ## CLI
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,6 +7,7 @@ API reference
    catalog
    models
    search
+   storage
    hooks
    validation
    writers-transactions

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -1,0 +1,6 @@
+Storage planning
+================
+
+.. automodule:: ogcat.storage
+   :members:
+   :member-order: bysource

--- a/docs/api/writers-transactions.rst
+++ b/docs/api/writers-transactions.rst
@@ -59,6 +59,24 @@ Methods
 
 .. automethod:: ogcat.writers.FunctionArtifactWriter.write
 
+CopyArtifactWriter
+------------------
+
+.. autoclass:: ogcat.writers.CopyArtifactWriter
+   :members:
+   :member-order: bysource
+   :exclude-members: source_kind, target_kind
+   :no-show-inheritance:
+
+MoveArtifactWriter
+------------------
+
+.. autoclass:: ogcat.writers.MoveArtifactWriter
+   :members:
+   :member-order: bysource
+   :exclude-members: source_kind, target_kind
+   :no-show-inheritance:
+
 UnzipArtifactWriter
 -------------------
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -69,7 +69,8 @@ print(plan.locator)
 Plans are also passed to hooks and artifact writers as
 ``context.storage_plan``.  This lets domain code materialise a generic artifact
 such as a directory of NetCDF files or a ``.zarr`` store while ogcat core only
-records the locator and handles rollback registration.
+records the locator.  Artifact writers remain responsible for filesystem side
+effects and rollback registration.
 
 ## External references
 
@@ -81,7 +82,7 @@ from ogcat import ArtifactLocator
 
 catalog.add_artifact(
     record_type="external_reference",
-    locator=ArtifactLocator.path("/data/shared/flux.nc"),
+    locator=ArtifactLocator.from_path("/data/shared/flux.nc"),
     metadata={"species": "CO2"},
 )
 ```
@@ -100,9 +101,9 @@ catalog.add_artifact(
 )
 ```
 
-Use ``ArtifactLocator.urlpath(...)`` when the location should be interpreted by
-fsspec-backed storage operations.  Install the optional dependency with
-``ogcat[fsspec]`` before executing fsspec-backed plans.
+Use ``ArtifactLocator.from_urlpath(...)`` when the location should be interpreted
+by fsspec-backed storage adapters.  Install the optional dependency with
+``ogcat[fsspec]`` before a writer performs fsspec-backed storage work.
 
 ## Catalog layout
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -52,19 +52,24 @@ filename:  {title_slug|original_stem}{original_suffix}
 
 ## Storage plans
 
-``Catalog.plan_artifact()`` performs the planning part of an add operation
+``Catalog.plan_artifact_storage()`` performs the planning part of an add operation
 without writing data or inserting a record.  It validates metadata, applies the
 same naming templates, lets locator-resolution hooks adjust the result, and
 returns a ``StoragePlan``.
 
 ```python
-plan = catalog.plan_artifact(
+plan = catalog.plan_artifact_storage(
     Path("incoming/example.nc"),
     metadata={"title": "example"},
     write_mode="copy",
 )
 print(plan.locator)
 ```
+
+``StoragePlan`` describes storage only.  It carries the resolved locator,
+target kind, write mode, storage-relative path, resolved directory, and resolved
+filename.  It does not carry record metadata; pass metadata again to
+``add_artifact(...)`` when turning a storage plan into a record.
 
 Hook timing matters.  ``before_validate_metadata`` runs before planning, so it
 receives neither ``context.planned_locators`` nor ``context.storage_plan``.

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -11,13 +11,22 @@ the file ended up there.
     this kind.  Path-backed records support :meth:`ogcat.CatalogRecord.path`
     and the ``ogcat path`` CLI command.
 
+``urlpath``
+:   An fsspec-addressable URL path, such as ``ssh://host/path/file.nc`` or
+    ``s3://bucket/path/store.zarr``.  These locators are interpreted only when
+    fsspec-backed storage behavior is requested.
+
+``uri``
+:   An external reference that ogcat records but does not manage or inspect.
+    Use this for DOI, FTP, HTTP, ICOS, object-store, or project-specific
+    references that domain code will interpret later.
+
 ``opaque``
 :   A placeholder used when the locator is not yet set or when no path is
     applicable.  You will not normally see this in practice.
 
-Other kinds such as ``uri`` or ``s3`` can be stored using
-:meth:`ogcat.ArtifactLocator` directly, but ogcat does not interpret them
-beyond recording the string value.
+Other project-specific kinds can be stored using :meth:`ogcat.ArtifactLocator`
+directly, but ogcat does not interpret them beyond recording the string value.
 
 ## Managed files
 
@@ -41,6 +50,27 @@ directory: {year_added}/{original_stem}
 filename:  {title_slug|original_stem}{original_suffix}
 ```
 
+## Storage plans
+
+``Catalog.plan_artifact()`` performs the planning part of an add operation
+without writing data or inserting a record.  It validates metadata, applies the
+same naming templates, lets locator-resolution hooks adjust the result, and
+returns a ``StoragePlan``.
+
+```python
+plan = catalog.plan_artifact(
+    Path("incoming/example.nc"),
+    metadata={"title": "example"},
+    write_mode="copy",
+)
+print(plan.locator)
+```
+
+Plans are also passed to hooks and artifact writers as
+``context.storage_plan``.  This lets domain code materialise a generic artifact
+such as a directory of NetCDF files or a ``.zarr`` store while ogcat core only
+records the locator and handles rollback registration.
+
 ## External references
 
 To catalog a file that should stay in place, use ``add_artifact()`` with a
@@ -58,6 +88,21 @@ catalog.add_artifact(
 
 The file is not copied or moved.  ogcat records only the path and the
 metadata.
+
+For non-local references, use a ``uri`` locator when ogcat should not check or
+manage the target:
+
+```python
+catalog.add_artifact(
+    record_type="external_reference",
+    locator=ArtifactLocator(kind="uri", value="ftp://example.org/data/file.nc"),
+    storage_mode="external",
+)
+```
+
+Use ``ArtifactLocator.urlpath(...)`` when the location should be interpreted by
+fsspec-backed storage operations.  Install the optional dependency with
+``ogcat[fsspec]`` before executing fsspec-backed plans.
 
 ## Catalog layout
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -66,11 +66,14 @@ plan = catalog.plan_artifact(
 print(plan.locator)
 ```
 
-Plans are also passed to hooks and artifact writers as
-``context.storage_plan``.  This lets domain code materialise a generic artifact
-such as a directory of NetCDF files or a ``.zarr`` store while ogcat core only
-records the locator.  Artifact writers remain responsible for filesystem side
-effects and rollback registration.
+After locator-resolution hooks have run, the selected plan is available to later
+hooks and artifact writers as ``context.storage_plan``.  Earlier hooks such as
+``before_validate_metadata`` and ``resolve_artifact_locator`` should inspect
+``context.planned_locators`` instead because the final ``StoragePlan`` has not
+been built yet.  The plan lets domain code materialise a generic artifact such as
+a directory of NetCDF files or a ``.zarr`` store while ogcat core only records
+the locator.  Artifact writers remain responsible for filesystem side effects
+and rollback registration.
 
 ## External references
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -66,14 +66,16 @@ plan = catalog.plan_artifact(
 print(plan.locator)
 ```
 
-After locator-resolution hooks have run, the selected plan is available to later
-hooks and artifact writers as ``context.storage_plan``.  Earlier hooks such as
-``before_validate_metadata`` and ``resolve_artifact_locator`` should inspect
-``context.planned_locators`` instead because the final ``StoragePlan`` has not
-been built yet.  The plan lets domain code materialise a generic artifact such as
-a directory of NetCDF files or a ``.zarr`` store while ogcat core only records
-the locator.  Artifact writers remain responsible for filesystem side effects
-and rollback registration.
+Hook timing matters.  ``before_validate_metadata`` runs before planning, so it
+receives neither ``context.planned_locators`` nor ``context.storage_plan``.
+``resolve_artifact_locator`` receives proposed locators in
+``context.planned_locators`` and can return the locator that should be used for
+the artifact being added.  After that hook returns, ogcat builds the final
+``StoragePlan`` and exposes it to later hooks and artifact writers as
+``context.storage_plan``.  The plan lets domain code materialise a generic
+artifact such as a directory of NetCDF files or a ``.zarr`` store while ogcat
+core only records the locator.  Artifact writers remain responsible for
+filesystem side effects and rollback registration.
 
 ## External references
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -77,5 +77,5 @@ Event log
   operation state.
 
 Storage profile
-: A planned named configuration for resolving non-local storage backends and
+: A planned named configuration for resolving non-local storage adapters and
   credentials without storing secrets in records.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ searching records.
    tutorials/basic-catalog
    tutorials/intermediate
    tutorials/advanced-real-world
+   tutorials/artifact-workflows
 
 .. toctree::
    :maxdepth: 1

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -155,30 +155,33 @@ the write operation and rollback cleanup. ogcat owns the plan and record.
 ```python
 from ogcat import UnzipArtifactWriter, path_source
 
-collection_plan = catalog.plan_artifact(
+collection_metadata = {
+    "species": "co2",
+    "product": "cams",
+    "title": "CAMS CO2 concentration NetCDF collection",
+    "domain": "global",
+    "source_record_id": raw_zip_record.id,
+    "source_url": ads_dataset,
+    "archive_name": downloaded_zip.name,
+    "archive_member_glob": "*.nc",
+    "member_count": 36,
+    "time_coverage": "2020-01/2022-12",
+    "bc_input": "cams",
+    "bc_input_version": "cams73_latest",
+}
+
+collection_plan = catalog.plan_artifact_storage(
     downloaded_zip,
     record_type="raw_netcdf_collection",
     target_kind="directory",
     write_mode="write",
-    metadata={
-        "species": "co2",
-        "product": "cams",
-        "title": "CAMS CO2 concentration NetCDF collection",
-        "domain": "global",
-        "source_record_id": raw_zip_record.id,
-        "source_url": ads_dataset,
-        "archive_name": downloaded_zip.name,
-        "archive_member_glob": "*.nc",
-        "member_count": 36,
-        "time_coverage": "2020-01/2022-12",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-    },
+    metadata=collection_metadata,
 )
 
 collection_record = catalog.add_artifact(
     record_type="raw_netcdf_collection",
     storage_plan=collection_plan,
+    metadata=collection_metadata,
     source=path_source(downloaded_zip, kind="zip_file"),
     artifact_writer=UnzipArtifactWriter(),
 )
@@ -258,32 +261,35 @@ collection_path = collection_record.path()
 if collection_path is None:
     raise RuntimeError("Expected extracted collection to have a local path.")
 
-processed_plan = catalog.plan_artifact(
+processed_metadata = {
+    "species": "co2",
+    "domain": "europe",
+    "bc_input": "cams",
+    "bc_input_version": "cams73_latest",
+    "title": "CAMS CO2 boundary conditions for EUROPE",
+    "source_record_id": collection_record.id,
+    "raw_zip_record_id": raw_zip_record.id,
+    "source_url": ads_dataset,
+    "processing_domain": "EUROPE",
+    "provenance": {
+        "raw_zip_record_id": raw_zip_record.id,
+        "netcdf_collection_record_id": collection_record.id,
+        "operation": "create_cams_bc",
+        "opened_with": "xarray.open_mfdataset",
+    },
+}
+
+processed_plan = catalog.plan_artifact_storage(
     record_type="boundary_conditions",
     target_kind="directory",
     write_mode="write",
-    metadata={
-        "species": "co2",
-        "domain": "europe",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-        "title": "CAMS CO2 boundary conditions for EUROPE",
-        "source_record_id": collection_record.id,
-        "raw_zip_record_id": raw_zip_record.id,
-        "source_url": ads_dataset,
-        "processing_domain": "EUROPE",
-        "provenance": {
-            "raw_zip_record_id": raw_zip_record.id,
-            "netcdf_collection_record_id": collection_record.id,
-            "operation": "create_cams_bc",
-            "opened_with": "xarray.open_mfdataset",
-        },
-    },
+    metadata=processed_metadata,
 )
 
 processed_record = catalog.add_artifact(
     record_type="boundary_conditions",
     storage_plan=processed_plan,
+    metadata=processed_metadata,
     source=memory_source(
         None,
         kind="cams_netcdf_collection",
@@ -417,31 +423,34 @@ class LocalCamsZipToZarrWriter:
 Plan and run the processing step:
 
 ```python
-local_processed_plan = catalog.plan_artifact(
+local_processed_metadata = {
+    "species": "co2",
+    "domain": "europe",
+    "bc_input": "cams",
+    "bc_input_version": "cams73_latest",
+    "title": "CAMS CO2 boundary conditions for EUROPE",
+    "source_record_id": raw_zip_record.id,
+    "source_url": ads_dataset,
+    "processing_domain": "EUROPE",
+    "provenance": {
+        "raw_zip_record_id": raw_zip_record.id,
+        "operation": "create_cams_bc",
+        "opened_with": "xarray.open_mfdataset",
+        "zip_access": "fsspec zip filesystem over local file URL",
+    },
+}
+
+local_processed_plan = catalog.plan_artifact_storage(
     record_type="boundary_conditions",
     target_kind="directory",
     write_mode="write",
-    metadata={
-        "species": "co2",
-        "domain": "europe",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-        "title": "CAMS CO2 boundary conditions for EUROPE",
-        "source_record_id": raw_zip_record.id,
-        "source_url": ads_dataset,
-        "processing_domain": "EUROPE",
-        "provenance": {
-            "raw_zip_record_id": raw_zip_record.id,
-            "operation": "create_cams_bc",
-            "opened_with": "xarray.open_mfdataset",
-            "zip_access": "fsspec zip filesystem over local file URL",
-        },
-    },
+    metadata=local_processed_metadata,
 )
 
 local_processed_record = catalog.add_artifact(
     record_type="boundary_conditions",
     storage_plan=local_processed_plan,
+    metadata=local_processed_metadata,
     source=memory_source(
         None,
         kind="local_cams_zip_urlpath",
@@ -606,31 +615,34 @@ Then plan and write the final Zarr artifact:
 ```python
 catalog.hook_manager.register(CamsZipMemberUrlpathHook())
 
-zip_chain_processed_plan = catalog.plan_artifact(
+zip_chain_processed_metadata = {
+    "species": "co2",
+    "domain": "europe",
+    "bc_input": "cams",
+    "bc_input_version": "cams73_latest",
+    "title": "CAMS CO2 boundary conditions for EUROPE",
+    "source_record_id": raw_zip_record.id,
+    "source_url": ads_dataset,
+    "processing_domain": "EUROPE",
+    "provenance": {
+        "raw_zip_record_id": raw_zip_record.id,
+        "operation": "create_cams_bc",
+        "opened_with": "xarray.open_mfdataset",
+        "zip_access": "writer built fsspec chain from raw locator",
+    },
+}
+
+zip_chain_processed_plan = catalog.plan_artifact_storage(
     record_type="boundary_conditions",
     target_kind="directory",
     write_mode="write",
-    metadata={
-        "species": "co2",
-        "domain": "europe",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-        "title": "CAMS CO2 boundary conditions for EUROPE",
-        "source_record_id": raw_zip_record.id,
-        "source_url": ads_dataset,
-        "processing_domain": "EUROPE",
-        "provenance": {
-            "raw_zip_record_id": raw_zip_record.id,
-            "operation": "create_cams_bc",
-            "opened_with": "xarray.open_mfdataset",
-            "zip_access": "writer built fsspec chain from raw locator",
-        },
-    },
+    metadata=zip_chain_processed_metadata,
 )
 
 zip_chain_processed_record = catalog.add_artifact(
     record_type="boundary_conditions",
     storage_plan=zip_chain_processed_plan,
+    metadata=zip_chain_processed_metadata,
     source=memory_source(
         None,
         kind="cams_zip_member_urlpath",
@@ -736,20 +748,23 @@ class RequestsDownloadWriter:
         )
 
 
-download_plan = catalog.plan_artifact(
+download_metadata = {
+    "species": "co2",
+    "product": "example",
+    "title": "Example downloaded CO2 data",
+    "source_record_id": source_record.id,
+}
+
+download_plan = catalog.plan_artifact_storage(
     Path("example.nc"),
     write_mode="write",
-    metadata={
-        "species": "co2",
-        "product": "example",
-        "title": "Example downloaded CO2 data",
-        "source_record_id": source_record.id,
-    },
+    metadata=download_metadata,
 )
 
 download_record = catalog.add_artifact(
     record_type="downloaded_file",
     storage_plan=download_plan,
+    metadata=download_metadata,
     source=memory_source(
         None,
         kind="download_uri",

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -46,7 +46,12 @@ condition input metadata.
 ```python
 from pathlib import Path
 
-from ogcat import Catalog, CatalogSpec, RecordSchema
+from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
+
+
+def required_field(name: str, description: str) -> MetadataFieldDescription:
+    """Describe a required metadata field."""
+    return MetadataFieldDescription(name=name, description=description, required=True)
 
 catalog = Catalog.create(
     Path("cams-bc-catalog"),
@@ -58,24 +63,46 @@ catalog = Catalog.create(
         ),
         record_schemas={
             "raw_download": RecordSchema(
+                description="Raw downloaded files, including archives.",
                 directory_template="raw/{product}/{species}",
                 filename_template="{title_slug|original_stem}{original_suffix}",
-                required=["species", "product", "title"],
+                metadata_fields=[
+                    required_field("species", "Species represented by the data."),
+                    required_field("product", "Upstream product or data family."),
+                    required_field("title", "Human-readable data title."),
+                ],
             ),
             "raw_netcdf_collection": RecordSchema(
+                description="Raw NetCDF file collections extracted from archive artifacts.",
                 directory_template="raw/{product}/{species}",
                 filename_template="{title_slug|original_stem}",
-                required=["species", "product", "title"],
+                metadata_fields=[
+                    required_field("species", "Species represented by the data."),
+                    required_field("product", "Upstream product or data family."),
+                    required_field("title", "Human-readable data title."),
+                ],
             ),
             "boundary_conditions": RecordSchema(
+                description="Processed boundary-condition stores.",
                 directory_template="boundary_conditions/{species}/{domain}",
                 filename_template="{bc_input}_{species}_{domain}.zarr",
-                required=["species", "domain", "bc_input"],
+                metadata_fields=[
+                    required_field("species", "Species represented by the data."),
+                    required_field("domain", "Processing or model domain."),
+                    required_field("bc_input", "Boundary-condition input product."),
+                ],
             ),
         },
     ),
 )
 ```
+
+These schemas are not meant to be a complete artifact-type hierarchy. They
+describe the metadata fields and naming templates that differ between raw
+downloads, extracted raw collections, and processed boundary-condition outputs.
+A simpler catalog could use one broad ``raw`` schema and distinguish zip files,
+NetCDF files, and collections with ordinary metadata such as ``format`` or
+``content_kind``.
 
 ### 1. Reference the raw zip
 
@@ -111,6 +138,7 @@ raw_zip_record = catalog.add_artifact(
             "contains global concentration fields for CO2."
         ),
         "archive_name": downloaded_zip.name,
+        "archive_member_glob": "*.nc",
         "member_count": 36,
         "time_coverage": "2020-01/2022-12",
         "bc_input": "cams",
@@ -140,7 +168,7 @@ collection_plan = catalog.plan_artifact(
         "source_record_id": raw_zip_record.id,
         "source_url": ads_dataset,
         "archive_name": downloaded_zip.name,
-        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        "archive_member_glob": "*.nc",
         "member_count": 36,
         "time_coverage": "2020-01/2022-12",
         "bc_input": "cams",
@@ -279,52 +307,28 @@ concepts.
 ## Local CAMS zip to processed Zarr with temporary extraction
 
 The same operation can avoid a persistent extracted collection when the raw zip
-already lives on a filesystem visible to the processing job, such as a shared
-HPC/group filesystem. fsspec can still be useful here: the local path can be
-wrapped as a ``file://`` URL-path, opened through ``fsspec.open_local()``, and
-then treated as a zip filesystem. The writer extracts the NetCDF members into a
-temporary directory only long enough for ``xarray.open_mfdataset()`` and writes a
-single managed Zarr artifact.
+already lives on a filesystem visible to the processing job. fsspec can still be
+useful here: the writer can wrap the already-recorded local path as a ``file://``
+URL-path, open it through ``fsspec.open_local()``, and then treat it as a zip
+filesystem. The writer extracts the NetCDF members into a temporary directory
+only long enough for ``xarray.open_mfdataset()`` and writes a single managed
+Zarr artifact.
 
 This pattern is useful when the intermediate NetCDF collection is an
 implementation detail of the processing step rather than an artifact you want to
 keep in the catalog.
 
-First record the local zip as a URL-path reference. This keeps the example on the
-same filesystem as the zip while still exercising the ``urlpath`` locator kind:
+The raw zip can be the same path-backed reference recorded earlier. Its metadata
+does not need to choose this later processing strategy. A compact archive
+summary, such as ``archive_member_glob="*.nc"`` and ``member_count=36``, is
+usually enough for downstream processing decisions. A full ``ncdump -h`` for
+every member would probably be better as a separate sidecar artifact than as
+inline catalog metadata.
 
 ```python
-from datetime import date
-from pathlib import Path
-
-from ogcat import ArtifactLocator
-
-shared_zip = Path(
-    "/group/chem/acrg/verification_games_round_2/"
-    "cams_bc/bab75005df9571750d518b0aacdedb35.zip"
-)
-shared_zip_urlpath = shared_zip.as_uri()
-
-local_zip_record = catalog.add_artifact(
-    record_type="raw_download",
-    locator=ArtifactLocator.from_urlpath(shared_zip_urlpath),
-    storage_mode="external",
-    metadata={
-        "species": "co2",
-        "product": "cams",
-        "title": "CAMS global inversion-optimised greenhouse gas fluxes and concentrations",
-        "domain": "global",
-        "source_url": ads_dataset,
-        "downloaded_from": "Copernicus Atmosphere Data Store",
-        "downloaded_on": date(2026, 3, 18).isoformat(),
-        "archive_name": "bab75005df9571750d518b0aacdedb35.zip",
-        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
-        "member_count": 36,
-        "time_coverage": "2020-01/2022-12",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-    },
-)
+zip_path = raw_zip_record.path()
+if zip_path is None:
+    raise RuntimeError("Expected the raw CAMS zip record to have a local path.")
 ```
 
 Then use a writer that opens the zip through fsspec, extracts the NetCDF members
@@ -346,7 +350,7 @@ from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_sou
 
 @dataclass(frozen=True)
 class LocalCamsZipToZarrWriter:
-    """Create a Zarr store directly from a local CAMS zip URL path."""
+    """Create a Zarr store directly from a local CAMS zip path."""
 
     def write(
         self,
@@ -360,10 +364,11 @@ class LocalCamsZipToZarrWriter:
         if target_path.exists():
             raise FileExistsError(target_path)
 
-        zip_urlpath = str(source.metadata["zip_urlpath"])
+        zip_path = Path(str(source.metadata["zip_path"]))
+        zip_urlpath = zip_path.as_uri()
         species = str(source.metadata.get("species", "co2"))
         processing_domain = str(source.metadata["processing_domain"])
-        member_pattern = str(source.metadata["member_pattern"])
+        member_glob = str(source.metadata.get("archive_member_glob", "*.nc"))
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
         context.rollback(
@@ -380,7 +385,7 @@ class LocalCamsZipToZarrWriter:
             zip_fs = fsspec.filesystem("zip", fo=local_zip)
             try:
                 input_paths: list[Path] = []
-                for member in sorted(zip_fs.glob(member_pattern)):
+                for member in sorted(zip_fs.glob(member_glob)):
                     local_member = extracted_dir / Path(member).name
                     with zip_fs.open(member, "rb") as src, local_member.open("wb") as dst:
                         shutil.copyfileobj(src, dst)
@@ -396,7 +401,7 @@ class LocalCamsZipToZarrWriter:
             {
                 "raw_zip_record_id": source.metadata["raw_zip_record_id"],
                 "zip_urlpath": zip_urlpath,
-                "member_pattern": member_pattern,
+                "archive_member_glob": member_glob,
                 "input_file_count": len(input_paths),
                 "input_files": [path.name for path in input_paths],
                 "temporary_extract": "NetCDF members extracted inside a TemporaryDirectory",
@@ -422,11 +427,11 @@ local_processed_plan = catalog.plan_artifact(
         "bc_input": "cams",
         "bc_input_version": "cams73_latest",
         "title": "CAMS CO2 boundary conditions for EUROPE",
-        "source_record_id": local_zip_record.id,
+        "source_record_id": raw_zip_record.id,
         "source_url": ads_dataset,
         "processing_domain": "EUROPE",
         "provenance": {
-            "raw_zip_record_id": local_zip_record.id,
+            "raw_zip_record_id": raw_zip_record.id,
             "operation": "create_cams_bc",
             "opened_with": "xarray.open_mfdataset",
             "zip_access": "fsspec zip filesystem over local file URL",
@@ -441,11 +446,11 @@ local_processed_record = catalog.add_artifact(
         None,
         kind="local_cams_zip_urlpath",
         metadata={
-            "zip_urlpath": local_zip_record.locator.value,
-            "raw_zip_record_id": local_zip_record.id,
+            "zip_path": str(zip_path),
+            "raw_zip_record_id": raw_zip_record.id,
             "species": "co2",
             "processing_domain": "EUROPE",
-            "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+            "archive_member_glob": raw_zip_record.user_metadata.get("archive_member_glob", "*.nc"),
         },
     ),
     artifact_writer=LocalCamsZipToZarrWriter(),
@@ -453,7 +458,7 @@ local_processed_record = catalog.add_artifact(
 ```
 
 This example still keeps fsspec and xarray out of ogcat core. ogcat records the
-local zip URL-path and the processed Zarr locator; the writer owns the temporary
+local zip path and the processed Zarr locator; the writer owns the temporary
 extracted NetCDF files, processing call, and cleanup. If the zip later moves to a
 remote filesystem, the same writer shape can be adapted to use fsspec URL
 chaining and a temporary ``simplecache`` directory before opening the zip
@@ -470,7 +475,7 @@ In this variant, a hook builds the fsspec URL pattern only during the processing
 operation, immediately before the custom writer runs:
 
 ```text
-simplecache::zip://cams73_latest_co2_conc_surface_inst_*.nc::file:///.../bab75005df9571750d518b0aacdedb35.zip
+simplecache::zip://*.nc::file:///.../bab75005df9571750d518b0aacdedb35.zip
 ```
 
 The existing ``resolve_artifact_locator`` hook is best kept for the artifact
@@ -484,33 +489,17 @@ syntax with ``::`` passes the nested path through each filesystem layer. With
 ``simplecache`` as the outer layer, the selected zip members can be cached as
 local files in a directory chosen by the writer.
 
-The zip record stays faithful to the source file:
+The zip record stays faithful to the source file. In this example, reuse the
+``raw_zip_record`` created earlier from ``~/Downloads`` rather than creating a
+second record just to support the fsspec processing path:
 
 ```python
-zip_source_record = catalog.add_artifact(
-    record_type="raw_download",
-    locator=ArtifactLocator.from_path(shared_zip),
-    storage_mode="external",
-    metadata={
-        "species": "co2",
-        "product": "cams",
-        "title": "CAMS global inversion-optimised greenhouse gas fluxes and concentrations",
-        "domain": "global",
-        "source_url": ads_dataset,
-        "downloaded_from": "Copernicus Atmosphere Data Store",
-        "downloaded_on": date(2026, 3, 18).isoformat(),
-        "archive_name": shared_zip.name,
-        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
-        "member_count": 36,
-        "time_coverage": "2020-01/2022-12",
-        "bc_input": "cams",
-        "bc_input_version": "cams73_latest",
-    },
-)
+assert raw_zip_record.locator.kind == "path"
+assert raw_zip_record.user_metadata["archive_member_glob"] == "*.nc"
 ```
 
 The processing operation receives the raw record's locator as source metadata. A
-hook converts that locator to a fsspec member pattern and stores it on
+hook converts that locator and archive member glob to a fsspec URL path and stores it on
 ``context.source.metadata``. The writer then gives ``simplecache`` a temporary
 directory, receives local cached member files from ``fsspec.open_local()``, opens
 them with xarray, and lets the temporary directory clean up the cache when it
@@ -528,7 +517,7 @@ import xarray as xr
 from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
 
 
-def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_pattern: str) -> str:
+def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_glob: str) -> str:
     """Build a chained fsspec URL pattern for CAMS NetCDF members."""
     if locator.kind == "path":
         zip_url = Path(locator.value).as_uri()
@@ -536,7 +525,7 @@ def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_pattern: str) ->
         zip_url = locator.value
     else:
         raise ValueError(f"Cannot build a fsspec zip chain from {locator.kind!r}")
-    return f"simplecache::zip://{member_pattern}::{zip_url}"
+    return f"simplecache::zip://{member_glob}::{zip_url}"
 
 
 @dataclass(frozen=True)
@@ -550,10 +539,10 @@ class CamsZipMemberUrlpathHook:
             return
 
         raw_locator = ArtifactLocator.from_dict(context.source.metadata["raw_locator"])
-        member_pattern = str(context.source.metadata["member_pattern"])
+        member_glob = str(context.source.metadata.get("archive_member_glob", "*.nc"))
         context.source.metadata["input_urlpath"] = cams_zip_member_urlpath(
             raw_locator,
-            member_pattern=member_pattern,
+            member_glob=member_glob,
         )
 
 
@@ -599,7 +588,7 @@ class CamsZipChainToZarrWriter:
             {
                 "raw_zip_record_id": source.metadata["raw_zip_record_id"],
                 "input_urlpath": input_urlpath,
-                "member_pattern": source.metadata["member_pattern"],
+                "archive_member_glob": source.metadata.get("archive_member_glob", "*.nc"),
                 "input_file_count": len(input_paths),
                 "input_files": [path.name for path in input_paths],
                 "temporary_cache": "fsspec simplecache inside a TemporaryDirectory",
@@ -627,11 +616,11 @@ zip_chain_processed_plan = catalog.plan_artifact(
         "bc_input": "cams",
         "bc_input_version": "cams73_latest",
         "title": "CAMS CO2 boundary conditions for EUROPE",
-        "source_record_id": zip_source_record.id,
+        "source_record_id": raw_zip_record.id,
         "source_url": ads_dataset,
         "processing_domain": "EUROPE",
         "provenance": {
-            "raw_zip_record_id": zip_source_record.id,
+            "raw_zip_record_id": raw_zip_record.id,
             "operation": "create_cams_bc",
             "opened_with": "xarray.open_mfdataset",
             "zip_access": "writer built fsspec chain from raw locator",
@@ -646,11 +635,11 @@ zip_chain_processed_record = catalog.add_artifact(
         None,
         kind="cams_zip_member_urlpath",
         metadata={
-            "raw_locator": zip_source_record.locator.to_dict(),
-            "raw_zip_record_id": zip_source_record.id,
+            "raw_locator": raw_zip_record.locator.to_dict(),
+            "raw_zip_record_id": raw_zip_record.id,
             "species": "co2",
             "processing_domain": "EUROPE",
-            "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+            "archive_member_glob": raw_zip_record.user_metadata.get("archive_member_glob", "*.nc"),
         },
     ),
     artifact_writer=CamsZipChainToZarrWriter(),

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -714,7 +714,7 @@ Write a managed copy with a small requests-based writer:
 ```python
 import requests
 
-from ogcat import OperationContext, OperationSource, memory_source
+from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
 
 
 class RequestsDownloadWriter:

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -719,9 +719,12 @@ class RequestsDownloadWriter:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove download")
 
-        response = requests.get(url, timeout=60)
-        response.raise_for_status()
-        target_path.write_bytes(response.content)
+        with requests.get(url, timeout=60, stream=True) as response:
+            response.raise_for_status()
+            with target_path.open("wb") as target_file:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        target_file.write(chunk)
 
         context.derived_metadata.update(
             {

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -1,0 +1,776 @@
+# Artifact workflow examples
+
+These examples show how to keep ogcat responsible for cataloging, naming,
+locators, and operation rollback while domain code performs the scientific or
+network-specific work.
+
+## CAMS zip to processed boundary conditions
+
+This workflow tracks a raw CAMS download, extracts its NetCDF members into a
+managed directory artifact, and writes a processed Zarr store with provenance
+linking the output back to the raw inputs.
+
+The example uses the CAMS global inversion-optimised greenhouse gas fluxes and
+concentrations dataset from the Copernicus Atmosphere Data Store:
+
+<https://ads.atmosphere.copernicus.eu/datasets/cams-global-greenhouse-gas-inversion?tab=overview>
+
+The ADS download page configures the request. Those options are reflected in the
+downloaded file. Here the downloaded archive is:
+
+```text
+~/Downloads/bab75005df9571750d518b0aacdedb35.zip
+```
+
+Its members are monthly CO2 concentration files for 2020-2022, with names like:
+
+```text
+cams73_latest_co2_conc_surface_inst_202001.nc
+cams73_latest_co2_conc_surface_inst_202002.nc
+...
+cams73_latest_co2_conc_surface_inst_202212.nc
+```
+
+In this naming convention, ``latest`` is the input version, ``co2`` is the
+species, ``conc`` means concentration, and ``surface_inst`` indicates surface in
+situ observations. The ``73`` in ``cams73`` is kept as part of the upstream input
+version string because the workflow does not interpret it further.
+
+### Catalog spec
+
+The raw data schemas use readable title slugs and year/month fields when those
+are present. Raw files and extracted raw collections live under ``files/raw``.
+The processed boundary-condition schema uses species, domain, and boundary
+condition input metadata.
+
+```python
+from pathlib import Path
+
+from ogcat import Catalog, CatalogSpec, RecordSchema
+
+catalog = Catalog.create(
+    Path("cams-bc-catalog"),
+    CatalogSpec(
+        catalog_name="cams_bc",
+        default_schema=RecordSchema(
+            directory_template="raw/{product}/{species}",
+            filename_template="{title_slug|original_stem}_{year_month_or_original_stem}{original_suffix}",
+        ),
+        record_schemas={
+            "raw_download": RecordSchema(
+                directory_template="raw/{product}/{species}",
+                filename_template="{title_slug|original_stem}{original_suffix}",
+                required=["species", "product", "title"],
+            ),
+            "raw_netcdf_collection": RecordSchema(
+                directory_template="raw/{product}/{species}",
+                filename_template="{title_slug|original_stem}",
+                required=["species", "product", "title"],
+            ),
+            "boundary_conditions": RecordSchema(
+                directory_template="boundary_conditions/{species}/{domain}",
+                filename_template="{bc_input}_{species}_{domain}.zarr",
+                required=["species", "domain", "bc_input"],
+            ),
+        },
+    ),
+)
+```
+
+### 1. Reference the raw zip
+
+The first record documents the raw file in the download folder. ogcat records the
+locator and metadata but does not copy or inspect the archive.
+
+```python
+from datetime import date
+from pathlib import Path
+
+from ogcat import ArtifactLocator
+
+downloaded_zip = Path("~/Downloads/bab75005df9571750d518b0aacdedb35.zip").expanduser()
+ads_dataset = (
+    "https://ads.atmosphere.copernicus.eu/datasets/"
+    "cams-global-greenhouse-gas-inversion?tab=overview"
+)
+
+raw_zip_record = catalog.add_artifact(
+    record_type="raw_download",
+    locator=ArtifactLocator.from_path(downloaded_zip),
+    storage_mode="external",
+    metadata={
+        "species": "co2",
+        "product": "cams",
+        "title": "CAMS global inversion-optimised greenhouse gas fluxes and concentrations",
+        "domain": "global",
+        "source_url": ads_dataset,
+        "downloaded_from": "Copernicus Atmosphere Data Store",
+        "downloaded_on": date(2026, 3, 18).isoformat(),
+        "comment": (
+            "Raw zip downloaded from the Copernicus Atmosphere Data Store; "
+            "contains global concentration fields for CO2."
+        ),
+        "archive_name": downloaded_zip.name,
+        "member_count": 36,
+        "time_coverage": "2020-01/2022-12",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+    },
+)
+```
+
+### 2. Extract the NetCDF collection into managed storage
+
+The extracted collection is a directory artifact. ``UnzipArtifactWriter`` owns
+the write operation and rollback cleanup. ogcat owns the plan and record.
+
+```python
+from ogcat import UnzipArtifactWriter, path_source
+
+collection_plan = catalog.plan_artifact(
+    downloaded_zip,
+    record_type="raw_netcdf_collection",
+    target_kind="directory",
+    write_mode="write",
+    metadata={
+        "species": "co2",
+        "product": "cams",
+        "title": "CAMS CO2 concentration NetCDF collection",
+        "domain": "global",
+        "source_record_id": raw_zip_record.id,
+        "source_url": ads_dataset,
+        "archive_name": downloaded_zip.name,
+        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        "member_count": 36,
+        "time_coverage": "2020-01/2022-12",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+    },
+)
+
+collection_record = catalog.add_artifact(
+    record_type="raw_netcdf_collection",
+    storage_plan=collection_plan,
+    source=path_source(downloaded_zip, kind="zip_file"),
+    artifact_writer=UnzipArtifactWriter(),
+)
+```
+
+### 3. Process the collection into a Zarr artifact
+
+The processing writer is domain code. It opens the extracted NetCDF files with
+``xarray.open_mfdataset()``, calls a project-specific ``create_cams_bc()``
+function, and writes the returned dataset to a single ``.zarr`` store.
+
+```python
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import xarray as xr
+
+from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+
+
+def create_cams_bc(ds: xr.Dataset, *, species: str, domain: str) -> xr.Dataset:
+    """Create boundary-condition data from CAMS concentration fields."""
+    ...
+
+
+@dataclass(frozen=True)
+class CamsBoundaryConditionWriter:
+    """Write processed CAMS boundary conditions to a planned Zarr directory."""
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        target_path = target.as_path()
+        if target_path is None:
+            raise ValueError("CAMS boundary-condition writer requires a path target.")
+        if target_path.exists():
+            raise FileExistsError(target_path)
+
+        collection_path = Path(source.metadata["collection_path"])
+        input_paths = sorted(collection_path.glob("cams73_latest_co2_conc_surface_inst_*.nc"))
+        species = str(source.metadata.get("species", "co2"))
+        processing_domain = str(source.metadata["processing_domain"])
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(
+            lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+            description=f"remove processed Zarr store {target_path}",
+        )
+
+        with xr.open_mfdataset(input_paths) as ds:
+            processed = create_cams_bc(ds, species=species, domain=processing_domain)
+            processed.to_zarr(target_path, mode="w")
+
+        context.derived_metadata.update(
+            {
+                "input_record_id": source.metadata["collection_record_id"],
+                "raw_zip_record_id": source.metadata["raw_zip_record_id"],
+                "input_file_count": len(input_paths),
+                "input_files": [path.name for path in input_paths],
+                "species": species,
+                "bc_input": "cams",
+                "bc_input_version": "cams73_latest",
+                "domain": processing_domain.lower(),
+                "reader_hint": "xarray.open_zarr",
+            }
+        )
+```
+
+Plan and write the processed artifact:
+
+```python
+collection_path = collection_record.path()
+if collection_path is None:
+    raise RuntimeError("Expected extracted collection to have a local path.")
+
+processed_plan = catalog.plan_artifact(
+    record_type="boundary_conditions",
+    target_kind="directory",
+    write_mode="write",
+    metadata={
+        "species": "co2",
+        "domain": "europe",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+        "title": "CAMS CO2 boundary conditions for EUROPE",
+        "source_record_id": collection_record.id,
+        "raw_zip_record_id": raw_zip_record.id,
+        "source_url": ads_dataset,
+        "processing_domain": "EUROPE",
+        "provenance": {
+            "raw_zip_record_id": raw_zip_record.id,
+            "netcdf_collection_record_id": collection_record.id,
+            "operation": "create_cams_bc",
+            "opened_with": "xarray.open_mfdataset",
+        },
+    },
+)
+
+processed_record = catalog.add_artifact(
+    record_type="boundary_conditions",
+    storage_plan=processed_plan,
+    source=memory_source(
+        None,
+        kind="cams_netcdf_collection",
+        metadata={
+            "collection_path": str(collection_path),
+            "collection_record_id": collection_record.id,
+            "raw_zip_record_id": raw_zip_record.id,
+            "species": "co2",
+            "processing_domain": "EUROPE",
+        },
+    ),
+    artifact_writer=CamsBoundaryConditionWriter(),
+)
+```
+
+The resulting record is a generic directory artifact whose locator points to the
+``.zarr`` store. The fact that it can be opened with xarray, and the provenance
+needed to rebuild it, are ordinary metadata rather than special ogcat core
+concepts.
+
+## Local CAMS zip to processed Zarr with temporary extraction
+
+The same operation can avoid a persistent extracted collection when the raw zip
+already lives on a filesystem visible to the processing job, such as a shared
+HPC/group filesystem. fsspec can still be useful here: the local path can be
+wrapped as a ``file://`` URL-path, opened through ``fsspec.open_local()``, and
+then treated as a zip filesystem. The writer extracts the NetCDF members into a
+temporary directory only long enough for ``xarray.open_mfdataset()`` and writes a
+single managed Zarr artifact.
+
+This pattern is useful when the intermediate NetCDF collection is an
+implementation detail of the processing step rather than an artifact you want to
+keep in the catalog.
+
+First record the local zip as a URL-path reference. This keeps the example on the
+same filesystem as the zip while still exercising the ``urlpath`` locator kind:
+
+```python
+from datetime import date
+from pathlib import Path
+
+from ogcat import ArtifactLocator
+
+shared_zip = Path(
+    "/group/chem/acrg/verification_games_round_2/"
+    "cams_bc/bab75005df9571750d518b0aacdedb35.zip"
+)
+shared_zip_urlpath = shared_zip.as_uri()
+
+local_zip_record = catalog.add_artifact(
+    record_type="raw_download",
+    locator=ArtifactLocator.from_urlpath(shared_zip_urlpath),
+    storage_mode="external",
+    metadata={
+        "species": "co2",
+        "product": "cams",
+        "title": "CAMS global inversion-optimised greenhouse gas fluxes and concentrations",
+        "domain": "global",
+        "source_url": ads_dataset,
+        "downloaded_from": "Copernicus Atmosphere Data Store",
+        "downloaded_on": date(2026, 3, 18).isoformat(),
+        "archive_name": "bab75005df9571750d518b0aacdedb35.zip",
+        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        "member_count": 36,
+        "time_coverage": "2020-01/2022-12",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+    },
+)
+```
+
+Then use a writer that opens the zip through fsspec, extracts the NetCDF members
+into a temporary directory, opens them with ``xarray.open_mfdataset()``, and
+removes the temporary files when the operation finishes. The target Zarr store is
+the only managed artifact created by this operation.
+
+```python
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import fsspec
+import xarray as xr
+
+from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+
+
+@dataclass(frozen=True)
+class LocalCamsZipToZarrWriter:
+    """Create a Zarr store directly from a local CAMS zip URL path."""
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        target_path = target.as_path()
+        if target_path is None:
+            raise ValueError("CAMS writer requires a local Zarr target.")
+        if target_path.exists():
+            raise FileExistsError(target_path)
+
+        zip_urlpath = str(source.metadata["zip_urlpath"])
+        species = str(source.metadata.get("species", "co2"))
+        processing_domain = str(source.metadata["processing_domain"])
+        member_pattern = str(source.metadata["member_pattern"])
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(
+            lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+            description=f"remove processed Zarr store {target_path}",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="ogcat-cams-") as work_dir:
+            work_path = Path(work_dir)
+            extracted_dir = work_path / "netcdf"
+            extracted_dir.mkdir()
+
+            local_zip = fsspec.open_local(zip_urlpath, mode="rb")
+            zip_fs = fsspec.filesystem("zip", fo=local_zip)
+            try:
+                input_paths: list[Path] = []
+                for member in sorted(zip_fs.glob(member_pattern)):
+                    local_member = extracted_dir / Path(member).name
+                    with zip_fs.open(member, "rb") as src, local_member.open("wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    input_paths.append(local_member)
+
+                with xr.open_mfdataset(input_paths) as ds:
+                    processed = create_cams_bc(ds, species=species, domain=processing_domain)
+                    processed.to_zarr(target_path, mode="w")
+            finally:
+                zip_fs.close()
+
+        context.derived_metadata.update(
+            {
+                "raw_zip_record_id": source.metadata["raw_zip_record_id"],
+                "zip_urlpath": zip_urlpath,
+                "member_pattern": member_pattern,
+                "input_file_count": len(input_paths),
+                "input_files": [path.name for path in input_paths],
+                "temporary_extract": "NetCDF members extracted inside a TemporaryDirectory",
+                "species": species,
+                "bc_input": "cams",
+                "bc_input_version": "cams73_latest",
+                "domain": processing_domain.lower(),
+                "reader_hint": "xarray.open_zarr",
+            }
+        )
+```
+
+Plan and run the processing step:
+
+```python
+local_processed_plan = catalog.plan_artifact(
+    record_type="boundary_conditions",
+    target_kind="directory",
+    write_mode="write",
+    metadata={
+        "species": "co2",
+        "domain": "europe",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+        "title": "CAMS CO2 boundary conditions for EUROPE",
+        "source_record_id": local_zip_record.id,
+        "source_url": ads_dataset,
+        "processing_domain": "EUROPE",
+        "provenance": {
+            "raw_zip_record_id": local_zip_record.id,
+            "operation": "create_cams_bc",
+            "opened_with": "xarray.open_mfdataset",
+            "zip_access": "fsspec zip filesystem over local file URL",
+        },
+    },
+)
+
+local_processed_record = catalog.add_artifact(
+    record_type="boundary_conditions",
+    storage_plan=local_processed_plan,
+    source=memory_source(
+        None,
+        kind="local_cams_zip_urlpath",
+        metadata={
+            "zip_urlpath": local_zip_record.locator.value,
+            "raw_zip_record_id": local_zip_record.id,
+            "species": "co2",
+            "processing_domain": "EUROPE",
+            "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        },
+    ),
+    artifact_writer=LocalCamsZipToZarrWriter(),
+)
+```
+
+This example still keeps fsspec and xarray out of ogcat core. ogcat records the
+local zip URL-path and the processed Zarr locator; the writer owns the temporary
+extracted NetCDF files, processing call, and cleanup. If the zip later moves to a
+remote filesystem, the same writer shape can be adapted to use fsspec URL
+chaining and a temporary ``simplecache`` directory before opening the zip
+filesystem.
+
+### Variant: build the fsspec chain at processing time
+
+The raw zip record does not need to know how it will be processed later. Keep the
+raw record as a plain path or URL-path reference, then decide during the
+processing operation whether to unzip permanently, read through fsspec, cache
+members temporarily, or use some other domain-specific strategy.
+
+In this variant, a hook builds the fsspec URL pattern only during the processing
+operation, immediately before the custom writer runs:
+
+```text
+simplecache::zip://cams73_latest_co2_conc_surface_inst_*.nc::file:///.../bab75005df9571750d518b0aacdedb35.zip
+```
+
+The existing ``resolve_artifact_locator`` hook is best kept for the artifact
+being written, which in this operation is the output Zarr store. The input
+interpretation belongs with this processing operation, so the example uses
+``before_validate_metadata`` to enrich the operation source instead of rewriting
+the raw data record.
+
+The chain uses fsspec's zip filesystem and ``simplecache``. fsspec's chaining
+syntax with ``::`` passes the nested path through each filesystem layer. With
+``simplecache`` as the outer layer, the selected zip members can be cached as
+local files in a directory chosen by the writer.
+
+The zip record stays faithful to the source file:
+
+```python
+zip_source_record = catalog.add_artifact(
+    record_type="raw_download",
+    locator=ArtifactLocator.from_path(shared_zip),
+    storage_mode="external",
+    metadata={
+        "species": "co2",
+        "product": "cams",
+        "title": "CAMS global inversion-optimised greenhouse gas fluxes and concentrations",
+        "domain": "global",
+        "source_url": ads_dataset,
+        "downloaded_from": "Copernicus Atmosphere Data Store",
+        "downloaded_on": date(2026, 3, 18).isoformat(),
+        "archive_name": shared_zip.name,
+        "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        "member_count": 36,
+        "time_coverage": "2020-01/2022-12",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+    },
+)
+```
+
+The processing operation receives the raw record's locator as source metadata. A
+hook converts that locator to a fsspec member pattern and stores it on
+``context.source.metadata``. The writer then gives ``simplecache`` a temporary
+directory, receives local cached member files from ``fsspec.open_local()``, opens
+them with xarray, and lets the temporary directory clean up the cache when it
+exits.
+
+```python
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import fsspec
+import xarray as xr
+
+from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+
+
+def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_pattern: str) -> str:
+    """Build a chained fsspec URL pattern for CAMS NetCDF members."""
+    if locator.kind == "path":
+        zip_url = Path(locator.value).as_uri()
+    elif locator.kind == "urlpath":
+        zip_url = locator.value
+    else:
+        raise ValueError(f"Cannot build a fsspec zip chain from {locator.kind!r}")
+    return f"simplecache::zip://{member_pattern}::{zip_url}"
+
+
+@dataclass(frozen=True)
+class CamsZipMemberUrlpathHook:
+    """Prepare a chained fsspec URL path for a CAMS processing operation."""
+
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        if context.record_type != "boundary_conditions":
+            return
+        if context.source.kind != "cams_zip_member_urlpath":
+            return
+
+        raw_locator = ArtifactLocator.from_dict(context.source.metadata["raw_locator"])
+        member_pattern = str(context.source.metadata["member_pattern"])
+        context.source.metadata["input_urlpath"] = cams_zip_member_urlpath(
+            raw_locator,
+            member_pattern=member_pattern,
+        )
+
+
+@dataclass(frozen=True)
+class CamsZipChainToZarrWriter:
+    """Create a Zarr store from a prepared fsspec zip-member URL path."""
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        target_path = target.as_path()
+        if target_path is None:
+            raise ValueError("CAMS writer requires a local Zarr target.")
+        if target_path.exists():
+            raise FileExistsError(target_path)
+
+        input_urlpath = str(source.metadata["input_urlpath"])
+        species = str(source.metadata.get("species", "co2"))
+        processing_domain = str(source.metadata["processing_domain"])
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(
+            lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+            description=f"remove processed Zarr store {target_path}",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="ogcat-cams-cache-") as cache_dir:
+            local_members = fsspec.open_local(
+                input_urlpath,
+                mode="rb",
+                simplecache={"cache_storage": cache_dir},
+            )
+            input_paths = [Path(path) for path in local_members]
+
+            with xr.open_mfdataset(input_paths) as ds:
+                processed = create_cams_bc(ds, species=species, domain=processing_domain)
+                processed.to_zarr(target_path, mode="w")
+
+        context.derived_metadata.update(
+            {
+                "raw_zip_record_id": source.metadata["raw_zip_record_id"],
+                "input_urlpath": input_urlpath,
+                "member_pattern": source.metadata["member_pattern"],
+                "input_file_count": len(input_paths),
+                "input_files": [path.name for path in input_paths],
+                "temporary_cache": "fsspec simplecache inside a TemporaryDirectory",
+                "species": species,
+                "bc_input": "cams",
+                "bc_input_version": "cams73_latest",
+                "domain": processing_domain.lower(),
+                "reader_hint": "xarray.open_zarr",
+            }
+        )
+```
+
+Then plan and write the final Zarr artifact:
+
+```python
+catalog.hook_manager.register(CamsZipMemberUrlpathHook())
+
+zip_chain_processed_plan = catalog.plan_artifact(
+    record_type="boundary_conditions",
+    target_kind="directory",
+    write_mode="write",
+    metadata={
+        "species": "co2",
+        "domain": "europe",
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+        "title": "CAMS CO2 boundary conditions for EUROPE",
+        "source_record_id": zip_source_record.id,
+        "source_url": ads_dataset,
+        "processing_domain": "EUROPE",
+        "provenance": {
+            "raw_zip_record_id": zip_source_record.id,
+            "operation": "create_cams_bc",
+            "opened_with": "xarray.open_mfdataset",
+            "zip_access": "writer built fsspec chain from raw locator",
+        },
+    },
+)
+
+zip_chain_processed_record = catalog.add_artifact(
+    record_type="boundary_conditions",
+    storage_plan=zip_chain_processed_plan,
+    source=memory_source(
+        None,
+        kind="cams_zip_member_urlpath",
+        metadata={
+            "raw_locator": zip_source_record.locator.to_dict(),
+            "raw_zip_record_id": zip_source_record.id,
+            "species": "co2",
+            "processing_domain": "EUROPE",
+            "member_pattern": "cams73_latest_co2_conc_surface_inst_*.nc",
+        },
+    ),
+    artifact_writer=CamsZipChainToZarrWriter(),
+)
+```
+
+This version leaves the raw record independent of the later processing strategy.
+The processing operation chooses the fsspec interpretation when the writer runs,
+so future workflows can use the same raw zip record with different extraction or
+transformation approaches.
+
+## URI reference followed by a download writer
+
+This pattern records an external URI first, then creates a managed local copy
+with a custom writer. It is useful when downloads are performed by ``requests``,
+``curl``, an authenticated client, or a project-specific API.
+
+The catalog can use UUIDs in storage names so the downloaded filename does not
+need to be meaningful:
+
+```python
+from pathlib import Path
+
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, RecordSchema
+
+catalog = Catalog.create(
+    Path("download-catalog"),
+    CatalogSpec(
+        catalog_name="downloads",
+        default_schema=RecordSchema(
+            directory_template="downloads/{year_added}",
+            filename_template="{uuid}{original_suffix}",
+        ),
+    ),
+)
+```
+
+Record the external reference:
+
+```python
+from datetime import date
+
+source_record = catalog.add_artifact(
+    record_type="download_reference",
+    locator=ArtifactLocator(kind="uri", value="https://example.org/data/example.nc"),
+    storage_mode="external",
+    metadata={
+        "species": "co2",
+        "product": "example",
+        "title": "Example downloadable CO2 data",
+        "download_page": "https://example.org/data",
+        "selected_options": {"format": "netcdf", "variable": "co2"},
+        "reference_recorded_on": date.today().isoformat(),
+    },
+)
+```
+
+Write a managed copy with a small requests-based writer:
+
+```python
+import requests
+
+from ogcat import OperationContext, OperationSource, memory_source
+
+
+class RequestsDownloadWriter:
+    """Download a URI to the planned local target."""
+
+    def write(self, context: OperationContext, source: OperationSource, target: ArtifactLocator) -> None:
+        target_path = target.as_path()
+        if target_path is None:
+            raise ValueError("Download writer requires a local path target.")
+        if target_path.exists():
+            raise FileExistsError(target_path)
+
+        url = str(source.metadata["url"])
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove download")
+
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+        target_path.write_bytes(response.content)
+
+        context.derived_metadata.update(
+            {
+                "source_record_id": source.metadata["source_record_id"],
+                "downloaded_from": url,
+                "downloaded_on": source.metadata["downloaded_on"],
+                "byte_count": target_path.stat().st_size,
+            }
+        )
+
+
+download_plan = catalog.plan_artifact(
+    Path("example.nc"),
+    write_mode="write",
+    metadata={
+        "species": "co2",
+        "product": "example",
+        "title": "Example downloaded CO2 data",
+        "source_record_id": source_record.id,
+    },
+)
+
+download_record = catalog.add_artifact(
+    record_type="downloaded_file",
+    storage_plan=download_plan,
+    source=memory_source(
+        None,
+        kind="download_uri",
+        metadata={
+            "url": source_record.locator.value,
+            "source_record_id": source_record.id,
+            "downloaded_on": date.today().isoformat(),
+        },
+    ),
+    artifact_writer=RequestsDownloadWriter(),
+)
+```
+
+This keeps the distinction clear: the URI record says where the data came from,
+and the managed file record says what was downloaded, where it was stored, and
+which source record it came from.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+fsspec = [
+  "fsspec>=2024.0",
+]
 netcdf = [
   "xarray>=2024.0",
 ]

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -7,6 +7,14 @@ from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
 from ogcat.search import FieldPath, SearchOp, SearchQuery, SearchTerm
 from ogcat.spec import CatalogSpec, RecordSchema
+from ogcat.storage import (
+    FsspecStorageBackend,
+    LocalStorageBackend,
+    StoragePlan,
+    backend_for_locator,
+    execute_storage_plan,
+    plan_storage,
+)
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import (
     ValidationIssue,
@@ -34,8 +42,10 @@ __all__ = [
     "CatalogRecordSet",
     "CatalogSpec",
     "FunctionArtifactWriter",
+    "FsspecStorageBackend",
     "HookManager",
     "HookWarning",
+    "LocalStorageBackend",
     "MetadataFieldDescription",
     "OperationState",
     "OperationContext",
@@ -47,6 +57,7 @@ __all__ = [
     "SearchOp",
     "SearchQuery",
     "SearchTerm",
+    "StoragePlan",
     "UnitOfWork",
     "UnzipArtifactWriter",
     "ValidationIssue",
@@ -59,5 +70,8 @@ __all__ = [
     "memory_writer",
     "path_source",
     "path_writer",
+    "backend_for_locator",
+    "execute_storage_plan",
+    "plan_storage",
     "source_writer",
 ]

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -8,12 +8,17 @@ from ogcat.record_set import CatalogRecordSet
 from ogcat.search import FieldPath, SearchOp, SearchQuery, SearchTerm
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.storage import (
-    FsspecStorageBackend,
-    LocalStorageBackend,
+    FsspecStorageAdapter,
+    LocalStorageAdapter,
     StoragePlan,
-    backend_for_locator,
-    execute_storage_plan,
+    adapter_for_locator,
+    create_directory_target,
+    ensure_parent_directory,
+    ensure_target_absent,
     plan_storage,
+    remove_target,
+    require_local_path,
+    require_storage_target,
 )
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import (
@@ -25,7 +30,9 @@ from ogcat.validation import (
     validate_spec,
 )
 from ogcat.writers import (
+    CopyArtifactWriter,
     FunctionArtifactWriter,
+    MoveArtifactWriter,
     UnzipArtifactWriter,
     memory_source,
     memory_writer,
@@ -41,12 +48,14 @@ __all__ = [
     "CatalogRecord",
     "CatalogRecordSet",
     "CatalogSpec",
+    "CopyArtifactWriter",
+    "FsspecStorageAdapter",
     "FunctionArtifactWriter",
-    "FsspecStorageBackend",
     "HookManager",
     "HookWarning",
-    "LocalStorageBackend",
+    "LocalStorageAdapter",
     "MetadataFieldDescription",
+    "MoveArtifactWriter",
     "OperationState",
     "OperationContext",
     "OperationSource",
@@ -70,8 +79,13 @@ __all__ = [
     "memory_writer",
     "path_source",
     "path_writer",
-    "backend_for_locator",
-    "execute_storage_plan",
+    "adapter_for_locator",
+    "create_directory_target",
+    "ensure_parent_directory",
+    "ensure_target_absent",
     "plan_storage",
+    "remove_target",
+    "require_local_path",
+    "require_storage_target",
     "source_writer",
 ]

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
@@ -785,7 +786,9 @@ class Catalog:
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
-                exists=lambda _candidate: False,
+                exists=lambda candidate: _urlpath_exists_if_supported(
+                    _join_urlpath(root_url, candidate.relative_to(fake_root).as_posix())
+                ),
             )
             relative_path = target.relative_to(fake_root).as_posix()
             return ArtifactLocator.from_urlpath(
@@ -913,6 +916,8 @@ class Catalog:
             self.hook_manager.resolve_artifact_locator(hook_context)
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
+            if naming_metadata is not None and "resolved_filename" in naming_metadata:
+                naming_metadata["resolved_filename"] = _filename_from_locator(canonical_locator)
             hook_context.storage_plan = (
                 storage_plan_factory(hook_context, canonical_locator)
                 if storage_plan_factory is not None
@@ -1087,6 +1092,25 @@ def _adapter_name(locator: ArtifactLocator) -> str | None:
     return None
 
 
+def _urlpath_exists_if_supported(urlpath: str) -> bool:
+    """Return whether a URL path exists when fsspec is installed.
+
+    Args:
+        urlpath: URL path to check.
+
+    Returns:
+        ``True`` when the fsspec target exists. Returns ``False`` when fsspec is
+        not installed so planning can remain a dry-run without optional storage
+        dependencies.
+    """
+    if importlib.util.find_spec("fsspec") is None:
+        return False
+    from ogcat.storage import adapter_for_locator
+
+    locator = ArtifactLocator.from_urlpath(urlpath)
+    return adapter_for_locator(locator).exists(locator)
+
+
 def _is_urlpath_root(value: str | Path) -> bool:
     """Return whether a storage root should be treated as an fsspec URL."""
     return isinstance(value, str) and "://" in value
@@ -1113,6 +1137,13 @@ def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator
     if not context.planned_locators:
         raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
     return context.planned_locators[0]
+
+
+def _filename_from_locator(locator: ArtifactLocator) -> str:
+    """Return the final filename-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).name
+    return locator.value.rstrip("/").rsplit("/", 1)[-1]
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -20,17 +20,17 @@ from ogcat.repository import CatalogRepository
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.storage import (
-    LocalStorageBackend,
+    LocalStorageAdapter,
     StoragePlan,
     TargetKind,
     WriteMode,
-    backend_for_locator,
-    execute_storage_plan,
+    adapter_for_locator,
     plan_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import OperationState, UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
+from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
@@ -175,16 +175,16 @@ class Catalog:
                 metadata=context.user_metadata,
                 date_added=timestamp[:10],
             )
-            storage_backend = LocalStorageBackend()
+            storage_adapter = LocalStorageAdapter()
             target, rel_path, _resolved_filename = render_storage_location(
                 files_root=files_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
-                exists=lambda candidate: storage_backend.exists(ArtifactLocator.path(candidate)),
+                exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
             )
             naming_metadata["resolved_filename"] = _resolved_filename
-            return ArtifactLocator.path(target, relative_path=rel_path)
+            return ArtifactLocator.from_path(target, relative_path=rel_path)
 
         def plan_local_file_storage(
             context: OperationContext,
@@ -193,11 +193,10 @@ class Catalog:
             """Build the storage plan for a managed local file."""
             return plan_storage(
                 locator,
-                source=ArtifactLocator.path(source),
                 target_kind="file",
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
-                backend="local",
+                adapter="local",
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
@@ -205,6 +204,9 @@ class Catalog:
             context.derived_metadata.update(extract_derived_metadata(_path_from_locator(locator)))
 
         source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
+        artifact_writer: ArtifactWriter = (
+            CopyArtifactWriter() if chosen_operation == "copy" else MoveArtifactWriter()
+        )
         with self.transaction() as transaction:
             return self._run_add_operation(
                 transaction=transaction,
@@ -224,6 +226,7 @@ class Catalog:
                 source=source_description,
                 locator_factory=resolve_local_file_locator,
                 storage_plan_factory=plan_local_file_storage,
+                artifact_writer=artifact_writer,
                 derived_metadata_collector=collect_file_metadata,
             )
 
@@ -307,11 +310,10 @@ class Catalog:
         canonical_locator = _artifact_locator_from_context(context)
         plan = plan_storage(
             canonical_locator,
-            source=None if source_path is None else ArtifactLocator.path(source_path),
             target_kind=target_kind,
             write_mode=resolved_write_mode,
             ogcat_owned=ogcat_owned,
-            backend=_backend_name(canonical_locator),
+            adapter=_adapter_name(canonical_locator),
         )
         context.storage_plan = plan
         return plan
@@ -777,22 +779,22 @@ class Catalog:
             root_url = str(storage_root).rstrip("/")
             fake_root = Path("/__ogcat_storage__")
 
-            def storage_backend_locator(candidate: Path) -> ArtifactLocator:
+            def storage_adapter_locator(candidate: Path) -> ArtifactLocator:
                 """Build a URL locator for a candidate rendered path."""
                 relative_path = candidate.relative_to(fake_root).as_posix()
-                return ArtifactLocator.urlpath(_join_urlpath(root_url, relative_path))
+                return ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path))
 
             target, _rel_path, _resolved_filename = render_storage_location(
                 files_root=fake_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
-                exists=lambda candidate: backend_for_locator(storage_backend_locator(candidate)).exists(
-                    storage_backend_locator(candidate)
+                exists=lambda candidate: adapter_for_locator(storage_adapter_locator(candidate)).exists(
+                    storage_adapter_locator(candidate)
                 ),
             )
             relative_path = target.relative_to(fake_root).as_posix()
-            return ArtifactLocator.urlpath(
+            return ArtifactLocator.from_urlpath(
                 _join_urlpath(root_url, relative_path),
                 relative_path=relative_path,
             )
@@ -801,15 +803,15 @@ class Catalog:
             files_root = self.root / self.spec.files_root
         else:
             files_root = Path(storage_root).expanduser().resolve()
-        storage_backend = LocalStorageBackend()
+        storage_adapter = LocalStorageAdapter()
         target, rel_path, _resolved_filename = render_storage_location(
             files_root=files_root,
             directory_template=directory_template,
             filename_template=filename_template,
             context=naming_context,
-            exists=lambda candidate: storage_backend.exists(ArtifactLocator.path(candidate)),
+            exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
         )
-        return ArtifactLocator.path(target, relative_path=rel_path)
+        return ArtifactLocator.from_path(target, relative_path=rel_path)
 
     def _add_artifact_in_transaction(
         self,
@@ -923,25 +925,20 @@ class Catalog:
                     canonical_locator,
                     write_mode="reference",
                     ogcat_owned=False,
-                    backend=_backend_name(canonical_locator),
+                    adapter=_adapter_name(canonical_locator),
                 )
             )
-            if artifact_writer is not None:
-                artifact_writer.write(hook_context, hook_context.source, canonical_locator)
             storage_plan = hook_context.storage_plan
             if storage_plan is None:
                 raise RuntimeError("Add operation did not produce a storage plan.")
-            if artifact_writer is None and storage_plan.write_mode != "reference":
-
-                def register_storage_rollback(action: Callable[[], None], description: str) -> None:
-                    """Register storage cleanup with the active operation."""
-                    hook_context.rollback(action, description=description)
-
-                execute_storage_plan(
-                    storage_plan,
-                    source_path=hook_context.source.path,
-                    register_rollback=register_storage_rollback,
-                )
+            if artifact_writer is None:
+                if storage_plan.write_mode != "reference":
+                    raise ValueError(
+                        f"Storage plan with write mode {storage_plan.write_mode!r} "
+                        "requires an artifact_writer."
+                    )
+            else:
+                artifact_writer.write(hook_context, hook_context.source, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
@@ -1083,11 +1080,11 @@ def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> S
     """Return a storage plan adjusted to a hook-resolved canonical locator."""
     if plan.locator == locator:
         return plan
-    return replace(plan, locator=locator, backend=_backend_name(locator))
+    return replace(plan, locator=locator, adapter=_adapter_name(locator))
 
 
-def _backend_name(locator: ArtifactLocator) -> str | None:
-    """Return the storage backend name implied by a locator."""
+def _adapter_name(locator: ArtifactLocator) -> str | None:
+    """Return the storage adapter name implied by a locator."""
     if locator.kind == "path":
         return "local"
     if locator.kind == "urlpath":

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import shutil
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, cast, overload
+from uuid import uuid4
 
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, OperationContext, OperationSource
@@ -19,11 +19,21 @@ from ogcat.record_set import CatalogRecordSet
 from ogcat.repository import CatalogRepository
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
+from ogcat.storage import (
+    LocalStorageBackend,
+    StoragePlan,
+    TargetKind,
+    WriteMode,
+    backend_for_locator,
+    execute_storage_plan,
+    plan_storage,
+)
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import OperationState, UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
 
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
+StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 
 
@@ -165,23 +175,36 @@ class Catalog:
                 metadata=context.user_metadata,
                 date_added=timestamp[:10],
             )
+            storage_backend = LocalStorageBackend()
             target, rel_path, _resolved_filename = render_storage_location(
                 files_root=files_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
+                exists=lambda candidate: storage_backend.exists(ArtifactLocator.path(candidate)),
             )
+            naming_metadata["resolved_filename"] = _resolved_filename
             return ArtifactLocator.path(target, relative_path=rel_path)
+
+        def plan_local_file_storage(
+            context: OperationContext,
+            locator: ArtifactLocator,
+        ) -> StoragePlan:
+            """Build the storage plan for a managed local file."""
+            return plan_storage(
+                locator,
+                source=ArtifactLocator.path(source),
+                target_kind="file",
+                write_mode=cast(WriteMode, chosen_operation),
+                ogcat_owned=True,
+                backend="local",
+            )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
             """Collect generic derived metadata from the written file."""
             context.derived_metadata.update(extract_derived_metadata(_path_from_locator(locator)))
 
         source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
-        writer = _LocalFileArtifactWriter(
-            operation=chosen_operation,
-            naming_metadata=naming_metadata,
-        )
         with self.transaction() as transaction:
             return self._run_add_operation(
                 transaction=transaction,
@@ -200,15 +223,105 @@ class Catalog:
                 time_added=timestamp,
                 source=source_description,
                 locator_factory=resolve_local_file_locator,
-                artifact_writer=writer,
+                storage_plan_factory=plan_local_file_storage,
                 derived_metadata_collector=collect_file_metadata,
             )
+
+    def plan_artifact(
+        self,
+        path: str | Path | None = None,
+        *,
+        record_type: str | None = None,
+        metadata: MetadataDict | None = None,
+        locator: ArtifactLocator | None = None,
+        target_kind: TargetKind = "file",
+        write_mode: WriteMode | None = None,
+        ogcat_owned: bool = True,
+        storage_root: str | Path | None = None,
+    ) -> StoragePlan:
+        """Plan an artifact location without writing data or a catalog record.
+
+        Args:
+            path: Optional local source path used for naming and copy/move
+                plans.
+            record_type: Optional named schema to validate and use for naming.
+            metadata: JSON-compatible user metadata.
+            locator: Optional pre-resolved target locator. When omitted,
+                schema naming templates are rendered under ``storage_root`` or
+                this catalog's managed files root.
+            target_kind: Whether the target is a file-like or directory-like
+                artifact.
+            write_mode: Desired materialisation mode. Defaults to ``"write"``
+                for owned artifacts and ``"reference"`` otherwise.
+            ogcat_owned: Whether ogcat should treat the target as managed.
+            storage_root: Optional local root or fsspec URL root for rendered
+                template targets.
+
+        Returns:
+            Planned storage decision.
+        """
+        metadata_input = {} if metadata is None else metadata
+        schema = self._select_schema(record_type, require_known=record_type is not None)
+        schema_name = self._schema_name(record_type)
+        user_metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
+        resolved_record_type = "managed_artifact" if record_type is None else record_type
+        resolved_write_mode = write_mode or ("write" if ogcat_owned else "reference")
+        source_path = None if path is None else Path(path).expanduser().resolve()
+        operation_id = uuid4().hex
+        source = OperationSource(
+            kind="planned_artifact" if source_path is None else "local_file",
+            path=source_path,
+            descriptor=None if source_path is None else str(source_path),
+        )
+        context = OperationContext(
+            catalog_root=self.root,
+            operation_id=operation_id,
+            operation_type="plan_artifact",
+            record_type=resolved_record_type,
+            user_metadata=user_metadata,
+            source=source,
+            storage_mode=resolved_write_mode,
+            original_path=source_path,
+            original_filename=None if source_path is None else source_path.name,
+            suffixes=[] if source_path is None else list(source_path.suffixes),
+        )
+
+        self.hook_manager.before_validate_metadata(context)
+        validation_report = self._metadata_validation_report(
+            schema=schema,
+            metadata=context.user_metadata,
+            record_type=record_type,
+        )
+        self.hook_manager.after_validate_metadata(context, validation_report)
+        validation_report.raise_for_errors()
+
+        planned_locator = locator or self._render_planned_locator(
+            context=context,
+            schema=schema,
+            record_type=record_type,
+            source_path=source_path,
+            storage_root=storage_root,
+        )
+        context.planned_locators = [planned_locator]
+        self.hook_manager.resolve_artifact_locator(context)
+        canonical_locator = _artifact_locator_from_context(context)
+        plan = plan_storage(
+            canonical_locator,
+            source=None if source_path is None else ArtifactLocator.path(source_path),
+            target_kind=target_kind,
+            write_mode=resolved_write_mode,
+            ogcat_owned=ogcat_owned,
+            backend=_backend_name(canonical_locator),
+        )
+        context.storage_plan = plan
+        return plan
 
     def add_artifact(
         self,
         *,
         record_type: str,
-        locator: ArtifactLocator,
+        locator: ArtifactLocator | None = None,
+        storage_plan: StoragePlan | None = None,
         metadata: MetadataDict | None = None,
         storage_mode: str | None = None,
         original_path: str | Path | None = None,
@@ -221,7 +334,7 @@ class Catalog:
         artifact_writer: ArtifactWriter | None = None,
         transaction: UnitOfWork | None = None,
     ) -> CatalogRecord:
-        """Add an artifact record without performing any file operation.
+        """Add an artifact record and optionally materialise planned storage.
 
         This is the minimal general record API. ``add_file()`` remains the
         managed ingest convenience wrapper that prepares a path-backed locator
@@ -229,7 +342,10 @@ class Catalog:
 
         Args:
             record_type: Logical type of record to create.
-            locator: Artifact locator to store with the record.
+            locator: Artifact locator to store with the record. Required unless
+                ``storage_plan`` is supplied.
+            storage_plan: Optional planned storage decision to use instead of a
+                standalone locator.
             metadata: JSON-compatible user metadata.
             storage_mode: Optional description such as ``"external"``.
             original_path: Optional source path or URI.
@@ -251,6 +367,15 @@ class Catalog:
             ValueError: If validation fails or the transaction belongs to a
                 different repository.
         """
+        if locator is None and storage_plan is None:
+            raise ValueError("add_artifact requires either locator or storage_plan.")
+        if locator is not None and storage_plan is not None:
+            raise ValueError("Pass either locator or storage_plan, not both.")
+        if storage_plan is not None:
+            locator = storage_plan.locator
+            if storage_mode is None:
+                storage_mode = storage_plan.write_mode
+        assert locator is not None
         metadata_input = {} if metadata is None else metadata
         derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
         schema = self._select_schema(record_type, require_known=False)
@@ -276,6 +401,7 @@ class Catalog:
                 time_added=time_added,
                 source=validated_source,
                 artifact_writer=validated_artifact_writer,
+                storage_plan=storage_plan,
                 schema=schema,
             )
         with self.transaction() as unit_of_work:
@@ -294,6 +420,7 @@ class Catalog:
                 time_added=time_added,
                 source=validated_source,
                 artifact_writer=validated_artifact_writer,
+                storage_plan=storage_plan,
                 schema=schema,
             )
 
@@ -329,12 +456,15 @@ class Catalog:
 
         records: list[CatalogRecord] = []
         for index, validated in enumerate(validated_items):
-            try:
-                locator = _coerce_artifact_locator(validated["locator"])
-            except TypeError as exc:
-                raise TypeError(f"artifact batch item {index}: invalid locator: {exc}") from exc
-            except ValueError as exc:
-                raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
+            storage_plan = _optional_storage_plan(validated.get("storage_plan"))
+            locator: ArtifactLocator | None = None
+            if storage_plan is None:
+                try:
+                    locator = _coerce_artifact_locator(validated["locator"])
+                except TypeError as exc:
+                    raise TypeError(f"artifact batch item {index}: invalid locator: {exc}") from exc
+                except ValueError as exc:
+                    raise ValueError(f"artifact batch item {index}: invalid locator: {exc}") from exc
 
             record_type = str(validated["record_type"])
             try:
@@ -342,6 +472,7 @@ class Catalog:
                     self.add_artifact(
                         record_type=record_type,
                         locator=locator,
+                        storage_plan=storage_plan,
                         metadata=validated.get("metadata"),  # type: ignore[arg-type]
                         storage_mode=(
                             None if validated.get("storage_mode") is None else str(validated["storage_mode"])
@@ -621,6 +752,65 @@ class Catalog:
             naming_metadata={} if naming_metadata is None else dict(naming_metadata),
         )
 
+    def _render_planned_locator(
+        self,
+        *,
+        context: OperationContext,
+        schema: RecordSchema,
+        record_type: str | None,
+        source_path: Path | None,
+        storage_root: str | Path | None,
+    ) -> ArtifactLocator:
+        """Render schema naming templates into a local or fsspec target locator."""
+        directory_template = _require_template(schema.directory_template, field_name="directory_template")
+        filename_template = _require_template(schema.filename_template, field_name="filename_template")
+        naming_source = source_path or Path("artifact")
+        naming_context = build_naming_context(
+            record_id=context.operation_id,
+            operation_id=context.operation_id,
+            original_path=naming_source,
+            metadata=context.user_metadata,
+            date_added=_utc_timestamp()[:10],
+        )
+
+        if storage_root is not None and _is_urlpath_root(storage_root):
+            root_url = str(storage_root).rstrip("/")
+            fake_root = Path("/__ogcat_storage__")
+
+            def storage_backend_locator(candidate: Path) -> ArtifactLocator:
+                """Build a URL locator for a candidate rendered path."""
+                relative_path = candidate.relative_to(fake_root).as_posix()
+                return ArtifactLocator.urlpath(_join_urlpath(root_url, relative_path))
+
+            target, _rel_path, _resolved_filename = render_storage_location(
+                files_root=fake_root,
+                directory_template=directory_template,
+                filename_template=filename_template,
+                context=naming_context,
+                exists=lambda candidate: backend_for_locator(storage_backend_locator(candidate)).exists(
+                    storage_backend_locator(candidate)
+                ),
+            )
+            relative_path = target.relative_to(fake_root).as_posix()
+            return ArtifactLocator.urlpath(
+                _join_urlpath(root_url, relative_path),
+                relative_path=relative_path,
+            )
+
+        if storage_root is None:
+            files_root = self.root / self.spec.files_root
+        else:
+            files_root = Path(storage_root).expanduser().resolve()
+        storage_backend = LocalStorageBackend()
+        target, rel_path, _resolved_filename = render_storage_location(
+            files_root=files_root,
+            directory_template=directory_template,
+            filename_template=filename_template,
+            context=naming_context,
+            exists=lambda candidate: storage_backend.exists(ArtifactLocator.path(candidate)),
+        )
+        return ArtifactLocator.path(target, relative_path=rel_path)
+
     def _add_artifact_in_transaction(
         self,
         *,
@@ -638,6 +828,7 @@ class Catalog:
         time_added: str | None,
         source: OperationSource | None,
         artifact_writer: ArtifactWriter | None,
+        storage_plan: StoragePlan | None,
         schema: RecordSchema,
     ) -> CatalogRecord:
         """Add an artifact record within an active transaction."""
@@ -664,6 +855,14 @@ class Catalog:
             source=operation_source,
             locator_factory=lambda context: locator,
             artifact_writer=artifact_writer,
+            storage_plan_factory=(
+                None
+                if storage_plan is None
+                else lambda context, canonical_locator: _storage_plan_with_locator(
+                    storage_plan,
+                    canonical_locator,
+                )
+            ),
         )
 
     def _run_add_operation(
@@ -685,6 +884,7 @@ class Catalog:
         time_added: str | None,
         source: OperationSource,
         locator_factory: ArtifactLocatorFactory,
+        storage_plan_factory: StoragePlanFactory | None = None,
         artifact_writer: ArtifactWriter | None = None,
         derived_metadata_collector: DerivedMetadataCollector | None = None,
     ) -> CatalogRecord:
@@ -716,8 +916,32 @@ class Catalog:
             self.hook_manager.resolve_artifact_locator(hook_context)
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
+            hook_context.storage_plan = (
+                storage_plan_factory(hook_context, canonical_locator)
+                if storage_plan_factory is not None
+                else plan_storage(
+                    canonical_locator,
+                    write_mode="reference",
+                    ogcat_owned=False,
+                    backend=_backend_name(canonical_locator),
+                )
+            )
             if artifact_writer is not None:
                 artifact_writer.write(hook_context, hook_context.source, canonical_locator)
+            storage_plan = hook_context.storage_plan
+            if storage_plan is None:
+                raise RuntimeError("Add operation did not produce a storage plan.")
+            if artifact_writer is None and storage_plan.write_mode != "reference":
+
+                def register_storage_rollback(action: Callable[[], None], description: str) -> None:
+                    """Register storage cleanup with the active operation."""
+                    hook_context.rollback(action, description=description)
+
+                execute_storage_plan(
+                    storage_plan,
+                    source_path=hook_context.source.path,
+                    register_rollback=register_storage_rollback,
+                )
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
@@ -855,42 +1079,30 @@ def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
     return metadata
 
 
-@dataclass(slots=True)
-class _LocalFileArtifactWriter:
-    """Artifact writer for the bundled managed local-file operation."""
+def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
+    """Return a storage plan adjusted to a hook-resolved canonical locator."""
+    if plan.locator == locator:
+        return plan
+    return replace(plan, locator=locator, backend=_backend_name(locator))
 
-    operation: str
-    naming_metadata: MetadataDict
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        """Copy or move a local source file to the target path locator."""
-        if source.path is None:
-            raise ValueError("Local file writer requires a path-backed operation source.")
+def _backend_name(locator: ArtifactLocator) -> str | None:
+    """Return the storage backend name implied by a locator."""
+    if locator.kind == "path":
+        return "local"
+    if locator.kind == "urlpath":
+        return "fsspec"
+    return None
 
-        target_path = _path_from_locator(target)
-        self.naming_metadata["resolved_filename"] = target_path.name
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        if self.operation == "copy":
-            context.rollback(
-                lambda path=target_path: path.unlink(missing_ok=True),
-                description=f"remove copied file {target_path}",
-            )
-            shutil.copy2(source.path, target_path)
-            return
 
-        context.rollback(
-            lambda source_path=source.path, target_path=target_path: _rollback_moved_file(
-                source_path=source_path,
-                target_path=target_path,
-            ),
-            description=f"restore moved file from {target_path} to {source.path}",
-        )
-        shutil.move(str(source.path), str(target_path))
+def _is_urlpath_root(value: str | Path) -> bool:
+    """Return whether a storage root should be treated as an fsspec URL."""
+    return isinstance(value, str) and "://" in value
+
+
+def _join_urlpath(root_url: str, relative_path: str) -> str:
+    """Join an fsspec URL root and relative path without local path coercion."""
+    return f"{root_url.rstrip('/')}/{relative_path.lstrip('/')}"
 
 
 def _coerce_metadata_input(
@@ -917,17 +1129,6 @@ def _path_from_locator(locator: ArtifactLocator) -> Path:
     if path is None:
         raise ValueError("Managed file operations require a path-backed artifact locator.")
     return path
-
-
-def _rollback_moved_file(*, source_path: Path, target_path: Path) -> None:
-    """Restore a moved file when possible, otherwise remove the moved target."""
-    if not target_path.exists():
-        return
-    if not source_path.exists():
-        source_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(target_path), str(source_path))
-        return
-    target_path.unlink(missing_ok=True)
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:
@@ -978,6 +1179,15 @@ def _optional_artifact_writer(value: object) -> ArtifactWriter | None:
     return _validate_artifact_writer(value)
 
 
+def _optional_storage_plan(value: object) -> StoragePlan | None:
+    """Return an optional storage plan for artifact batch forwarding."""
+    if value is None:
+        return None
+    if isinstance(value, StoragePlan):
+        return value
+    raise TypeError(f"storage_plan must be a StoragePlan, got {type(value).__name__}")
+
+
 def _validate_artifact_writer(value: object) -> ArtifactWriter | None:
     """Return an artifact writer when the optional value implements the writer protocol."""
     if value is None:
@@ -992,10 +1202,14 @@ def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]
     if not isinstance(item, dict):
         raise TypeError(f"artifact batch item {index} must be a dictionary")
 
-    missing_keys = [key for key in ["record_type", "locator"] if key not in item]
+    missing_keys = [key for key in ["record_type"] if key not in item]
+    if "locator" not in item and "storage_plan" not in item:
+        missing_keys.append("locator or storage_plan")
     if missing_keys:
         missing = ", ".join(missing_keys)
         raise ValueError(f"artifact batch item {index} is missing required key(s): {missing}")
+    if "locator" in item and "storage_plan" in item:
+        raise ValueError(f"artifact batch item {index} must not supply both locator and storage_plan")
     forbidden_id_keys = [key for key in ["record_id", "id"] if key in item]
     if forbidden_id_keys:
         forbidden = ", ".join(forbidden_id_keys)

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -272,6 +272,7 @@ class Catalog:
         resolved_record_type = "managed_artifact" if record_type is None else record_type
         resolved_write_mode = write_mode or ("write" if ogcat_owned else "reference")
         source_path = None if path is None else Path(path).expanduser().resolve()
+        timestamp = _utc_timestamp()
         operation_id = uuid4().hex
         source = OperationSource(
             kind="planned_artifact" if source_path is None else "local_file",
@@ -306,6 +307,7 @@ class Catalog:
             record_type=record_type,
             source_path=source_path,
             storage_root=storage_root,
+            date_added=timestamp[:10],
         )
         context.planned_locators = [planned_locator]
         self.hook_manager.resolve_artifact_locator(context)
@@ -316,6 +318,7 @@ class Catalog:
             write_mode=resolved_write_mode,
             ogcat_owned=ogcat_owned,
             adapter=_adapter_name(canonical_locator),
+            time_added=timestamp,
         )
         context.storage_plan = plan
         return plan
@@ -379,6 +382,8 @@ class Catalog:
             locator = storage_plan.locator
             if storage_mode is None:
                 storage_mode = storage_plan.write_mode
+            if time_added is None:
+                time_added = storage_plan.time_added
         assert locator is not None
         metadata_input = {} if metadata is None else metadata
         derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
@@ -764,6 +769,7 @@ class Catalog:
         record_type: str | None,
         source_path: Path | None,
         storage_root: str | Path | None,
+        date_added: str,
     ) -> ArtifactLocator:
         """Render schema naming templates into a local or fsspec target locator."""
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
@@ -774,7 +780,7 @@ class Catalog:
             operation_id=context.operation_id,
             original_path=naming_source,
             metadata=context.user_metadata,
-            date_added=_utc_timestamp()[:10],
+            date_added=date_added,
         )
 
         if storage_root is not None and _is_urlpath_root(storage_root):
@@ -920,8 +926,9 @@ class Catalog:
                 if storage_plan_factory is not None
                 else plan_storage(
                     canonical_locator,
-                    write_mode="reference",
-                    ogcat_owned=False,
+                    target_kind=_target_kind_from_writer(artifact_writer),
+                    write_mode=_write_mode_from_writer(artifact_writer),
+                    ogcat_owned=artifact_writer is not None,
                     adapter=_adapter_name(canonical_locator),
                 )
             )
@@ -1078,6 +1085,26 @@ def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> S
     if plan.locator == locator:
         return plan
     return replace(plan, locator=locator, adapter=_adapter_name(locator))
+
+
+def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
+    """Infer a storage target kind from a writer when it declares one."""
+    if artifact_writer is None:
+        return "file"
+    target_kind = getattr(artifact_writer, "target_kind", "file")
+    if target_kind in {"file", "directory"}:
+        return cast(TargetKind, target_kind)
+    return "file"
+
+
+def _write_mode_from_writer(artifact_writer: ArtifactWriter | None) -> WriteMode:
+    """Infer a storage write mode from a writer when it declares one."""
+    if artifact_writer is None:
+        return "reference"
+    write_mode = getattr(artifact_writer, "write_mode", "write")
+    if write_mode in {"copy", "move", "write", "reference"}:
+        return cast(WriteMode, write_mode)
+    return "write"
 
 
 def _adapter_name(locator: ArtifactLocator) -> str | None:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -791,10 +791,7 @@ class Catalog:
                 ),
             )
             relative_path = target.relative_to(fake_root).as_posix()
-            return ArtifactLocator.from_urlpath(
-                _join_urlpath(root_url, relative_path),
-                relative_path=relative_path,
-            )
+            return ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path))
 
         if storage_root is None:
             files_root = self.root / self.spec.files_root
@@ -1099,16 +1096,19 @@ def _urlpath_exists_if_supported(urlpath: str) -> bool:
         urlpath: URL path to check.
 
     Returns:
-        ``True`` when the fsspec target exists. Returns ``False`` when fsspec is
-        not installed so planning can remain a dry-run without optional storage
-        dependencies.
+        ``True`` when the fsspec target exists. Returns ``False`` when fsspec or
+        a protocol-specific dependency is not installed so planning can remain a
+        dry-run without optional storage dependencies.
     """
     if importlib.util.find_spec("fsspec") is None:
         return False
     from ogcat.storage import adapter_for_locator
 
     locator = ArtifactLocator.from_urlpath(urlpath)
-    return adapter_for_locator(locator).exists(locator)
+    try:
+        return adapter_for_locator(locator).exists(locator)
+    except ImportError:
+        return False
 
 
 def _is_urlpath_root(value: str | Path) -> bool:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -24,7 +24,6 @@ from ogcat.storage import (
     StoragePlan,
     TargetKind,
     WriteMode,
-    adapter_for_locator,
     plan_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
@@ -196,12 +195,14 @@ class Catalog:
                 target_kind="file",
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
-                adapter="local",
+                adapter=_adapter_name(locator),
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
             """Collect generic derived metadata from the written file."""
-            context.derived_metadata.update(extract_derived_metadata(_path_from_locator(locator)))
+            locator_path = locator.as_path()
+            if locator_path is not None:
+                context.derived_metadata.update(extract_derived_metadata(locator_path))
 
         source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
         artifact_writer: ArtifactWriter = (
@@ -779,19 +780,12 @@ class Catalog:
             root_url = str(storage_root).rstrip("/")
             fake_root = Path("/__ogcat_storage__")
 
-            def storage_adapter_locator(candidate: Path) -> ArtifactLocator:
-                """Build a URL locator for a candidate rendered path."""
-                relative_path = candidate.relative_to(fake_root).as_posix()
-                return ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path))
-
             target, _rel_path, _resolved_filename = render_storage_location(
                 files_root=fake_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
-                exists=lambda candidate: adapter_for_locator(storage_adapter_locator(candidate)).exists(
-                    storage_adapter_locator(candidate)
-                ),
+                exists=lambda _candidate: False,
             )
             relative_path = target.relative_to(fake_root).as_posix()
             return ArtifactLocator.from_urlpath(
@@ -811,7 +805,8 @@ class Catalog:
             context=naming_context,
             exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
         )
-        return ArtifactLocator.from_path(target, relative_path=rel_path)
+        relative_path = rel_path if storage_root is None else None
+        return ArtifactLocator.from_path(target, relative_path=relative_path)
 
     def _add_artifact_in_transaction(
         self,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -35,6 +35,7 @@ from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
+PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
 
 
 @dataclass(slots=True)
@@ -197,6 +198,11 @@ class Catalog:
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
                 adapter=_adapter_name(locator),
+                storage_relative_path=locator.relative_path,
+                resolved_directory=(
+                    None if locator.relative_path is None else Path(locator.relative_path).parent.as_posix()
+                ),
+                resolved_filename=_filename_from_locator(locator),
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
@@ -232,7 +238,7 @@ class Catalog:
                 derived_metadata_collector=collect_file_metadata,
             )
 
-    def plan_artifact(
+    def plan_artifact_storage(
         self,
         path: str | Path | None = None,
         *,
@@ -244,7 +250,7 @@ class Catalog:
         ogcat_owned: bool = True,
         storage_root: str | Path | None = None,
     ) -> StoragePlan:
-        """Plan an artifact location without writing data or a catalog record.
+        """Plan artifact storage without writing data or a catalog record.
 
         Args:
             path: Optional local source path used for naming and copy/move
@@ -282,7 +288,7 @@ class Catalog:
         context = OperationContext(
             catalog_root=self.root,
             operation_id=operation_id,
-            operation_type="plan_artifact",
+            operation_type="plan_artifact_storage",
             record_type=resolved_record_type,
             user_metadata=user_metadata,
             source=source,
@@ -301,17 +307,32 @@ class Catalog:
         self.hook_manager.after_validate_metadata(context, validation_report)
         validation_report.raise_for_errors()
 
-        planned_locator = locator or self._render_planned_locator(
-            context=context,
-            schema=schema,
-            record_type=record_type,
-            source_path=source_path,
-            storage_root=storage_root,
-            date_added=timestamp[:10],
-        )
+        if locator is None:
+            (
+                planned_locator,
+                storage_relative_path,
+                resolved_directory,
+                resolved_filename,
+            ) = self._render_planned_locator(
+                context=context,
+                schema=schema,
+                record_type=record_type,
+                source_path=source_path,
+                storage_root=storage_root,
+                date_added=timestamp[:10],
+            )
+        else:
+            planned_locator = locator
+            storage_relative_path = locator.relative_path
+            resolved_directory = _directory_from_locator(locator)
+            resolved_filename = _filename_from_locator(locator)
         context.planned_locators = [planned_locator]
         self.hook_manager.resolve_artifact_locator(context)
         canonical_locator = _artifact_locator_from_context(context)
+        if canonical_locator != planned_locator:
+            storage_relative_path = canonical_locator.relative_path
+            resolved_directory = _directory_from_locator(canonical_locator)
+            resolved_filename = _filename_from_locator(canonical_locator)
         plan = plan_storage(
             canonical_locator,
             target_kind=target_kind,
@@ -319,6 +340,9 @@ class Catalog:
             ogcat_owned=ogcat_owned,
             adapter=_adapter_name(canonical_locator),
             time_added=timestamp,
+            storage_relative_path=storage_relative_path,
+            resolved_directory=resolved_directory,
+            resolved_filename=resolved_filename,
         )
         context.storage_plan = plan
         return plan
@@ -384,6 +408,8 @@ class Catalog:
                 storage_mode = storage_plan.write_mode
             if time_added is None:
                 time_added = storage_plan.time_added
+            if naming_metadata is None:
+                naming_metadata = _naming_metadata_from_storage_plan(storage_plan)
         assert locator is not None
         metadata_input = {} if metadata is None else metadata
         derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
@@ -751,7 +777,7 @@ class Catalog:
             record_type=record_type,
             locator=locator,
             stored_abspath=str(locator_path) if locator_path is not None else None,
-            stored_relpath=locator.relative_path,
+            stored_relpath=locator.relative_path if locator.kind == "path" else None,
             storage_mode=storage_mode,
             original_path=resolved_original_path,
             original_filename=original_filename,
@@ -770,7 +796,7 @@ class Catalog:
         source_path: Path | None,
         storage_root: str | Path | None,
         date_added: str,
-    ) -> ArtifactLocator:
+    ) -> PlannedLocatorResult:
         """Render schema naming templates into a local or fsspec target locator."""
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
         filename_template = _require_template(schema.filename_template, field_name="filename_template")
@@ -787,7 +813,7 @@ class Catalog:
             root_url = str(storage_root).rstrip("/")
             fake_root = Path("/__ogcat_storage__")
 
-            target, _rel_path, _resolved_filename = render_storage_location(
+            target, _rel_path, resolved_filename = render_storage_location(
                 files_root=fake_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
@@ -797,14 +823,22 @@ class Catalog:
                 ),
             )
             relative_path = target.relative_to(fake_root).as_posix()
-            return ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path))
+            resolved_directory = str(Path(relative_path).parent)
+            if resolved_directory == ".":
+                resolved_directory = ""
+            return (
+                ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path)),
+                relative_path,
+                resolved_directory,
+                resolved_filename,
+            )
 
         if storage_root is None:
             files_root = self.root / self.spec.files_root
         else:
             files_root = Path(storage_root).expanduser().resolve()
         storage_adapter = LocalStorageAdapter()
-        target, rel_path, _resolved_filename = render_storage_location(
+        target, rel_path, resolved_filename = render_storage_location(
             files_root=files_root,
             directory_template=directory_template,
             filename_template=filename_template,
@@ -812,7 +846,16 @@ class Catalog:
             exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
         )
         relative_path = rel_path if storage_root is None else None
-        return ArtifactLocator.from_path(target, relative_path=relative_path)
+        storage_relative_path = target.relative_to(files_root).as_posix()
+        resolved_directory = Path(storage_relative_path).parent.as_posix()
+        if resolved_directory == ".":
+            resolved_directory = ""
+        return (
+            ArtifactLocator.from_path(target, relative_path=relative_path),
+            storage_relative_path,
+            resolved_directory,
+            resolved_filename,
+        )
 
     def _add_artifact_in_transaction(
         self,
@@ -930,6 +973,9 @@ class Catalog:
                     write_mode=_write_mode_from_writer(artifact_writer),
                     ogcat_owned=artifact_writer is not None,
                     adapter=_adapter_name(canonical_locator),
+                    storage_relative_path=canonical_locator.relative_path,
+                    resolved_directory=_directory_from_locator(canonical_locator),
+                    resolved_filename=_filename_from_locator(canonical_locator),
                 )
             )
             storage_plan = hook_context.storage_plan
@@ -1084,7 +1130,26 @@ def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> S
     """Return a storage plan adjusted to a hook-resolved canonical locator."""
     if plan.locator == locator:
         return plan
-    return replace(plan, locator=locator, adapter=_adapter_name(locator))
+    return replace(
+        plan,
+        locator=locator,
+        adapter=_adapter_name(locator),
+        storage_relative_path=locator.relative_path,
+        resolved_directory=_directory_from_locator(locator),
+        resolved_filename=_filename_from_locator(locator),
+    )
+
+
+def _naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
+    """Build record naming metadata from storage planning outputs."""
+    metadata: MetadataDict = {}
+    if plan.storage_relative_path is not None:
+        metadata["storage_relative_path"] = plan.storage_relative_path
+    if plan.resolved_directory is not None:
+        metadata["resolved_directory"] = plan.resolved_directory
+    if plan.resolved_filename is not None:
+        metadata["resolved_filename"] = plan.resolved_filename
+    return metadata
 
 
 def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
@@ -1171,6 +1236,13 @@ def _filename_from_locator(locator: ArtifactLocator) -> str:
     if locator.kind == "path":
         return Path(locator.value).name
     return locator.value.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _directory_from_locator(locator: ArtifactLocator) -> str:
+    """Return the directory-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).parent.as_posix()
+    return locator.value.rstrip("/").rsplit("/", 1)[0]
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -199,9 +199,7 @@ class Catalog:
                 ogcat_owned=True,
                 adapter=_adapter_name(locator),
                 storage_relative_path=locator.relative_path,
-                resolved_directory=(
-                    None if locator.relative_path is None else Path(locator.relative_path).parent.as_posix()
-                ),
+                resolved_directory=_directory_from_relative_path(locator.relative_path),
                 resolved_filename=_filename_from_locator(locator),
             )
 
@@ -962,8 +960,6 @@ class Catalog:
             self.hook_manager.resolve_artifact_locator(hook_context)
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
-            if naming_metadata is not None and "resolved_filename" in naming_metadata:
-                naming_metadata["resolved_filename"] = _filename_from_locator(canonical_locator)
             hook_context.storage_plan = (
                 storage_plan_factory(hook_context, canonical_locator)
                 if storage_plan_factory is not None
@@ -981,6 +977,8 @@ class Catalog:
             storage_plan = hook_context.storage_plan
             if storage_plan is None:
                 raise RuntimeError("Add operation did not produce a storage plan.")
+            if naming_metadata is not None:
+                naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
             if artifact_writer is None:
                 if storage_plan.write_mode != "reference":
                     raise ValueError(
@@ -1243,6 +1241,14 @@ def _directory_from_locator(locator: ArtifactLocator) -> str:
     if locator.kind == "path":
         return Path(locator.value).parent.as_posix()
     return locator.value.rstrip("/").rsplit("/", 1)[0]
+
+
+def _directory_from_relative_path(relative_path: str | None) -> str | None:
+    """Return the directory component from a storage-relative path."""
+    if relative_path is None:
+        return None
+    directory = Path(relative_path).parent.as_posix()
+    return "" if directory == "." else directory
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from ogcat.models import ArtifactLocator, MetadataDict
+from ogcat.storage import StoragePlan
 from ogcat.transactions import RollbackAction
 from ogcat.validation import ValidationReport
 
@@ -123,6 +124,7 @@ class OperationContext:
             normally call ``context.rollback(...)`` instead.
         source: Artifact source description for this operation.
         storage_mode: Optional storage mode, such as ``"copy"`` or ``"move"``.
+        storage_plan: Optional planned artifact storage decision.
         original_path: Optional original path or URI.
         original_filename: Optional original filename.
         suffixes: Source suffixes associated with the artifact.
@@ -138,6 +140,7 @@ class OperationContext:
     register_rollback: RollbackRegistrar | None = None
     source: OperationSource = field(default_factory=lambda: OperationSource(kind="unknown"))
     storage_mode: str | None = None
+    storage_plan: StoragePlan | None = None
     original_path: str | Path | None = None
     original_filename: str | None = None
     suffixes: list[str] = field(default_factory=list)

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -69,7 +69,7 @@ class ArtifactLocator:
     relative_path: str | None = None
 
     @classmethod
-    def path(cls, path: str | Path, *, relative_path: str | None = None) -> ArtifactLocator:
+    def from_path(cls, path: str | Path, *, relative_path: str | None = None) -> ArtifactLocator:
         """Build a locator for a local path-backed artifact.
 
         Args:
@@ -82,7 +82,16 @@ class ArtifactLocator:
         return cls(kind="path", value=str(path), relative_path=relative_path)
 
     @classmethod
-    def urlpath(cls, urlpath: str, *, relative_path: str | None = None) -> ArtifactLocator:
+    def path(cls, path: str | Path, *, relative_path: str | None = None) -> ArtifactLocator:
+        """Build a local path locator.
+
+        This compatibility alias is kept for existing code. Prefer
+        :meth:`from_path` in new code.
+        """
+        return cls.from_path(path, relative_path=relative_path)
+
+    @classmethod
+    def from_urlpath(cls, urlpath: str, *, relative_path: str | None = None) -> ArtifactLocator:
         """Build a locator for an fsspec-addressable URL path.
 
         Args:
@@ -93,6 +102,15 @@ class ArtifactLocator:
             URL-path-backed artifact locator.
         """
         return cls(kind="urlpath", value=str(urlpath), relative_path=relative_path)
+
+    @classmethod
+    def urlpath(cls, urlpath: str, *, relative_path: str | None = None) -> ArtifactLocator:
+        """Build an fsspec URL-path locator.
+
+        This compatibility alias is kept for existing code. Prefer
+        :meth:`from_urlpath` in new code.
+        """
+        return cls.from_urlpath(urlpath, relative_path=relative_path)
 
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the locator to a plain dictionary."""

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -181,7 +181,11 @@ class CatalogRecord:
         locator_path = self.locator.as_path()
         if locator_path is not None and self.stored_abspath is None:
             self.stored_abspath = str(locator_path)
-        if self.locator.relative_path is not None and self.stored_relpath is None:
+        if (
+            self.locator.kind == "path"
+            and self.locator.relative_path is not None
+            and self.stored_relpath is None
+        ):
             self.stored_relpath = self.locator.relative_path
 
     def path(self) -> Path | None:

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -103,15 +103,6 @@ class ArtifactLocator:
         """
         return cls(kind="urlpath", value=str(urlpath), relative_path=relative_path)
 
-    @classmethod
-    def urlpath(cls, urlpath: str, *, relative_path: str | None = None) -> ArtifactLocator:
-        """Build an fsspec URL-path locator.
-
-        This compatibility alias is kept for existing code. Prefer
-        :meth:`from_urlpath` in new code.
-        """
-        return cls.from_urlpath(urlpath, relative_path=relative_path)
-
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the locator to a plain dictionary."""
         return {

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -81,6 +81,19 @@ class ArtifactLocator:
         """
         return cls(kind="path", value=str(path), relative_path=relative_path)
 
+    @classmethod
+    def urlpath(cls, urlpath: str, *, relative_path: str | None = None) -> ArtifactLocator:
+        """Build a locator for an fsspec-addressable URL path.
+
+        Args:
+            urlpath: URL path understood by fsspec, such as ``s3://...``.
+            relative_path: Optional storage-root-relative path.
+
+        Returns:
+            URL-path-backed artifact locator.
+        """
+        return cls(kind="urlpath", value=str(urlpath), relative_path=relative_path)
+
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the locator to a plain dictionary."""
         return {

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -114,9 +114,10 @@ def render_template(template: str, context: dict[str, Any]) -> str:
     return _TEMPLATE_PATTERN.sub(replace, template)
 
 
-def ensure_unique_path(path: Path) -> Path:
+def ensure_unique_path(path: Path, *, exists: Callable[[Path], bool] | None = None) -> Path:
     """Return a unique path by appending numeric suffixes if needed."""
-    if not path.exists():
+    path_exists = Path.exists if exists is None else exists
+    if not path_exists(path):
         return path
 
     parent = path.parent
@@ -125,7 +126,7 @@ def ensure_unique_path(path: Path) -> Path:
     counter = 2
     while True:
         candidate = parent / f"{stem}_{counter}{suffix}"
-        if not candidate.exists():
+        if not path_exists(candidate):
             return candidate
         counter += 1
 
@@ -207,6 +208,7 @@ def render_storage_location(
     directory_template: str,
     filename_template: str,
     context: dict[str, object],
+    exists: Callable[[Path], bool] | None = None,
 ) -> tuple[Path, str, str]:
     """Render directory and filename templates into a final storage path."""
     rel_dir = render_template(directory_template, context)
@@ -214,7 +216,7 @@ def render_storage_location(
 
     filename = _render_filename(filename_template, context)
     target = files_root / rel_dir / filename
-    target = ensure_unique_path(target)
+    target = ensure_unique_path(target, exists=exists)
 
     rel_path = target.relative_to(files_root.parent)
     return target, str(rel_path), target.name

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -14,7 +14,6 @@ from ogcat.models import CatalogRecord, JsonValue
 from ogcat.search import flatten_lookup, resolve_field
 
 DEFAULT_RECORDSET_FIELDS = ("id", "title", "product", "species", "path")
-_METADATA_NAMESPACES = ("user_metadata", "derived_metadata", "naming_metadata")
 
 
 def resolve_record_field(

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -39,6 +39,11 @@ class StoragePlan:
             ``"fsspec"``.
         time_added: Optional timestamp used when rendering date-based storage
             templates.
+        storage_relative_path: Optional target path relative to the configured
+            storage root.
+        resolved_directory: Optional rendered directory path for template-based
+            storage.
+        resolved_filename: Optional rendered filename or final path component.
     """
 
     locator: ArtifactLocator
@@ -49,6 +54,9 @@ class StoragePlan:
     profile: str | None = None
     adapter: str | None = None
     time_added: str | None = None
+    storage_relative_path: str | None = None
+    resolved_directory: str | None = None
+    resolved_filename: str | None = None
 
 
 class StorageAdapter(Protocol):
@@ -220,6 +228,9 @@ def plan_storage(
     profile: str | None = None,
     adapter: str | None = None,
     time_added: str | None = None,
+    storage_relative_path: str | None = None,
+    resolved_directory: str | None = None,
+    resolved_filename: str | None = None,
 ) -> StoragePlan:
     """Build a storage plan from already-resolved storage decisions.
 
@@ -234,6 +245,11 @@ def plan_storage(
             ``"fsspec"``.
         time_added: Optional timestamp used when rendering date-based storage
             templates.
+        storage_relative_path: Optional target path relative to the configured
+            storage root.
+        resolved_directory: Optional rendered directory path for template-based
+            storage.
+        resolved_filename: Optional rendered filename or final path component.
 
     Returns:
         Storage plan describing the target and intended write.
@@ -247,6 +263,9 @@ def plan_storage(
         profile=profile,
         adapter=adapter,
         time_added=time_added,
+        storage_relative_path=storage_relative_path,
+        resolved_directory=resolved_directory,
+        resolved_filename=resolved_filename,
     )
 
 

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -1,9 +1,9 @@
-"""Storage planning and lightweight backend primitives.
+"""Storage planning and lightweight adapter primitives.
 
 This module keeps storage decisions explicit without turning ``ogcat`` into a
 domain storage framework.  Plans describe where an artifact should live and how
-it should be materialised; writers and catalog operations decide whether to
-execute the plan.
+it should be materialised; :class:`ogcat.hooks.ArtifactWriter` implementations
+perform any side effects.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ from ogcat.models import ArtifactLocator
 
 TargetKind = Literal["file", "directory"]
 WriteMode = Literal["copy", "move", "write", "reference"]
-OverwritePolicy = Literal["error", "overwrite"]
 ChecksumPolicy = Literal["none"]
 
 
@@ -29,31 +28,27 @@ class StoragePlan:
 
     Args:
         locator: Canonical artifact locator that should be stored on the record.
-        source: Optional source locator or descriptor.
         target_kind: Whether the target is a file-like or directory-like
             artifact.
         write_mode: How data should be materialised, or ``"reference"`` for
             record-only external artifacts.
-        overwrite: Collision policy for the target.
         checksum: Checksum policy requested for the write.
         ogcat_owned: Whether ``ogcat`` is responsible for cleanup on rollback.
         profile: Optional storage profile name or hint.
-        backend: Optional backend identifier, such as ``"local"`` or
+        adapter: Optional adapter identifier, such as ``"local"`` or
             ``"fsspec"``.
     """
 
     locator: ArtifactLocator
-    source: ArtifactLocator | None = None
     target_kind: TargetKind = "file"
     write_mode: WriteMode = "reference"
-    overwrite: OverwritePolicy = "error"
     checksum: ChecksumPolicy = "none"
     ogcat_owned: bool = False
     profile: str | None = None
-    backend: str | None = None
+    adapter: str | None = None
 
 
-class StorageBackend(Protocol):
+class StorageAdapter(Protocol):
     """Minimal storage operations needed by plans and bundled writers."""
 
     def exists(self, locator: ArtifactLocator) -> bool:
@@ -76,42 +71,50 @@ class StorageBackend(Protocol):
         """Create a directory-like target."""
         ...
 
+    def mkdir_parent(self, locator: ArtifactLocator) -> None:
+        """Create the parent directory for a file-like target."""
+        ...
+
     def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
         """Remove a file-like or directory-like locator."""
         ...
 
 
 @dataclass(frozen=True, slots=True)
-class LocalStorageBackend:
-    """Storage backend for local path locators."""
+class LocalStorageAdapter:
+    """Storage adapter for local path locators."""
 
     def exists(self, locator: ArtifactLocator) -> bool:
         """Return whether a local path-backed locator exists."""
-        return _path_locator(locator).exists()
+        return require_local_path(locator).exists()
 
     def open(self, locator: ArtifactLocator, mode: str = "rb") -> IO[bytes]:
         """Open a local path-backed locator."""
-        return _path_locator(locator).open(mode)
+        return require_local_path(locator).open(mode)
 
     def copy_from_path(self, source: Path, target: ArtifactLocator) -> None:
         """Copy a local source path to a local target."""
-        target_path = _path_locator(target)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
+        self.mkdir_parent(target)
+        target_path = require_local_path(target)
         shutil.copy2(source, target_path)
 
     def move_from_path(self, source: Path, target: ArtifactLocator) -> None:
         """Move a local source path to a local target."""
-        target_path = _path_locator(target)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
+        self.mkdir_parent(target)
+        target_path = require_local_path(target)
         shutil.move(str(source), str(target_path))
 
     def mkdir(self, locator: ArtifactLocator) -> None:
         """Create a local directory target."""
-        _path_locator(locator).mkdir(parents=True, exist_ok=False)
+        require_local_path(locator).mkdir(parents=True, exist_ok=False)
+
+    def mkdir_parent(self, locator: ArtifactLocator) -> None:
+        """Create the parent directory for a local file target."""
+        require_local_path(locator).parent.mkdir(parents=True, exist_ok=True)
 
     def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
         """Remove a local file or directory target."""
-        path = _path_locator(locator)
+        path = require_local_path(locator)
         if target_kind == "directory":
             shutil.rmtree(path, ignore_errors=True)
             return
@@ -119,8 +122,8 @@ class LocalStorageBackend:
 
 
 @dataclass(frozen=True, slots=True)
-class FsspecStorageBackend:
-    """Storage backend for fsspec-addressable ``urlpath`` locators."""
+class FsspecStorageAdapter:
+    """Storage adapter for fsspec-addressable ``urlpath`` locators."""
 
     storage_options: dict[str, object] | None = None
 
@@ -137,9 +140,7 @@ class FsspecStorageBackend:
     def copy_from_path(self, source: Path, target: ArtifactLocator) -> None:
         """Copy a local file to a fsspec target."""
         fs, path = self._filesystem_and_path(target)
-        parent = str(Path(path).parent)
-        if parent not in {"", "."}:
-            fs.makedirs(parent, exist_ok=True)
+        self.mkdir_parent(target)
         fs.put_file(str(source), path)
 
     def move_from_path(self, source: Path, target: ArtifactLocator) -> None:
@@ -152,6 +153,13 @@ class FsspecStorageBackend:
         fs, path = self._filesystem_and_path(locator)
         fs.makedirs(path, exist_ok=False)
 
+    def mkdir_parent(self, locator: ArtifactLocator) -> None:
+        """Create the parent directory for a fsspec target."""
+        fs, path = self._filesystem_and_path(locator)
+        parent = str(Path(path).parent)
+        if parent not in {"", "."}:
+            fs.makedirs(parent, exist_ok=True)
+
     def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
         """Remove a fsspec target."""
         fs, path = self._filesystem_and_path(locator)
@@ -159,9 +167,9 @@ class FsspecStorageBackend:
             fs.rm(path, recursive=target_kind == "directory")
 
     def _filesystem_and_path(self, locator: ArtifactLocator) -> tuple[Any, str]:
-        """Return the fsspec filesystem and backend path for a locator."""
+        """Return the fsspec filesystem and adapter path for a locator."""
         if locator.kind != "urlpath":
-            raise ValueError(f"fsspec backend requires locator kind 'urlpath', got {locator.kind!r}")
+            raise ValueError(f"fsspec adapter requires locator kind 'urlpath', got {locator.kind!r}")
         fsspec = _load_fsspec()
         fs, path = fsspec.core.url_to_fs(locator.value, **self._storage_options())
         return fs, path
@@ -171,134 +179,107 @@ class FsspecStorageBackend:
         return {} if self.storage_options is None else dict(self.storage_options)
 
 
-def backend_for_locator(locator: ArtifactLocator) -> StorageBackend:
-    """Return the storage backend that can interpret a locator."""
+def adapter_for_locator(locator: ArtifactLocator) -> StorageAdapter:
+    """Return the storage adapter that can interpret a locator."""
     if locator.kind == "path":
-        return LocalStorageBackend()
+        return LocalStorageAdapter()
     if locator.kind == "urlpath":
-        return FsspecStorageBackend()
-    raise ValueError(f"No storage backend for locator kind {locator.kind!r}")
+        return FsspecStorageAdapter()
+    raise ValueError(f"No storage adapter for locator kind {locator.kind!r}")
 
 
 def plan_storage(
     locator: ArtifactLocator,
     *,
-    source: ArtifactLocator | None = None,
     target_kind: TargetKind = "file",
     write_mode: WriteMode = "reference",
-    overwrite: OverwritePolicy = "error",
     checksum: ChecksumPolicy = "none",
     ogcat_owned: bool = False,
     profile: str | None = None,
-    backend: str | None = None,
+    adapter: str | None = None,
 ) -> StoragePlan:
     """Build a storage plan from already-resolved storage decisions."""
     return StoragePlan(
         locator=locator,
-        source=source,
         target_kind=target_kind,
         write_mode=write_mode,
-        overwrite=overwrite,
         checksum=checksum,
         ogcat_owned=ogcat_owned,
         profile=profile,
-        backend=backend,
+        adapter=adapter,
     )
 
 
-def execute_storage_plan(
-    plan: StoragePlan,
+def require_storage_target(locator: ArtifactLocator) -> StorageAdapter:
+    """Return an adapter for a filesystem-like target locator."""
+    return adapter_for_locator(locator)
+
+
+def ensure_target_absent(
+    locator: ArtifactLocator,
     *,
-    source_path: Path | None,
-    register_rollback: Callable[[Callable[[], None], str], None] | None = None,
+    adapter: StorageAdapter | None = None,
 ) -> None:
-    """Execute a simple owned storage plan.
-
-    Args:
-        plan: Storage plan to execute.
-        source_path: Local source path for copy or move plans.
-        register_rollback: Optional callback that receives a cleanup callable
-            and description before data is written.
-    """
-    if plan.write_mode == "reference":
-        return
-    if not plan.ogcat_owned:
-        raise ValueError("Only ogcat-owned storage plans can be executed by ogcat core.")
-
-    backend = backend_for_locator(plan.locator)
-    if plan.overwrite == "error" and backend.exists(plan.locator):
-        raise FileExistsError(f"target already exists: {plan.locator.value}")
-    if plan.write_mode == "write":
-        _register_remove_rollback(plan, backend, register_rollback)
-        if plan.target_kind == "directory":
-            backend.mkdir(plan.locator)
-        return
-
-    if source_path is None:
-        raise ValueError(f"{plan.write_mode} storage plan requires a source path")
-
-    if plan.write_mode == "move" and plan.locator.kind == "path":
-        _register_local_move_rollback(plan, source_path, register_rollback)
-    else:
-        _register_remove_rollback(plan, backend, register_rollback)
-    if plan.write_mode == "copy":
-        backend.copy_from_path(source_path, plan.locator)
-        return
-    if plan.write_mode == "move":
-        backend.move_from_path(source_path, plan.locator)
-        return
-    raise ValueError(f"Unsupported storage write mode: {plan.write_mode}")
+    """Raise if a target already exists."""
+    storage = require_storage_target(locator) if adapter is None else adapter
+    if storage.exists(locator):
+        raise FileExistsError(f"target already exists: {locator.value}")
 
 
-def _register_local_move_rollback(
-    plan: StoragePlan,
-    source_path: Path,
-    register_rollback: Callable[[Callable[[], None], str], None] | None,
+def ensure_parent_directory(
+    locator: ArtifactLocator,
+    *,
+    adapter: StorageAdapter | None = None,
 ) -> None:
-    """Register source restoration for local move plans."""
-    if register_rollback is None:
-        return
-    target_path = _path_locator(plan.locator)
-    register_rollback(
-        lambda source=source_path, target=target_path: _rollback_moved_file(source, target),
-        f"restore moved file from {target_path} to {source_path}",
+    """Create parent directories for a file-like target."""
+    storage = require_storage_target(locator) if adapter is None else adapter
+    storage.mkdir_parent(locator)
+
+
+def create_directory_target(
+    locator: ArtifactLocator,
+    *,
+    adapter: StorageAdapter | None = None,
+) -> None:
+    """Create an empty directory target after checking it does not exist."""
+    storage = require_storage_target(locator) if adapter is None else adapter
+    ensure_target_absent(locator, adapter=storage)
+    storage.mkdir(locator)
+
+
+def remove_target(
+    locator: ArtifactLocator,
+    *,
+    target_kind: TargetKind = "file",
+    adapter: StorageAdapter | None = None,
+) -> None:
+    """Remove a file-like or directory-like target."""
+    storage = require_storage_target(locator) if adapter is None else adapter
+    storage.remove(locator, target_kind=target_kind)
+
+
+def register_remove_on_rollback(
+    rollback: Callable[[Callable[[], None], str], object],
+    locator: ArtifactLocator,
+    *,
+    target_kind: TargetKind = "file",
+    adapter: StorageAdapter | None = None,
+    description: str | None = None,
+) -> None:
+    """Register target removal with a writer's rollback callback."""
+    storage = require_storage_target(locator) if adapter is None else adapter
+    rollback(
+        lambda: storage.remove(locator, target_kind=target_kind),
+        description or f"remove written {target_kind} artifact {locator.value}",
     )
 
 
-def _register_remove_rollback(
-    plan: StoragePlan,
-    backend: StorageBackend,
-    register_rollback: Callable[[Callable[[], None], str], None] | None,
-) -> None:
-    """Register cleanup for an owned target before it is created."""
-    if register_rollback is None:
-        return
-    register_rollback(
-        lambda locator=plan.locator, target_kind=plan.target_kind: backend.remove(
-            locator,
-            target_kind=target_kind,
-        ),
-        f"remove written {plan.target_kind} artifact {plan.locator.value}",
-    )
-
-
-def _path_locator(locator: ArtifactLocator) -> Path:
+def require_local_path(locator: ArtifactLocator) -> Path:
     """Return a local path for a path-backed locator."""
     path = locator.as_path()
     if path is None:
-        raise ValueError(f"local backend requires locator kind 'path', got {locator.kind!r}")
+        raise ValueError(f"local adapter requires locator kind 'path', got {locator.kind!r}")
     return path
-
-
-def _rollback_moved_file(source_path: Path, target_path: Path) -> None:
-    """Restore a moved local file when possible, otherwise remove the target."""
-    if not target_path.exists():
-        return
-    if not source_path.exists():
-        source_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(target_path), str(source_path))
-        return
-    target_path.unlink(missing_ok=True)
 
 
 def _load_fsspec() -> Any:
@@ -313,14 +294,19 @@ def _load_fsspec() -> Any:
 
 __all__ = [
     "ChecksumPolicy",
-    "FsspecStorageBackend",
-    "LocalStorageBackend",
-    "OverwritePolicy",
-    "StorageBackend",
+    "FsspecStorageAdapter",
+    "LocalStorageAdapter",
+    "StorageAdapter",
     "StoragePlan",
     "TargetKind",
     "WriteMode",
-    "backend_for_locator",
-    "execute_storage_plan",
+    "adapter_for_locator",
+    "create_directory_target",
+    "ensure_parent_directory",
+    "ensure_target_absent",
     "plan_storage",
+    "register_remove_on_rollback",
+    "remove_target",
+    "require_local_path",
+    "require_storage_target",
 ]

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -188,7 +188,18 @@ class FsspecStorageAdapter:
 
 
 def adapter_for_locator(locator: ArtifactLocator) -> StorageAdapter:
-    """Return the storage adapter that can interpret a locator."""
+    """Return the storage adapter that can interpret a locator.
+
+    Args:
+        locator: Artifact locator to inspect.
+
+    Returns:
+        Storage adapter for local path or fsspec URL-path locators.
+
+    Raises:
+        ValueError: If ogcat does not provide a storage adapter for the locator
+            kind.
+    """
     if locator.kind == "path":
         return LocalStorageAdapter()
     if locator.kind == "urlpath":
@@ -206,7 +217,21 @@ def plan_storage(
     profile: str | None = None,
     adapter: str | None = None,
 ) -> StoragePlan:
-    """Build a storage plan from already-resolved storage decisions."""
+    """Build a storage plan from already-resolved storage decisions.
+
+    Args:
+        locator: Target locator that should be recorded for the artifact.
+        target_kind: Whether the target is file-like or directory-like.
+        write_mode: Intended materialisation mode.
+        checksum: Checksum policy requested for the write.
+        ogcat_owned: Whether ogcat should treat the target as managed.
+        profile: Optional storage profile name or hint.
+        adapter: Optional adapter identifier, such as ``"local"`` or
+            ``"fsspec"``.
+
+    Returns:
+        Storage plan describing the target and intended write.
+    """
     return StoragePlan(
         locator=locator,
         target_kind=target_kind,
@@ -219,7 +244,18 @@ def plan_storage(
 
 
 def require_storage_target(locator: ArtifactLocator) -> StorageAdapter:
-    """Return an adapter for a filesystem-like target locator."""
+    """Return an adapter for a filesystem-like target locator.
+
+    Args:
+        locator: Artifact locator that should be writable through a storage
+            adapter.
+
+    Returns:
+        Storage adapter that can operate on the locator.
+
+    Raises:
+        ValueError: If the locator kind is not filesystem-like.
+    """
     return adapter_for_locator(locator)
 
 
@@ -228,7 +264,16 @@ def ensure_target_absent(
     *,
     adapter: StorageAdapter | None = None,
 ) -> None:
-    """Raise if a target already exists."""
+    """Raise if a target already exists.
+
+    Args:
+        locator: Target locator to check.
+        adapter: Optional pre-resolved storage adapter.
+
+    Raises:
+        FileExistsError: If the target exists.
+        ValueError: If no adapter can interpret the locator.
+    """
     storage = require_storage_target(locator) if adapter is None else adapter
     if storage.exists(locator):
         raise FileExistsError(f"target already exists: {locator.value}")
@@ -239,7 +284,15 @@ def ensure_parent_directory(
     *,
     adapter: StorageAdapter | None = None,
 ) -> None:
-    """Create parent directories for a file-like target."""
+    """Create parent directories for a file-like target.
+
+    Args:
+        locator: File-like target locator whose parent should exist.
+        adapter: Optional pre-resolved storage adapter.
+
+    Raises:
+        ValueError: If no adapter can interpret the locator.
+    """
     storage = require_storage_target(locator) if adapter is None else adapter
     storage.mkdir_parent(locator)
 
@@ -249,7 +302,16 @@ def create_directory_target(
     *,
     adapter: StorageAdapter | None = None,
 ) -> None:
-    """Create an empty directory target after checking it does not exist."""
+    """Create an empty directory target after checking it does not exist.
+
+    Args:
+        locator: Directory-like target locator to create.
+        adapter: Optional pre-resolved storage adapter.
+
+    Raises:
+        FileExistsError: If the directory target already exists.
+        ValueError: If no adapter can interpret the locator.
+    """
     storage = require_storage_target(locator) if adapter is None else adapter
     ensure_target_absent(locator, adapter=storage)
     storage.mkdir(locator)
@@ -261,7 +323,16 @@ def remove_target(
     target_kind: TargetKind = "file",
     adapter: StorageAdapter | None = None,
 ) -> None:
-    """Remove a file-like or directory-like target."""
+    """Remove a file-like or directory-like target.
+
+    Args:
+        locator: Target locator to remove.
+        target_kind: Whether to remove a file-like or directory-like target.
+        adapter: Optional pre-resolved storage adapter.
+
+    Raises:
+        ValueError: If no adapter can interpret the locator.
+    """
     storage = require_storage_target(locator) if adapter is None else adapter
     storage.remove(locator, target_kind=target_kind)
 
@@ -274,7 +345,19 @@ def register_remove_on_rollback(
     adapter: StorageAdapter | None = None,
     description: str | None = None,
 ) -> None:
-    """Register target removal with a writer's rollback callback."""
+    """Register target removal with a writer's rollback callback.
+
+    Args:
+        rollback: Rollback registration callback, such as
+            :meth:`ogcat.hooks.OperationContext.rollback`.
+        locator: Target locator to remove if rollback runs.
+        target_kind: Whether the target is file-like or directory-like.
+        adapter: Optional pre-resolved storage adapter.
+        description: Optional human-readable rollback description.
+
+    Raises:
+        ValueError: If no adapter can interpret the locator.
+    """
     storage = require_storage_target(locator) if adapter is None else adapter
     rollback(
         lambda: storage.remove(locator, target_kind=target_kind),
@@ -283,7 +366,17 @@ def register_remove_on_rollback(
 
 
 def require_local_path(locator: ArtifactLocator) -> Path:
-    """Return a local path for a path-backed locator."""
+    """Return a local path for a path-backed locator.
+
+    Args:
+        locator: Artifact locator expected to contain a local path.
+
+    Returns:
+        Local filesystem path represented by the locator.
+
+    Raises:
+        ValueError: If the locator is not path-backed.
+    """
     path = locator.as_path()
     if path is None:
         raise ValueError(f"local adapter requires locator kind 'path', got {locator.kind!r}")

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -1,0 +1,326 @@
+"""Storage planning and lightweight backend primitives.
+
+This module keeps storage decisions explicit without turning ``ogcat`` into a
+domain storage framework.  Plans describe where an artifact should live and how
+it should be materialised; writers and catalog operations decide whether to
+execute the plan.
+"""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Any, Literal, Protocol
+
+from ogcat.models import ArtifactLocator
+
+TargetKind = Literal["file", "directory"]
+WriteMode = Literal["copy", "move", "write", "reference"]
+OverwritePolicy = Literal["error", "overwrite"]
+ChecksumPolicy = Literal["none"]
+
+
+@dataclass(frozen=True, slots=True)
+class StoragePlan:
+    """Concrete storage decision for a catalog operation.
+
+    Args:
+        locator: Canonical artifact locator that should be stored on the record.
+        source: Optional source locator or descriptor.
+        target_kind: Whether the target is a file-like or directory-like
+            artifact.
+        write_mode: How data should be materialised, or ``"reference"`` for
+            record-only external artifacts.
+        overwrite: Collision policy for the target.
+        checksum: Checksum policy requested for the write.
+        ogcat_owned: Whether ``ogcat`` is responsible for cleanup on rollback.
+        profile: Optional storage profile name or hint.
+        backend: Optional backend identifier, such as ``"local"`` or
+            ``"fsspec"``.
+    """
+
+    locator: ArtifactLocator
+    source: ArtifactLocator | None = None
+    target_kind: TargetKind = "file"
+    write_mode: WriteMode = "reference"
+    overwrite: OverwritePolicy = "error"
+    checksum: ChecksumPolicy = "none"
+    ogcat_owned: bool = False
+    profile: str | None = None
+    backend: str | None = None
+
+
+class StorageBackend(Protocol):
+    """Minimal storage operations needed by plans and bundled writers."""
+
+    def exists(self, locator: ArtifactLocator) -> bool:
+        """Return whether a locator currently exists."""
+        ...
+
+    def open(self, locator: ArtifactLocator, mode: str = "rb") -> IO[bytes]:
+        """Open a locator for binary file I/O."""
+        ...
+
+    def copy_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Copy a local source path to the target locator."""
+        ...
+
+    def move_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Move a local source path to the target locator."""
+        ...
+
+    def mkdir(self, locator: ArtifactLocator) -> None:
+        """Create a directory-like target."""
+        ...
+
+    def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
+        """Remove a file-like or directory-like locator."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class LocalStorageBackend:
+    """Storage backend for local path locators."""
+
+    def exists(self, locator: ArtifactLocator) -> bool:
+        """Return whether a local path-backed locator exists."""
+        return _path_locator(locator).exists()
+
+    def open(self, locator: ArtifactLocator, mode: str = "rb") -> IO[bytes]:
+        """Open a local path-backed locator."""
+        return _path_locator(locator).open(mode)
+
+    def copy_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Copy a local source path to a local target."""
+        target_path = _path_locator(target)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target_path)
+
+    def move_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Move a local source path to a local target."""
+        target_path = _path_locator(target)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(target_path))
+
+    def mkdir(self, locator: ArtifactLocator) -> None:
+        """Create a local directory target."""
+        _path_locator(locator).mkdir(parents=True, exist_ok=False)
+
+    def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
+        """Remove a local file or directory target."""
+        path = _path_locator(locator)
+        if target_kind == "directory":
+            shutil.rmtree(path, ignore_errors=True)
+            return
+        path.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class FsspecStorageBackend:
+    """Storage backend for fsspec-addressable ``urlpath`` locators."""
+
+    storage_options: dict[str, object] | None = None
+
+    def exists(self, locator: ArtifactLocator) -> bool:
+        """Return whether a fsspec URL exists."""
+        fs, path = self._filesystem_and_path(locator)
+        return bool(fs.exists(path))
+
+    def open(self, locator: ArtifactLocator, mode: str = "rb") -> IO[bytes]:
+        """Open a fsspec URL."""
+        fsspec = _load_fsspec()
+        return fsspec.open(locator.value, mode=mode, **self._storage_options()).open()
+
+    def copy_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Copy a local file to a fsspec target."""
+        fs, path = self._filesystem_and_path(target)
+        parent = str(Path(path).parent)
+        if parent not in {"", "."}:
+            fs.makedirs(parent, exist_ok=True)
+        fs.put_file(str(source), path)
+
+    def move_from_path(self, source: Path, target: ArtifactLocator) -> None:
+        """Move a local file to a fsspec target."""
+        self.copy_from_path(source, target)
+        source.unlink()
+
+    def mkdir(self, locator: ArtifactLocator) -> None:
+        """Create a fsspec directory target."""
+        fs, path = self._filesystem_and_path(locator)
+        fs.makedirs(path, exist_ok=False)
+
+    def remove(self, locator: ArtifactLocator, *, target_kind: TargetKind = "file") -> None:
+        """Remove a fsspec target."""
+        fs, path = self._filesystem_and_path(locator)
+        if fs.exists(path):
+            fs.rm(path, recursive=target_kind == "directory")
+
+    def _filesystem_and_path(self, locator: ArtifactLocator) -> tuple[Any, str]:
+        """Return the fsspec filesystem and backend path for a locator."""
+        if locator.kind != "urlpath":
+            raise ValueError(f"fsspec backend requires locator kind 'urlpath', got {locator.kind!r}")
+        fsspec = _load_fsspec()
+        fs, path = fsspec.core.url_to_fs(locator.value, **self._storage_options())
+        return fs, path
+
+    def _storage_options(self) -> dict[str, object]:
+        """Return a defensive copy of configured storage options."""
+        return {} if self.storage_options is None else dict(self.storage_options)
+
+
+def backend_for_locator(locator: ArtifactLocator) -> StorageBackend:
+    """Return the storage backend that can interpret a locator."""
+    if locator.kind == "path":
+        return LocalStorageBackend()
+    if locator.kind == "urlpath":
+        return FsspecStorageBackend()
+    raise ValueError(f"No storage backend for locator kind {locator.kind!r}")
+
+
+def plan_storage(
+    locator: ArtifactLocator,
+    *,
+    source: ArtifactLocator | None = None,
+    target_kind: TargetKind = "file",
+    write_mode: WriteMode = "reference",
+    overwrite: OverwritePolicy = "error",
+    checksum: ChecksumPolicy = "none",
+    ogcat_owned: bool = False,
+    profile: str | None = None,
+    backend: str | None = None,
+) -> StoragePlan:
+    """Build a storage plan from already-resolved storage decisions."""
+    return StoragePlan(
+        locator=locator,
+        source=source,
+        target_kind=target_kind,
+        write_mode=write_mode,
+        overwrite=overwrite,
+        checksum=checksum,
+        ogcat_owned=ogcat_owned,
+        profile=profile,
+        backend=backend,
+    )
+
+
+def execute_storage_plan(
+    plan: StoragePlan,
+    *,
+    source_path: Path | None,
+    register_rollback: Callable[[Callable[[], None], str], None] | None = None,
+) -> None:
+    """Execute a simple owned storage plan.
+
+    Args:
+        plan: Storage plan to execute.
+        source_path: Local source path for copy or move plans.
+        register_rollback: Optional callback that receives a cleanup callable
+            and description before data is written.
+    """
+    if plan.write_mode == "reference":
+        return
+    if not plan.ogcat_owned:
+        raise ValueError("Only ogcat-owned storage plans can be executed by ogcat core.")
+
+    backend = backend_for_locator(plan.locator)
+    if plan.overwrite == "error" and backend.exists(plan.locator):
+        raise FileExistsError(f"target already exists: {plan.locator.value}")
+    if plan.write_mode == "write":
+        _register_remove_rollback(plan, backend, register_rollback)
+        if plan.target_kind == "directory":
+            backend.mkdir(plan.locator)
+        return
+
+    if source_path is None:
+        raise ValueError(f"{plan.write_mode} storage plan requires a source path")
+
+    if plan.write_mode == "move" and plan.locator.kind == "path":
+        _register_local_move_rollback(plan, source_path, register_rollback)
+    else:
+        _register_remove_rollback(plan, backend, register_rollback)
+    if plan.write_mode == "copy":
+        backend.copy_from_path(source_path, plan.locator)
+        return
+    if plan.write_mode == "move":
+        backend.move_from_path(source_path, plan.locator)
+        return
+    raise ValueError(f"Unsupported storage write mode: {plan.write_mode}")
+
+
+def _register_local_move_rollback(
+    plan: StoragePlan,
+    source_path: Path,
+    register_rollback: Callable[[Callable[[], None], str], None] | None,
+) -> None:
+    """Register source restoration for local move plans."""
+    if register_rollback is None:
+        return
+    target_path = _path_locator(plan.locator)
+    register_rollback(
+        lambda source=source_path, target=target_path: _rollback_moved_file(source, target),
+        f"restore moved file from {target_path} to {source_path}",
+    )
+
+
+def _register_remove_rollback(
+    plan: StoragePlan,
+    backend: StorageBackend,
+    register_rollback: Callable[[Callable[[], None], str], None] | None,
+) -> None:
+    """Register cleanup for an owned target before it is created."""
+    if register_rollback is None:
+        return
+    register_rollback(
+        lambda locator=plan.locator, target_kind=plan.target_kind: backend.remove(
+            locator,
+            target_kind=target_kind,
+        ),
+        f"remove written {plan.target_kind} artifact {plan.locator.value}",
+    )
+
+
+def _path_locator(locator: ArtifactLocator) -> Path:
+    """Return a local path for a path-backed locator."""
+    path = locator.as_path()
+    if path is None:
+        raise ValueError(f"local backend requires locator kind 'path', got {locator.kind!r}")
+    return path
+
+
+def _rollback_moved_file(source_path: Path, target_path: Path) -> None:
+    """Restore a moved local file when possible, otherwise remove the target."""
+    if not target_path.exists():
+        return
+    if not source_path.exists():
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(target_path), str(source_path))
+        return
+    target_path.unlink(missing_ok=True)
+
+
+def _load_fsspec() -> Any:
+    """Import fsspec lazily and raise a clear optional-dependency error."""
+    try:
+        return importlib.import_module("fsspec")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "fsspec support requires the optional dependency. Install with 'ogcat[fsspec]'."
+        ) from exc
+
+
+__all__ = [
+    "ChecksumPolicy",
+    "FsspecStorageBackend",
+    "LocalStorageBackend",
+    "OverwritePolicy",
+    "StorageBackend",
+    "StoragePlan",
+    "TargetKind",
+    "WriteMode",
+    "backend_for_locator",
+    "execute_storage_plan",
+    "plan_storage",
+]

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -80,6 +80,14 @@ class StorageAdapter(Protocol):
         ...
 
 
+class _RollbackRegistrar(Protocol):
+    """Callable shape accepted by writer rollback helpers."""
+
+    def __call__(self, action: Callable[[], None], *, description: str | None = None) -> object:
+        """Register a rollback action with an optional description."""
+        ...
+
+
 @dataclass(frozen=True, slots=True)
 class LocalStorageAdapter:
     """Storage adapter for local path locators."""
@@ -259,7 +267,7 @@ def remove_target(
 
 
 def register_remove_on_rollback(
-    rollback: Callable[[Callable[[], None], str], object],
+    rollback: _RollbackRegistrar,
     locator: ArtifactLocator,
     *,
     target_kind: TargetKind = "file",
@@ -270,7 +278,7 @@ def register_remove_on_rollback(
     storage = require_storage_target(locator) if adapter is None else adapter
     rollback(
         lambda: storage.remove(locator, target_kind=target_kind),
-        description or f"remove written {target_kind} artifact {locator.value}",
+        description=description or f"remove written {target_kind} artifact {locator.value}",
     )
 
 

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -37,6 +37,8 @@ class StoragePlan:
         profile: Optional storage profile name or hint.
         adapter: Optional adapter identifier, such as ``"local"`` or
             ``"fsspec"``.
+        time_added: Optional timestamp used when rendering date-based storage
+            templates.
     """
 
     locator: ArtifactLocator
@@ -46,6 +48,7 @@ class StoragePlan:
     ogcat_owned: bool = False
     profile: str | None = None
     adapter: str | None = None
+    time_added: str | None = None
 
 
 class StorageAdapter(Protocol):
@@ -216,6 +219,7 @@ def plan_storage(
     ogcat_owned: bool = False,
     profile: str | None = None,
     adapter: str | None = None,
+    time_added: str | None = None,
 ) -> StoragePlan:
     """Build a storage plan from already-resolved storage decisions.
 
@@ -228,6 +232,8 @@ def plan_storage(
         profile: Optional storage profile name or hint.
         adapter: Optional adapter identifier, such as ``"local"`` or
             ``"fsspec"``.
+        time_added: Optional timestamp used when rendering date-based storage
+            templates.
 
     Returns:
         Storage plan describing the target and intended write.
@@ -240,6 +246,7 @@ def plan_storage(
         ogcat_owned=ogcat_owned,
         profile=profile,
         adapter=adapter,
+        time_added=time_added,
     )
 
 

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -28,6 +28,7 @@ from ogcat.hooks import OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, JsonValue, MetadataDict
 from ogcat.storage import (
     TargetKind,
+    WriteMode,
     adapter_for_locator,
     ensure_parent_directory,
     ensure_target_absent,
@@ -113,6 +114,7 @@ class FunctionArtifactWriter:
     write_function: SourceWriteFunction
     target_kind: TargetKind
     source_kind: str | None = None
+    write_mode: WriteMode = "write"
 
     def write(
         self,
@@ -141,6 +143,7 @@ class CopyArtifactWriter:
 
     source_kind: str = "local_file"
     target_kind: TargetKind = "file"
+    write_mode: WriteMode = "copy"
 
     def write(
         self,
@@ -173,6 +176,7 @@ class MoveArtifactWriter:
 
     source_kind: str = "local_file"
     target_kind: TargetKind = "file"
+    write_mode: WriteMode = "move"
 
     def write(
         self,
@@ -252,6 +256,8 @@ class UnzipArtifactWriter:
     """Example writer that safely extracts a zip file into a directory target."""
 
     source_kind: str = "zip_file"
+    target_kind: TargetKind = "directory"
+    write_mode: WriteMode = "write"
 
     def write(
         self,

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -183,12 +183,12 @@ class MoveArtifactWriter:
         """Move a local source path to the target and register rollback."""
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(f"move writer requires OperationSource(kind={self.source_kind!r}, path=...)")
-        adapter = adapter_for_locator(target)
-        ensure_target_absent(target, adapter=adapter)
         if target.kind != "path":
             raise ValueError("move writer currently requires a path-backed target for rollback-safe moves")
         if self.target_kind != "file":
             raise ValueError("move writer currently supports file targets only")
+        adapter = adapter_for_locator(target)
+        ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
         ensure_parent_directory(target, adapter=adapter)
         context.rollback(

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -22,12 +22,19 @@ import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 
 from ogcat.hooks import OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, JsonValue, MetadataDict
+from ogcat.storage import (
+    TargetKind,
+    adapter_for_locator,
+    ensure_parent_directory,
+    ensure_target_absent,
+    remove_target,
+    require_local_path,
+)
 
-TargetKind: TypeAlias = Literal["file", "directory"]
 SourceWriteFunction: TypeAlias = Callable[[OperationSource, Path], MetadataDict | None]
 MemoryWriteFunction: TypeAlias = Callable[[object, Path], MetadataDict | None]
 PathWriteFunction: TypeAlias = Callable[[Path, Path], MetadataDict | None]
@@ -126,6 +133,72 @@ class FunctionArtifactWriter:
         metadata = self.write_function(source, target_path)
         if metadata is not None:
             context.derived_metadata.update(metadata)
+
+
+@dataclass(frozen=True, slots=True)
+class CopyArtifactWriter:
+    """Artifact writer that copies a local source path to a storage target."""
+
+    source_kind: str = "local_file"
+    target_kind: TargetKind = "file"
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Copy a local source path to the target and register rollback."""
+        if source.kind != self.source_kind or source.path is None:
+            raise ValueError(f"copy writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+        if self.target_kind != "file":
+            raise ValueError("copy writer currently supports file targets only")
+        adapter = adapter_for_locator(target)
+        ensure_target_absent(target, adapter=adapter)
+        ensure_parent_directory(target, adapter=adapter)
+        context.rollback(
+            lambda locator=target, target_kind=self.target_kind, storage=adapter: remove_target(
+                locator,
+                target_kind=target_kind,
+                adapter=storage,
+            ),
+            description=f"remove copied {self.target_kind} artifact {target.value}",
+        )
+        adapter.copy_from_path(source.path, target)
+
+
+@dataclass(frozen=True, slots=True)
+class MoveArtifactWriter:
+    """Artifact writer that moves a local source path to a storage target."""
+
+    source_kind: str = "local_file"
+    target_kind: TargetKind = "file"
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Move a local source path to the target and register rollback."""
+        if source.kind != self.source_kind or source.path is None:
+            raise ValueError(f"move writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+        adapter = adapter_for_locator(target)
+        ensure_target_absent(target, adapter=adapter)
+        if target.kind != "path":
+            raise ValueError("move writer currently requires a path-backed target for rollback-safe moves")
+        if self.target_kind != "file":
+            raise ValueError("move writer currently supports file targets only")
+        target_path = require_local_path(target)
+        ensure_parent_directory(target, adapter=adapter)
+        context.rollback(
+            lambda source_path=source.path, stored_path=target_path: _rollback_moved_file(
+                source_path=source_path,
+                target_path=stored_path,
+            ),
+            description=f"restore moved file from {target_path} to {source.path}",
+        )
+        adapter.move_from_path(source.path, target)
 
 
 def source_writer(
@@ -245,9 +318,22 @@ def _remove_target(target_path: Path, target_kind: TargetKind) -> None:
     shutil.rmtree(target_path, ignore_errors=True)
 
 
+def _rollback_moved_file(*, source_path: Path, target_path: Path) -> None:
+    """Restore a moved file when possible, otherwise remove the moved target."""
+    if not target_path.exists():
+        return
+    if not source_path.exists():
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(target_path), str(source_path))
+        return
+    target_path.unlink(missing_ok=True)
+
+
 __all__ = [
+    "CopyArtifactWriter",
     "FunctionArtifactWriter",
     "MemoryWriteFunction",
+    "MoveArtifactWriter",
     "PathWriteFunction",
     "SourceWriteFunction",
     "TargetKind",

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -336,7 +336,6 @@ __all__ = [
     "MoveArtifactWriter",
     "PathWriteFunction",
     "SourceWriteFunction",
-    "TargetKind",
     "UnzipArtifactWriter",
     "memory_source",
     "memory_writer",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -513,7 +513,7 @@ def test_add_file_removes_partial_target_when_copy_fails(
         target_path.write_text("partial", encoding="utf-8")
         raise OSError("simulated copy failure")
 
-    monkeypatch.setattr("ogcat.catalog.shutil.copy2", fail_copy)
+    monkeypatch.setattr("ogcat.storage.shutil.copy2", fail_copy)
 
     with pytest.raises(OSError, match="simulated copy failure"):
         catalog.add_file(source)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -51,6 +51,24 @@ def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) ->
     assert catalog.repository.all() == []
 
 
+def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path) -> None:
+    """Records created from plans keep the timestamp used for date templates."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(directory_template="{year_added}", filename_template="{title}.txt"),
+        ),
+    )
+
+    plan = catalog.plan_artifact(metadata={"title": "planned"}, write_mode="reference")
+    record = catalog.add_artifact(record_type="managed_artifact", storage_plan=plan)
+
+    assert plan.time_added is not None
+    assert record.time_added == plan.time_added
+    assert record.locator.relative_path == f"files/{plan.time_added[:4]}/planned.txt"
+
+
 def test_plan_artifact_collision_uses_storage_adapter_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, RecordSchema
+from ogcat.storage import LocalStorageBackend, backend_for_locator, plan_storage
+
+
+def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) -> None:
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{species}/{year}",
+                filename_template="{title}{original_suffix}",
+            ),
+        ),
+    )
+
+    plan = catalog.plan_artifact(
+        source,
+        metadata={"species": "CO2", "year": 2024, "title": "paris"},
+        write_mode="copy",
+    )
+
+    expected = root / "files" / "CO2" / "2024" / "paris.nc"
+    assert plan.locator == ArtifactLocator.path(expected, relative_path="files/CO2/2024/paris.nc")
+    assert plan.write_mode == "copy"
+    assert plan.ogcat_owned
+    assert not expected.exists()
+    assert catalog.repository.all() == []
+
+
+def test_plan_artifact_collision_uses_storage_backend_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(directory_template="", filename_template="fixed{original_suffix}"),
+        ),
+    )
+    seen: list[str] = []
+
+    def fake_exists(self: LocalStorageBackend, locator: ArtifactLocator) -> bool:
+        seen.append(locator.value)
+        return Path(locator.value).name == "fixed.nc"
+
+    monkeypatch.setattr(LocalStorageBackend, "exists", fake_exists)
+
+    plan = catalog.plan_artifact(source, write_mode="copy")
+
+    assert Path(plan.locator.value).name == "fixed_2.nc"
+    assert [Path(value).name for value in seen] == ["fixed.nc", "fixed_2.nc"]
+
+
+def test_add_artifact_records_external_uri_without_existence_check(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="ssh://example.org/data/example.nc"),
+        storage_mode="external",
+    )
+
+    assert record.locator.kind == "uri"
+    assert record.storage_mode == "external"
+    assert record.stored_abspath is None
+
+
+def test_urlpath_backend_reports_missing_fsspec_only_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "fsspec":
+            raise ModuleNotFoundError(name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    local_backend = backend_for_locator(ArtifactLocator.path("/tmp/example.nc"))
+    assert isinstance(local_backend, LocalStorageBackend)
+    with pytest.raises(RuntimeError, match="Install with 'ogcat\\[fsspec\\]'"):
+        backend_for_locator(ArtifactLocator.urlpath("memory://example.nc")).exists(
+            ArtifactLocator.urlpath("memory://example.nc")
+        )
+
+
+def test_plan_storage_accepts_urlpath_locator_without_importing_fsspec() -> None:
+    plan = plan_storage(
+        ArtifactLocator.urlpath("ssh://example.org/path/data.zarr"),
+        target_kind="directory",
+        write_mode="reference",
+        ogcat_owned=False,
+    )
+
+    assert plan.locator.kind == "urlpath"
+    assert plan.write_mode == "reference"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -321,6 +321,8 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
 
     assert record.locator.kind == "urlpath"
     assert record.derived_metadata["writer"] == "redirected"
+    assert record.naming_metadata["storage_relative_path"] == "copied.nc"
+    assert record.naming_metadata["resolved_directory"] == ""
     assert record.naming_metadata["resolved_filename"] == "copied.nc"
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,7 @@ from ogcat.storage import (
 
 
 def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) -> None:
+    """Planning renders local templates but does not create files or records."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
     root = tmp_path / "catalog"
@@ -53,6 +55,7 @@ def test_plan_artifact_collision_uses_storage_adapter_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Local planning asks the storage adapter when allocating a suffix."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
     catalog = Catalog.create(
@@ -80,6 +83,7 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Remote planning skips fsspec imports when the optional dependency is absent."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
     catalog = Catalog.create(
@@ -92,13 +96,20 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
         ),
     )
     real_import_module = importlib.import_module
+    real_find_spec = importlib.util.find_spec
 
     def fake_import_module(name: str, package: str | None = None) -> object:
         if name == "fsspec":
             raise AssertionError("planning should not import fsspec")
         return real_import_module(name, package)
 
+    def fake_find_spec(name: str):
+        if name == "fsspec":
+            return None
+        return real_find_spec(name)
+
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
 
     plan = catalog.plan_artifact(
         source,
@@ -114,7 +125,43 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
     assert plan.adapter == "fsspec"
 
 
+def test_plan_artifact_urlpath_root_uses_available_collision_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote planning allocates a unique suffix when a URL path is known to exist."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files", default_schema=RecordSchema(filename_template="fixed{original_suffix}")
+        ),
+    )
+    seen: list[str] = []
+
+    def fake_exists(urlpath: str) -> bool:
+        seen.append(urlpath)
+        return urlpath.endswith("/fixed.nc")
+
+    monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", fake_exists)
+
+    plan = catalog.plan_artifact(source, storage_root="s3://bucket/prefix", write_mode="copy")
+
+    assert plan.locator == ArtifactLocator.from_urlpath(
+        "s3://bucket/prefix/2026/source/fixed_2.nc",
+        relative_path="2026/source/fixed_2.nc",
+    )
+    assert seen == (
+        [
+            "s3://bucket/prefix/2026/source/fixed.nc",
+            "s3://bucket/prefix/2026/source/fixed_2.nc",
+        ]
+    )
+
+
 def test_plan_artifact_custom_local_root_has_no_catalog_relative_path(tmp_path: Path) -> None:
+    """Custom local storage roots do not populate catalog-relative compatibility paths."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
     external_root = tmp_path / "external-root"
@@ -146,6 +193,8 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Hook-redirected add_file operations keep plan metadata consistent."""
+
     class RedirectHook:
         def resolve_artifact_locator(self, context: OperationContext) -> None:
             context.planned_locators = [
@@ -182,9 +231,11 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
 
     assert record.locator.kind == "urlpath"
     assert record.derived_metadata["writer"] == "redirected"
+    assert record.naming_metadata["resolved_filename"] == "copied.nc"
 
 
 def test_add_artifact_records_external_uri_without_existence_check(tmp_path: Path) -> None:
+    """External URI references are recorded without filesystem checks."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     record = catalog.add_artifact(
@@ -201,6 +252,7 @@ def test_add_artifact_records_external_uri_without_existence_check(tmp_path: Pat
 def test_urlpath_adapter_reports_missing_fsspec_only_when_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """URL-path adapters raise the optional fsspec error only when used."""
     real_import_module = importlib.import_module
 
     def fake_import_module(name: str, package: str | None = None) -> object:
@@ -219,6 +271,7 @@ def test_urlpath_adapter_reports_missing_fsspec_only_when_requested(
 
 
 def test_plan_storage_accepts_urlpath_locator_without_importing_fsspec() -> None:
+    """StoragePlan construction is descriptive and does not load fsspec."""
     plan = plan_storage(
         ArtifactLocator.from_urlpath("ssh://example.org/path/data.zarr"),
         target_kind="directory",
@@ -231,15 +284,14 @@ def test_plan_storage_accepts_urlpath_locator_without_importing_fsspec() -> None
 
 
 def test_artifact_locator_constructor_aliases(tmp_path: Path) -> None:
+    """The path constructor alias remains compatible with from_path."""
     path = tmp_path / "example.nc"
 
     assert ArtifactLocator.from_path(path) == ArtifactLocator.path(path)
-    assert ArtifactLocator.from_urlpath("memory://example.nc") == ArtifactLocator.urlpath(
-        "memory://example.nc"
-    )
 
 
 def test_storage_helpers_prepare_and_remove_local_targets(tmp_path: Path) -> None:
+    """Storage helper functions create parents, reject collisions, and remove targets."""
     file_locator = ArtifactLocator.from_path(tmp_path / "nested" / "output.txt")
     directory_locator = ArtifactLocator.from_path(tmp_path / "store.zarr")
 
@@ -262,6 +314,7 @@ def test_storage_helpers_prepare_and_remove_local_targets(tmp_path: Path) -> Non
 
 
 def test_register_remove_on_rollback_uses_keyword_description(tmp_path: Path) -> None:
+    """Rollback helper passes descriptions using the OperationContext-compatible keyword."""
     target = tmp_path / "written.txt"
     target.write_text("payload", encoding="utf-8")
     actions = []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import pytest
 
-from ogcat import ArtifactLocator, Catalog, CatalogSpec, RecordSchema
+import ogcat.catalog as catalog_module
+from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
+from ogcat.hooks import OperationContext, OperationSource
 from ogcat.storage import (
     LocalStorageAdapter,
     adapter_for_locator,
@@ -72,6 +74,114 @@ def test_plan_artifact_collision_uses_storage_adapter_exists(
 
     assert Path(plan.locator.value).name == "fixed_2.nc"
     assert [Path(value).name for value in seen] == ["fixed.nc", "fixed_2.nc"]
+
+
+def test_plan_artifact_urlpath_root_does_not_import_fsspec(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{species}", filename_template="{title}{original_suffix}"
+            ),
+        ),
+    )
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "fsspec":
+            raise AssertionError("planning should not import fsspec")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    plan = catalog.plan_artifact(
+        source,
+        metadata={"species": "CO2", "title": "remote"},
+        storage_root="s3://bucket/prefix",
+        write_mode="copy",
+    )
+
+    assert plan.locator == ArtifactLocator.from_urlpath(
+        "s3://bucket/prefix/CO2/remote.nc",
+        relative_path="CO2/remote.nc",
+    )
+    assert plan.adapter == "fsspec"
+
+
+def test_plan_artifact_custom_local_root_has_no_catalog_relative_path(tmp_path: Path) -> None:
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    external_root = tmp_path / "external-root"
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{species}", filename_template="{title}{original_suffix}"
+            ),
+        ),
+    )
+
+    plan = catalog.plan_artifact(
+        source,
+        metadata={"species": "CO2", "title": "external"},
+        storage_root=external_root,
+        write_mode="reference",
+        ogcat_owned=False,
+    )
+    record = catalog.add_artifact(record_type="external_file", storage_plan=plan)
+
+    assert plan.locator == ArtifactLocator.from_path(external_root / "CO2" / "external.nc")
+    assert record.stored_relpath is None
+    assert record.locator.relative_path is None
+
+
+def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RedirectHook:
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            context.planned_locators = [
+                ArtifactLocator.from_urlpath(
+                    "memory://bucket/copied.nc",
+                    relative_path="copied.nc",
+                )
+            ]
+
+        def before_record_write(self, context: OperationContext) -> None:
+            assert context.storage_plan is not None
+            assert context.storage_plan.locator.kind == "urlpath"
+            assert context.storage_plan.adapter == "fsspec"
+
+    def fake_write(self, context: OperationContext, source: OperationSource, target: ArtifactLocator) -> None:
+        assert source.path == source_file
+        assert target.kind == "urlpath"
+        context.derived_metadata["writer"] = "redirected"
+
+    def fail_extract(path: Path) -> dict[str, object]:
+        raise AssertionError(f"path extractor should not run for redirected target {path}")
+
+    source_file = tmp_path / "source.nc"
+    source_file.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        plugins=PluginRegistry([RedirectHook()]),
+    )
+    monkeypatch.setattr(catalog_module.CopyArtifactWriter, "write", fake_write)
+    monkeypatch.setattr(catalog_module, "extract_derived_metadata", fail_extract)
+
+    record = catalog.add_file(source_file, operation="copy")
+
+    assert record.locator.kind == "urlpath"
+    assert record.derived_metadata["writer"] == "redirected"
 
 
 def test_add_artifact_records_external_uri_without_existence_check(tmp_path: Path) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -9,6 +9,7 @@ import pytest
 import ogcat.catalog as catalog_module
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
 from ogcat.hooks import OperationContext, OperationSource
+from ogcat.models import MetadataDict
 from ogcat.storage import (
     LocalStorageAdapter,
     adapter_for_locator,
@@ -21,7 +22,7 @@ from ogcat.storage import (
 )
 
 
-def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) -> None:
+def test_plan_artifact_storage_renders_local_template_without_writing(tmp_path: Path) -> None:
     """Planning renders local templates but does not create files or records."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
@@ -37,7 +38,7 @@ def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) ->
         ),
     )
 
-    plan = catalog.plan_artifact(
+    plan = catalog.plan_artifact_storage(
         source,
         metadata={"species": "CO2", "year": 2024, "title": "paris"},
         write_mode="copy",
@@ -46,6 +47,9 @@ def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) ->
     expected = root / "files" / "CO2" / "2024" / "paris.nc"
     assert plan.locator == ArtifactLocator.from_path(expected, relative_path="files/CO2/2024/paris.nc")
     assert plan.write_mode == "copy"
+    assert plan.storage_relative_path == "CO2/2024/paris.nc"
+    assert plan.resolved_directory == "CO2/2024"
+    assert plan.resolved_filename == "paris.nc"
     assert plan.ogcat_owned
     assert not expected.exists()
     assert catalog.repository.all() == []
@@ -61,15 +65,22 @@ def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path
         ),
     )
 
-    plan = catalog.plan_artifact(metadata={"title": "planned"}, write_mode="reference")
-    record = catalog.add_artifact(record_type="managed_artifact", storage_plan=plan)
+    metadata: MetadataDict = {"title": "planned"}
+    plan = catalog.plan_artifact_storage(metadata=metadata, write_mode="reference")
+    record = catalog.add_artifact(
+        record_type="managed_artifact",
+        storage_plan=plan,
+        metadata=metadata,
+    )
 
     assert plan.time_added is not None
     assert record.time_added == plan.time_added
     assert record.locator.relative_path == f"files/{plan.time_added[:4]}/planned.txt"
+    assert record.user_metadata == metadata
+    assert record.naming_metadata["resolved_filename"] == "planned.txt"
 
 
-def test_plan_artifact_collision_uses_storage_adapter_exists(
+def test_plan_artifact_storage_collision_uses_storage_adapter_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -91,13 +102,13 @@ def test_plan_artifact_collision_uses_storage_adapter_exists(
 
     monkeypatch.setattr(LocalStorageAdapter, "exists", fake_exists)
 
-    plan = catalog.plan_artifact(source, write_mode="copy")
+    plan = catalog.plan_artifact_storage(source, write_mode="copy")
 
     assert Path(plan.locator.value).name == "fixed_2.nc"
     assert [Path(value).name for value in seen] == ["fixed.nc", "fixed_2.nc"]
 
 
-def test_plan_artifact_urlpath_root_does_not_import_fsspec(
+def test_plan_artifact_storage_urlpath_root_does_not_import_fsspec(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -129,7 +140,7 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
 
-    plan = catalog.plan_artifact(
+    plan = catalog.plan_artifact_storage(
         source,
         metadata={"species": "CO2", "title": "remote"},
         storage_root="s3://bucket/prefix",
@@ -141,6 +152,9 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
     )
     assert plan.locator.relative_path is None
     assert plan.adapter == "fsspec"
+    assert plan.storage_relative_path == "CO2/remote.nc"
+    assert plan.resolved_directory == "CO2"
+    assert plan.resolved_filename == "remote.nc"
 
 
 def test_urlpath_storage_root_does_not_populate_stored_relpath(
@@ -161,7 +175,7 @@ def test_urlpath_storage_root_does_not_populate_stored_relpath(
     )
     monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", lambda _urlpath: False)
 
-    plan = catalog.plan_artifact(
+    plan = catalog.plan_artifact_storage(
         source,
         metadata={"species": "CO2", "title": "remote"},
         storage_root="s3://bucket/prefix",
@@ -178,7 +192,23 @@ def test_urlpath_storage_root_does_not_populate_stored_relpath(
     assert record.stored_relpath is None
 
 
-def test_plan_artifact_urlpath_root_uses_available_collision_check(
+def test_urlpath_locator_relative_path_does_not_populate_stored_relpath(tmp_path: Path) -> None:
+    """Explicit URL-path relative paths do not fill local compatibility fields."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_artifact(
+        record_type="remote_file",
+        locator=ArtifactLocator.from_urlpath(
+            "s3://bucket/prefix/example.nc",
+            relative_path="prefix/example.nc",
+        ),
+    )
+
+    assert record.locator.relative_path == "prefix/example.nc"
+    assert record.stored_relpath is None
+
+
+def test_plan_artifact_storage_urlpath_root_uses_available_collision_check(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -199,7 +229,7 @@ def test_plan_artifact_urlpath_root_uses_available_collision_check(
 
     monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", fake_exists)
 
-    plan = catalog.plan_artifact(source, storage_root="s3://bucket/prefix", write_mode="copy")
+    plan = catalog.plan_artifact_storage(source, storage_root="s3://bucket/prefix", write_mode="copy")
 
     assert plan.locator == ArtifactLocator.from_urlpath(
         "s3://bucket/prefix/2026/source/fixed_2.nc",
@@ -213,7 +243,7 @@ def test_plan_artifact_urlpath_root_uses_available_collision_check(
     )
 
 
-def test_plan_artifact_custom_local_root_has_no_catalog_relative_path(tmp_path: Path) -> None:
+def test_plan_artifact_storage_custom_local_root_has_no_catalog_relative_path(tmp_path: Path) -> None:
     """Custom local storage roots do not populate catalog-relative compatibility paths."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
@@ -228,16 +258,23 @@ def test_plan_artifact_custom_local_root_has_no_catalog_relative_path(tmp_path: 
         ),
     )
 
-    plan = catalog.plan_artifact(
+    plan = catalog.plan_artifact_storage(
         source,
         metadata={"species": "CO2", "title": "external"},
         storage_root=external_root,
         write_mode="reference",
         ogcat_owned=False,
     )
-    record = catalog.add_artifact(record_type="external_file", storage_plan=plan)
+    record = catalog.add_artifact(
+        record_type="external_file",
+        storage_plan=plan,
+        metadata={"species": "CO2", "title": "external"},
+    )
 
     assert plan.locator == ArtifactLocator.from_path(external_root / "CO2" / "external.nc")
+    assert plan.storage_relative_path == "CO2/external.nc"
+    assert plan.resolved_directory == "CO2"
+    assert plan.resolved_filename == "external.nc"
     assert record.stored_relpath is None
     assert record.locator.relative_path is None
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -13,6 +13,7 @@ from ogcat.storage import (
     ensure_parent_directory,
     ensure_target_absent,
     plan_storage,
+    register_remove_on_rollback,
     remove_target,
 )
 
@@ -148,3 +149,24 @@ def test_storage_helpers_prepare_and_remove_local_targets(tmp_path: Path) -> Non
     remove_target(directory_locator, target_kind="directory")
     assert not (tmp_path / "nested" / "output.txt").exists()
     assert not (tmp_path / "store.zarr").exists()
+
+
+def test_register_remove_on_rollback_uses_keyword_description(tmp_path: Path) -> None:
+    target = tmp_path / "written.txt"
+    target.write_text("payload", encoding="utf-8")
+    actions = []
+    descriptions: list[str | None] = []
+
+    def rollback(action, *, description: str | None = None):
+        actions.append(action)
+        descriptions.append(description)
+
+    register_remove_on_rollback(
+        rollback,
+        ArtifactLocator.from_path(target),
+        description="remove test target",
+    )
+
+    assert descriptions == ["remove test target"]
+    actions[0]()
+    assert not target.exists()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -120,9 +120,44 @@ def test_plan_artifact_urlpath_root_does_not_import_fsspec(
 
     assert plan.locator == ArtifactLocator.from_urlpath(
         "s3://bucket/prefix/CO2/remote.nc",
-        relative_path="CO2/remote.nc",
     )
+    assert plan.locator.relative_path is None
     assert plan.adapter == "fsspec"
+
+
+def test_urlpath_storage_root_does_not_populate_stored_relpath(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote planned locators do not fill local compatibility path fields."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{species}", filename_template="{title}{original_suffix}"
+            ),
+        ),
+    )
+    monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", lambda _urlpath: False)
+
+    plan = catalog.plan_artifact(
+        source,
+        metadata={"species": "CO2", "title": "remote"},
+        storage_root="s3://bucket/prefix",
+        write_mode="reference",
+    )
+    record = catalog.add_artifact(
+        record_type="managed_file",
+        storage_plan=plan,
+        metadata={"species": "CO2", "title": "remote"},
+    )
+
+    assert record.locator.kind == "urlpath"
+    assert record.locator.relative_path is None
+    assert record.stored_relpath is None
 
 
 def test_plan_artifact_urlpath_root_uses_available_collision_check(
@@ -150,8 +185,8 @@ def test_plan_artifact_urlpath_root_uses_available_collision_check(
 
     assert plan.locator == ArtifactLocator.from_urlpath(
         "s3://bucket/prefix/2026/source/fixed_2.nc",
-        relative_path="2026/source/fixed_2.nc",
     )
+    assert plan.locator.relative_path is None
     assert seen == (
         [
             "s3://bucket/prefix/2026/source/fixed.nc",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,15 @@ from pathlib import Path
 import pytest
 
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, RecordSchema
-from ogcat.storage import LocalStorageBackend, backend_for_locator, plan_storage
+from ogcat.storage import (
+    LocalStorageAdapter,
+    adapter_for_locator,
+    create_directory_target,
+    ensure_parent_directory,
+    ensure_target_absent,
+    plan_storage,
+    remove_target,
+)
 
 
 def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) -> None:
@@ -31,14 +39,14 @@ def test_plan_artifact_renders_local_template_without_writing(tmp_path: Path) ->
     )
 
     expected = root / "files" / "CO2" / "2024" / "paris.nc"
-    assert plan.locator == ArtifactLocator.path(expected, relative_path="files/CO2/2024/paris.nc")
+    assert plan.locator == ArtifactLocator.from_path(expected, relative_path="files/CO2/2024/paris.nc")
     assert plan.write_mode == "copy"
     assert plan.ogcat_owned
     assert not expected.exists()
     assert catalog.repository.all() == []
 
 
-def test_plan_artifact_collision_uses_storage_backend_exists(
+def test_plan_artifact_collision_uses_storage_adapter_exists(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -53,11 +61,11 @@ def test_plan_artifact_collision_uses_storage_backend_exists(
     )
     seen: list[str] = []
 
-    def fake_exists(self: LocalStorageBackend, locator: ArtifactLocator) -> bool:
+    def fake_exists(self: LocalStorageAdapter, locator: ArtifactLocator) -> bool:
         seen.append(locator.value)
         return Path(locator.value).name == "fixed.nc"
 
-    monkeypatch.setattr(LocalStorageBackend, "exists", fake_exists)
+    monkeypatch.setattr(LocalStorageAdapter, "exists", fake_exists)
 
     plan = catalog.plan_artifact(source, write_mode="copy")
 
@@ -79,7 +87,7 @@ def test_add_artifact_records_external_uri_without_existence_check(tmp_path: Pat
     assert record.stored_abspath is None
 
 
-def test_urlpath_backend_reports_missing_fsspec_only_when_requested(
+def test_urlpath_adapter_reports_missing_fsspec_only_when_requested(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     real_import_module = importlib.import_module
@@ -91,17 +99,17 @@ def test_urlpath_backend_reports_missing_fsspec_only_when_requested(
 
     monkeypatch.setattr(importlib, "import_module", fake_import_module)
 
-    local_backend = backend_for_locator(ArtifactLocator.path("/tmp/example.nc"))
-    assert isinstance(local_backend, LocalStorageBackend)
+    local_adapter = adapter_for_locator(ArtifactLocator.from_path("/tmp/example.nc"))
+    assert isinstance(local_adapter, LocalStorageAdapter)
     with pytest.raises(RuntimeError, match="Install with 'ogcat\\[fsspec\\]'"):
-        backend_for_locator(ArtifactLocator.urlpath("memory://example.nc")).exists(
-            ArtifactLocator.urlpath("memory://example.nc")
+        adapter_for_locator(ArtifactLocator.from_urlpath("memory://example.nc")).exists(
+            ArtifactLocator.from_urlpath("memory://example.nc")
         )
 
 
 def test_plan_storage_accepts_urlpath_locator_without_importing_fsspec() -> None:
     plan = plan_storage(
-        ArtifactLocator.urlpath("ssh://example.org/path/data.zarr"),
+        ArtifactLocator.from_urlpath("ssh://example.org/path/data.zarr"),
         target_kind="directory",
         write_mode="reference",
         ogcat_owned=False,
@@ -109,3 +117,34 @@ def test_plan_storage_accepts_urlpath_locator_without_importing_fsspec() -> None
 
     assert plan.locator.kind == "urlpath"
     assert plan.write_mode == "reference"
+
+
+def test_artifact_locator_constructor_aliases(tmp_path: Path) -> None:
+    path = tmp_path / "example.nc"
+
+    assert ArtifactLocator.from_path(path) == ArtifactLocator.path(path)
+    assert ArtifactLocator.from_urlpath("memory://example.nc") == ArtifactLocator.urlpath(
+        "memory://example.nc"
+    )
+
+
+def test_storage_helpers_prepare_and_remove_local_targets(tmp_path: Path) -> None:
+    file_locator = ArtifactLocator.from_path(tmp_path / "nested" / "output.txt")
+    directory_locator = ArtifactLocator.from_path(tmp_path / "store.zarr")
+
+    ensure_parent_directory(file_locator)
+    assert (tmp_path / "nested").is_dir()
+    ensure_target_absent(file_locator)
+    (tmp_path / "nested" / "output.txt").write_text("payload", encoding="utf-8")
+    with pytest.raises(FileExistsError, match="target already exists"):
+        ensure_target_absent(file_locator)
+
+    create_directory_target(directory_locator)
+    assert (tmp_path / "store.zarr").is_dir()
+    with pytest.raises(FileExistsError, match="target already exists"):
+        create_directory_target(directory_locator)
+
+    remove_target(file_locator)
+    remove_target(directory_locator, target_kind="directory")
+    assert not (tmp_path / "nested" / "output.txt").exists()
+    assert not (tmp_path / "store.zarr").exists()

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import ogcat.writers as writers_module
 from ogcat import (
     ArtifactLocator,
     Catalog,
@@ -213,6 +214,31 @@ def test_move_artifact_writer_restores_source_on_rollback(tmp_path: Path) -> Non
 
     assert source.read_text(encoding="utf-8") == "payload"
     assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_move_artifact_writer_rejects_urlpath_before_adapter_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    def fail_adapter_lookup(target: ArtifactLocator):
+        raise AssertionError(f"adapter lookup should not run for {target.kind!r}")
+
+    monkeypatch.setattr(writers_module, "adapter_for_locator", fail_adapter_lookup)
+
+    with pytest.raises(ValueError, match="path-backed target"):
+        catalog.add_artifact(
+            record_type="moved_file",
+            locator=ArtifactLocator.from_urlpath("memory://catalog/files/moved.txt"),
+            source=path_source(source, kind="local_file"),
+            artifact_writer=MoveArtifactWriter(),
+        )
+
+    assert source.read_text(encoding="utf-8") == "payload"
     assert catalog.repository.all() == []
 
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import zipfile
 from pathlib import Path
 
@@ -11,11 +12,13 @@ from ogcat import (
     CatalogSpec,
     OperationSource,
     PluginRegistry,
+    RecordSchema,
     UnzipArtifactWriter,
     memory_source,
     memory_writer,
     path_source,
     path_writer,
+    plan_storage,
     source_writer,
 )
 from ogcat.hooks import OperationContext
@@ -135,3 +138,76 @@ def test_unzip_artifact_writer_rejects_path_traversal(tmp_path: Path) -> None:
 
     assert not target.exists()
     assert not (tmp_path / "escape.txt").exists()
+
+
+def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: Path) -> None:
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop after planned write")
+
+    class PlanAwareDirectoryWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            assert context.storage_plan is not None
+            assert context.storage_plan.target_kind == "directory"
+            assert context.storage_plan.locator == target
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.mkdir(parents=True, exist_ok=False)
+            (target_path / "payload.txt").write_text(str(source.payload), encoding="utf-8")
+            context.rollback(
+                lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+                description="remove planned directory",
+            )
+
+    target = tmp_path / "catalog" / "files" / "stores" / "example.zarr"
+    plan = plan_storage(
+        ArtifactLocator.path(target, relative_path="files/stores/example.zarr"),
+        target_kind="directory",
+        write_mode="write",
+        ogcat_owned=True,
+        backend="local",
+    )
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with pytest.raises(RuntimeError, match="stop after planned write"):
+        catalog.add_artifact(
+            record_type="zarr_store",
+            storage_plan=plan,
+            source=memory_source("zarr-ish", kind="memory"),
+            artifact_writer=PlanAwareDirectoryWriter(),
+        )
+
+    assert not target.exists()
+
+
+def test_plan_artifact_can_allocate_zarr_directory_name(tmp_path: Path) -> None:
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="artifacts",
+            record_schemas={
+                "zarr_store": RecordSchema(
+                    directory_template="{species}/{domain}",
+                    filename_template="{title}.zarr",
+                )
+            },
+        ),
+    )
+
+    plan = catalog.plan_artifact(
+        record_type="zarr_store",
+        metadata={"species": "CO2", "domain": "EUROPE", "title": "my_store"},
+        target_kind="directory",
+        write_mode="write",
+    )
+
+    assert plan.target_kind == "directory"
+    assert Path(plan.locator.value).name == "my_store.zarr"
+    assert Path(plan.locator.value).parent.name == "EUROPE"
+    assert not Path(plan.locator.value).exists()

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -323,7 +323,8 @@ def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: 
     assert not target.exists()
 
 
-def test_plan_artifact_can_allocate_zarr_directory_name(tmp_path: Path) -> None:
+def test_plan_artifact_storage_can_allocate_zarr_directory_name(tmp_path: Path) -> None:
+    """Storage planning can allocate directory-like Zarr store names."""
     catalog = Catalog.create(
         tmp_path / "catalog",
         CatalogSpec(
@@ -337,7 +338,7 @@ def test_plan_artifact_can_allocate_zarr_directory_name(tmp_path: Path) -> None:
         ),
     )
 
-    plan = catalog.plan_artifact(
+    plan = catalog.plan_artifact_storage(
         record_type="zarr_store",
         metadata={"species": "CO2", "domain": "EUROPE", "title": "my_store"},
         target_kind="directory",

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -29,6 +29,8 @@ from ogcat.models import MetadataDict
 
 
 def test_memory_writer_writes_file_and_persists_metadata(tmp_path: Path) -> None:
+    """Memory writer writes file data and records returned metadata."""
+
     def write_text(data: object, target: Path) -> MetadataDict:
         text = str(data)
         target.write_text(text, encoding="utf-8")
@@ -49,6 +51,8 @@ def test_memory_writer_writes_file_and_persists_metadata(tmp_path: Path) -> None
 
 
 def test_path_writer_writes_directory_and_rolls_back_on_hook_failure(tmp_path: Path) -> None:
+    """Path writer directory targets are cleaned up on later hook failure."""
+
     def copy_tree(source: Path, target: Path) -> MetadataDict:
         (target / "copied.txt").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
         return {"copied": True}
@@ -75,7 +79,38 @@ def test_path_writer_writes_directory_and_rolls_back_on_hook_failure(tmp_path: P
     assert catalog.repository.all() == []
 
 
+def test_locator_writer_fallback_plan_uses_writer_intent(tmp_path: Path) -> None:
+    """Plain locator-plus-writer calls expose writer storage intent in context."""
+    seen: list[tuple[str, str]] = []
+
+    def copy_tree(source: Path, target: Path) -> MetadataDict:
+        (target / "copied.txt").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        return {}
+
+    class InspectPlanHook:
+        def extract_metadata(self, context: OperationContext) -> None:
+            assert context.storage_plan is not None
+            seen.append((context.storage_plan.target_kind, context.storage_plan.write_mode))
+
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    target = tmp_path / "directory-target"
+    registry = PluginRegistry([InspectPlanHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    catalog.add_artifact(
+        record_type="processed_directory",
+        locator=ArtifactLocator.path(target),
+        source=path_source(source, kind="local_text"),
+        artifact_writer=path_writer(copy_tree, target_kind="directory", source_kind="local_text"),
+    )
+
+    assert seen == [("directory", "write")]
+
+
 def test_source_writer_receives_full_operation_source(tmp_path: Path) -> None:
+    """Source writer receives the full OperationSource object."""
+
     def write_source(source: OperationSource, target: Path) -> MetadataDict:
         assert source.path is None
         assert source.payload == {"value": 3}

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -10,6 +10,8 @@ from ogcat import (
     ArtifactLocator,
     Catalog,
     CatalogSpec,
+    CopyArtifactWriter,
+    MoveArtifactWriter,
     OperationSource,
     PluginRegistry,
     RecordSchema,
@@ -140,6 +142,80 @@ def test_unzip_artifact_writer_rejects_path_traversal(tmp_path: Path) -> None:
     assert not (tmp_path / "escape.txt").exists()
 
 
+def test_non_reference_storage_plan_requires_writer(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    target = tmp_path / "catalog" / "files" / "generated.txt"
+    plan = plan_storage(
+        ArtifactLocator.from_path(target, relative_path="files/generated.txt"),
+        write_mode="write",
+        ogcat_owned=True,
+    )
+
+    with pytest.raises(ValueError, match="requires an artifact_writer"):
+        catalog.add_artifact(record_type="generated_text", storage_plan=plan)
+
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_copy_artifact_writer_materialises_file_and_rolls_back(tmp_path: Path) -> None:
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop after copy")
+
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    target = tmp_path / "catalog" / "files" / "copied.txt"
+    plan = plan_storage(
+        ArtifactLocator.from_path(target, relative_path="files/copied.txt"),
+        write_mode="copy",
+        ogcat_owned=True,
+    )
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with pytest.raises(RuntimeError, match="stop after copy"):
+        catalog.add_artifact(
+            record_type="copied_file",
+            storage_plan=plan,
+            source=path_source(source, kind="local_file"),
+            artifact_writer=CopyArtifactWriter(),
+        )
+
+    assert source.exists()
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_move_artifact_writer_restores_source_on_rollback(tmp_path: Path) -> None:
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop after move")
+
+    source = tmp_path / "source.txt"
+    source.write_text("payload", encoding="utf-8")
+    target = tmp_path / "catalog" / "files" / "moved.txt"
+    plan = plan_storage(
+        ArtifactLocator.from_path(target, relative_path="files/moved.txt"),
+        write_mode="move",
+        ogcat_owned=True,
+    )
+    registry = PluginRegistry([FailingHook()])
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)
+
+    with pytest.raises(RuntimeError, match="stop after move"):
+        catalog.add_artifact(
+            record_type="moved_file",
+            storage_plan=plan,
+            source=path_source(source, kind="local_file"),
+            artifact_writer=MoveArtifactWriter(),
+        )
+
+    assert source.read_text(encoding="utf-8") == "payload"
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
 def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: Path) -> None:
     class FailingHook:
         def before_record_write(self, context: OperationContext) -> None:
@@ -166,11 +242,11 @@ def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: 
 
     target = tmp_path / "catalog" / "files" / "stores" / "example.zarr"
     plan = plan_storage(
-        ArtifactLocator.path(target, relative_path="files/stores/example.zarr"),
+        ArtifactLocator.from_path(target, relative_path="files/stores/example.zarr"),
         target_kind="directory",
         write_mode="write",
         ogcat_owned=True,
-        backend="local",
+        adapter="local",
     )
     registry = PluginRegistry([FailingHook()])
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"), plugins=registry)

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "furo"
 version = "2025.12.19"
 source = { registry = "https://pypi.org/simple" }
@@ -496,12 +505,16 @@ docs = [
     { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx-autodoc-typehints", version = "3.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
+fsspec = [
+    { name = "fsspec" },
+]
 netcdf = [
     { name = "xarray" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fsspec", marker = "extra == 'fsspec'", specifier = ">=2024.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2" },
@@ -515,7 +528,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "xarray", marker = "extra == 'netcdf'", specifier = ">=2024.0" },
 ]
-provides-extras = ["netcdf", "dev", "docs"]
+provides-extras = ["fsspec", "netcdf", "dev", "docs"]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary
- Add `StoragePlan` and lightweight storage backend primitives for local and fsspec-aware artifact handling.
- Add `Catalog.plan_artifact()` and thread planned storage through `OperationContext`, hooks, and `add_artifact()`.
- Refactor managed file ingest to use the shared planning path while keeping existing local `add_file()` behavior intact.
- Document `path`, `uri`, and `urlpath` locator use cases plus optional `ogcat[fsspec]` support.

## Testing
- Added unit tests for dry-run planning, collision handling, external URI cataloguing, planned directory writes, and fsspec-missing behavior.
- Ran the full pytest suite successfully.
- Ran Sphinx docs build successfully.