### PR TITLE
Validate search filters and normalize metadata inputs

### DIFF
--- a/docs/api/search.rst
+++ b/docs/api/search.rst
@@ -1,6 +1,22 @@
 Search and record sets
 ======================
 
+Contains semantics
+------------------
+
+``Catalog.search(contains=...)`` keeps the comparison rules simple and
+type-directed:
+
+* strings use substring containment;
+* lists and other stored sequences use membership matching, and a list expected
+  value requires every expected item to be present;
+* mappings match an expected mapping as a subset of key/value pairs;
+* scalar values fall back to equality.
+
+Search filter arguments such as ``where``, ``contains``, ``regex``, and
+``match`` must be mappings from field name to expected value. ``exists`` and
+``missing`` must be sequences of field names, not bare strings.
+
 .. autoclass:: ogcat.SearchQuery
    :members:
    :member-order: bysource

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -20,14 +20,17 @@ fixed set of reserved fields plus three metadata namespaces.
 
 ``user_metadata``
 :   Key–value pairs supplied by the caller at ingest time.  Any
-    JSON-serialisable value is accepted.  This is the primary place to store
-    domain metadata such as species, year, or instrument.
+    JSON-compatible value is accepted. Common Python values such as
+    `pathlib.Path`, tuples, sets, and NumPy scalar-like values are normalized
+    before the record is validated and stored. This is the primary place to
+    store domain metadata such as species, year, or instrument.
 
 ``derived_metadata``
 :   Metadata added automatically during ingest by extractors and hooks.  For
     netCDF files this includes dimension names and sizes when ``xarray`` is
-    installed.  Do not rely on derived metadata being present for every file
-    type.
+    installed. Derived metadata is normalized with the same JSON-compatible
+    rules before storage. Do not rely on derived metadata being present for
+    every file type.
 
 ``naming_metadata``
 :   Internal metadata used to evaluate directory and filename templates.  You

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -21,9 +21,10 @@ fixed set of reserved fields plus three metadata namespaces.
 ``user_metadata``
 :   Key–value pairs supplied by the caller at ingest time.  Any
     JSON-compatible value is accepted. Common Python values such as
-    `pathlib.Path`, tuples, sets, and NumPy scalar-like values are normalized
-    before the record is validated and stored. This is the primary place to
-    store domain metadata such as species, year, or instrument.
+    `pathlib.Path`, `datetime.date`, `datetime.datetime`, tuples, sets, and
+    NumPy scalar-like values are normalized before the record is validated and
+    stored. This is the primary place to store domain metadata such as species,
+    year, or instrument.
 
 ``derived_metadata``
 :   Metadata added automatically during ingest by extractors and hooks.  For

--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -20,6 +20,7 @@ Keys and values must be JSON-compatible. ogcat normalizes common Python values
 before validation, naming, and storage:
 
 - `pathlib.Path` values become strings.
+- `datetime.date` and `datetime.datetime` values become ISO 8601 strings.
 - Mapping keys become strings and mapping values are normalized recursively.
 - Tuples and lists become JSON lists.
 - Sets and frozensets become deterministic lists where their normalized values

--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -16,13 +16,30 @@ record = catalog.add_file(
 )
 ```
 
-Keys and values must be JSON-serialisable (strings, numbers, booleans, lists,
-or nested dictionaries).
+Keys and values must be JSON-compatible. ogcat normalizes common Python values
+before validation, naming, and storage:
 
-List values can be searched with contains/list-membership filters:
+- `pathlib.Path` values become strings.
+- Mapping keys become strings and mapping values are normalized recursively.
+- Tuples and lists become JSON lists.
+- Sets and frozensets become deterministic lists where their normalized values
+  can be sorted.
+- NumPy scalar-like values are converted through `.item()` when available.
+
+Unsupported objects are rejected with a `TypeError` naming the metadata path.
+
+`contains` filters follow the type of the stored value:
+
+- strings use substring containment;
+- lists and other stored sequences use membership matching, and a list expected
+  value requires every expected item to be present;
+- mappings match an expected mapping as a subset of key/value pairs;
+- scalar values fall back to equality.
 
 ```python
 matches = catalog.search(contains={"tags": "paris"})
+all_tags = catalog.search(contains={"tags": ["paris", "europe"]})
+site = catalog.search(contains={"site": {"code": "MHD"}})
 ```
 
 The equivalent CLI forms are:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, OperationContext, OperationSource
-from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict
+from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
@@ -127,7 +127,7 @@ class Catalog:
     def add_file(
         self,
         path: str | Path,
-        metadata: MetadataDict | None = None,
+        metadata: Mapping[Any, Any] | None = None,
         operation: str | None = None,
         record_type: str | None = None,
     ) -> CatalogRecord:
@@ -241,7 +241,7 @@ class Catalog:
         path: str | Path | None = None,
         *,
         record_type: str | None = None,
-        metadata: MetadataDict | None = None,
+        metadata: Mapping[Any, Any] | None = None,
         locator: ArtifactLocator | None = None,
         target_kind: TargetKind = "file",
         write_mode: WriteMode | None = None,
@@ -297,6 +297,10 @@ class Catalog:
         )
 
         self.hook_manager.before_validate_metadata(context)
+        context.user_metadata = _normalize_metadata_for_schema(
+            context.user_metadata,
+            schema_name=schema_name,
+        )
         validation_report = self._metadata_validation_report(
             schema=schema,
             metadata=context.user_metadata,
@@ -351,13 +355,13 @@ class Catalog:
         record_type: str,
         locator: ArtifactLocator | None = None,
         storage_plan: StoragePlan | None = None,
-        metadata: MetadataDict | None = None,
+        metadata: Mapping[Any, Any] | None = None,
         storage_mode: str | None = None,
         original_path: str | Path | None = None,
         original_filename: str | None = None,
         suffixes: list[str] | None = None,
-        derived_metadata: MetadataDict | None = None,
-        naming_metadata: MetadataDict | None = None,
+        derived_metadata: Mapping[Any, Any] | None = None,
+        naming_metadata: Mapping[Any, Any] | None = None,
         time_added: str | None = None,
         source: OperationSource | None = None,
         artifact_writer: ArtifactWriter | None = None,
@@ -410,7 +414,16 @@ class Catalog:
                 naming_metadata = _naming_metadata_from_storage_plan(storage_plan)
         assert locator is not None
         metadata_input = {} if metadata is None else metadata
-        derived_metadata = {} if derived_metadata is None else dict(derived_metadata)
+        derived_metadata = (
+            {}
+            if derived_metadata is None
+            else normalize_metadata(derived_metadata, field_name="derived_metadata")
+        )
+        naming_metadata = (
+            None
+            if naming_metadata is None
+            else normalize_metadata(naming_metadata, field_name="naming_metadata")
+        )
         schema = self._select_schema(record_type, require_known=False)
         schema_name = self._schema_name(record_type)
         metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
@@ -537,10 +550,10 @@ class Catalog:
         self,
         query: SearchQuery | None = None,
         *,
-        where: dict[str, object] | None = None,
-        contains: dict[str, object] | None = None,
-        regex: dict[str, str] | None = None,
-        match: dict[str, str] | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
@@ -552,10 +565,10 @@ class Catalog:
         self,
         *,
         query: SearchQuery | None = None,
-        where: dict[str, object] | None = None,
-        contains: dict[str, object] | None = None,
-        regex: dict[str, str] | None = None,
-        match: dict[str, str] | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
@@ -566,10 +579,10 @@ class Catalog:
         self,
         query: SearchQuery | None = None,
         *,
-        where: dict[str, object] | None = None,
-        contains: dict[str, object] | None = None,
-        regex: dict[str, str] | None = None,
-        match: dict[str, str] | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
@@ -754,8 +767,8 @@ class Catalog:
         original_path: str | Path | None = None,
         original_filename: str | None = None,
         suffixes: list[str] | None = None,
-        derived_metadata: MetadataDict | None = None,
-        naming_metadata: MetadataDict | None = None,
+        derived_metadata: Mapping[Any, Any] | None = None,
+        naming_metadata: Mapping[Any, Any] | None = None,
         time_added: str | None = None,
     ) -> CatalogRecord:
         """Build an artifact record without persisting it."""
@@ -767,6 +780,17 @@ class Catalog:
         else:
             resolved_original_path = original_path
         locator_path = locator.as_path()
+        user_metadata = {} if metadata is None else normalize_metadata(metadata, field_name="metadata")
+        normalized_derived_metadata = (
+            {}
+            if derived_metadata is None
+            else normalize_metadata(derived_metadata, field_name="derived_metadata")
+        )
+        normalized_naming_metadata = (
+            {}
+            if naming_metadata is None
+            else normalize_metadata(naming_metadata, field_name="naming_metadata")
+        )
 
         return CatalogRecord(
             id=record_id,
@@ -780,9 +804,9 @@ class Catalog:
             original_path=resolved_original_path,
             original_filename=original_filename,
             suffixes=[] if suffixes is None else list(suffixes),
-            user_metadata={} if metadata is None else dict(metadata),
-            derived_metadata={} if derived_metadata is None else dict(derived_metadata),
-            naming_metadata={} if naming_metadata is None else dict(naming_metadata),
+            user_metadata=user_metadata,
+            derived_metadata=normalized_derived_metadata,
+            naming_metadata=normalized_naming_metadata,
         )
 
     def _render_planned_locator(
@@ -949,6 +973,10 @@ class Catalog:
         )
         try:
             self.hook_manager.before_validate_metadata(hook_context)
+            hook_context.user_metadata = _normalize_metadata_for_schema(
+                hook_context.user_metadata,
+                schema_name=self._schema_name(schema_record_type),
+            )
             validation_report = self._metadata_validation_report(
                 schema=schema,
                 metadata=hook_context.user_metadata,
@@ -990,7 +1018,19 @@ class Catalog:
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
+            hook_context.derived_metadata = normalize_metadata(
+                hook_context.derived_metadata,
+                field_name="derived_metadata",
+            )
             self.hook_manager.before_record_write(hook_context)
+            hook_context.user_metadata = _normalize_metadata_for_schema(
+                hook_context.user_metadata,
+                schema_name=self._schema_name(schema_record_type),
+            )
+            hook_context.derived_metadata = normalize_metadata(
+                hook_context.derived_metadata,
+                field_name="derived_metadata",
+            )
             record = self._build_artifact_record(
                 record_type=record_type,
                 locator=canonical_locator,
@@ -1117,11 +1157,11 @@ def _coerce_hook_manager(
 
 def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
     """Return derived metadata with non-fatal hook warnings included."""
-    metadata = dict(context.derived_metadata)
+    metadata = normalize_metadata(context.derived_metadata, field_name="derived_metadata")
     if context.warnings:
         warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
         metadata["hook_warnings"] = warnings_metadata
-    return metadata
+    return normalize_metadata(metadata, field_name="derived_metadata")
 
 
 def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
@@ -1217,9 +1257,16 @@ def _coerce_metadata_input(
     schema_name: str,
 ) -> MetadataDict:
     """Copy user metadata after preserving existing non-dictionary errors."""
-    if isinstance(metadata, dict):
-        return dict(metadata)
-    raise TypeError(f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}")
+    return _normalize_metadata_for_schema(metadata, schema_name=schema_name)
+
+
+def _normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> MetadataDict:
+    """Normalize user metadata with the existing schema-aware error prefix."""
+    return normalize_metadata(
+        metadata,
+        field_name="metadata",
+        label=f"Metadata for schema {schema_name}",
+    )
 
 
 def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
@@ -1279,9 +1326,7 @@ def _optional_metadata(value: object) -> MetadataDict | None:
     """Return optional metadata for artifact batch forwarding."""
     if value is None:
         return None
-    if isinstance(value, dict):
-        return dict(value)
-    raise TypeError(f"optional metadata value must be a dictionary, got {type(value).__name__}")
+    return normalize_metadata(value, field_name="metadata", label="optional metadata value")
 
 
 def _optional_string_list(value: object) -> list[str] | None:

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -2,13 +2,109 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import TypeAlias, cast
 
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 MetadataDict: TypeAlias = dict[str, JsonValue]
+
+
+def normalize_metadata(
+    metadata: object,
+    *,
+    field_name: str = "metadata",
+    label: str | None = None,
+) -> MetadataDict:
+    """Return metadata as a JSON-compatible dictionary.
+
+    Args:
+        metadata: Mapping to normalize recursively.
+        field_name: Path used in nested error messages.
+        label: Optional user-facing label used for the top-level mapping error.
+
+    Returns:
+        Normalized metadata with string keys and JSON-compatible values.
+
+    Raises:
+        TypeError: If metadata is not a mapping or contains unsupported values.
+        ValueError: If two keys collide after string normalization.
+    """
+    if not isinstance(metadata, Mapping):
+        error_label = label or field_name
+        raise TypeError(f"{error_label} must be a dictionary, got {type(metadata).__name__}")
+
+    normalized: MetadataDict = {}
+    for key, value in metadata.items():
+        normalized_key = str(key)
+        if normalized_key in normalized:
+            raise ValueError(
+                f"{field_name} contains duplicate key after string normalization: {normalized_key!r}"
+            )
+        normalized[normalized_key] = normalize_metadata_value(
+            value,
+            field_name=f"{field_name}.{normalized_key}",
+        )
+    return normalized
+
+
+def normalize_metadata_value(value: object, *, field_name: str = "metadata") -> JsonValue:
+    """Return one metadata value as a JSON-compatible value.
+
+    Args:
+        value: Value to normalize recursively.
+        field_name: Path used in error messages.
+
+    Returns:
+        JSON-compatible normalized value.
+
+    Raises:
+        TypeError: If the value cannot be represented safely as JSON metadata.
+        ValueError: If nested mapping keys collide after string normalization.
+    """
+    if value is None or isinstance(value, str | int | float | bool):
+        return cast(JsonValue, value)
+    if isinstance(value, PurePath):
+        return str(value)
+    if isinstance(value, Mapping):
+        return normalize_metadata(value, field_name=field_name)
+    if isinstance(value, list | tuple):
+        return [
+            normalize_metadata_value(item, field_name=f"{field_name}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, set | frozenset):
+        normalized_items = [
+            normalize_metadata_value(item, field_name=f"{field_name}[{index}]")
+            for index, item in enumerate(value)
+        ]
+        return sorted(normalized_items, key=_json_sort_key)
+
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            item_value = item()
+        except Exception as exc:
+            raise TypeError(
+                f"{field_name} must be JSON-compatible; {type(value).__name__}.item() "
+                f"could not produce a scalar value"
+            ) from exc
+        if item_value is not value:
+            return normalize_metadata_value(item_value, field_name=field_name)
+
+    raise TypeError(
+        f"{field_name} must be JSON-compatible; got {type(value).__name__}. "
+        "Supported values are scalars, pathlib paths, mappings, lists, tuples, sets, "
+        "frozensets, and objects with item() returning a supported scalar."
+    )
+
+
+def _json_sort_key(value: JsonValue) -> str:
+    """Return a deterministic sort key for normalized set members."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
 
 
 @dataclass(slots=True)
@@ -28,6 +124,14 @@ class MetadataFieldDescription:
     example: JsonValue | None = None
     required: bool = False
     value_types: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Normalize schema example metadata when supplied directly."""
+        if self.example is not None:
+            self.example = normalize_metadata_value(
+                self.example,
+                field_name=f"metadata_fields.{self.name}.example",
+            )
 
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the field description to a plain dictionary."""
@@ -173,6 +277,15 @@ class CatalogRecord:
 
     def __post_init__(self) -> None:
         """Keep compatibility path fields aligned with the locator when possible."""
+        self.user_metadata = normalize_metadata(self.user_metadata, field_name="user_metadata")
+        self.derived_metadata = normalize_metadata(
+            self.derived_metadata,
+            field_name="derived_metadata",
+        )
+        self.naming_metadata = normalize_metadata(
+            self.naming_metadata,
+            field_name="naming_metadata",
+        )
         if not self.locator.value and self.stored_abspath is not None:
             self.locator = ArtifactLocator.path(
                 self.stored_abspath,
@@ -194,6 +307,9 @@ class CatalogRecord:
 
     def to_dict(self) -> dict[str, JsonValue]:
         """Convert the record to a plain dictionary."""
+        user_metadata = normalize_metadata(self.user_metadata, field_name="user_metadata")
+        derived_metadata = normalize_metadata(self.derived_metadata, field_name="derived_metadata")
+        naming_metadata = normalize_metadata(self.naming_metadata, field_name="naming_metadata")
         return cast(
             dict[str, JsonValue],
             {
@@ -208,9 +324,9 @@ class CatalogRecord:
                 "original_path": self.original_path,
                 "original_filename": self.original_filename,
                 "suffixes": self.suffixes,
-                "user_metadata": self.user_metadata,
-                "derived_metadata": self.derived_metadata,
-                "naming_metadata": self.naming_metadata,
+                "user_metadata": user_metadata,
+                "derived_metadata": derived_metadata,
+                "naming_metadata": naming_metadata,
             },
         )
 
@@ -275,4 +391,4 @@ def _coerce_metadata_dict(value: JsonValue) -> MetadataDict:
     """Coerce a JSON object value to metadata."""
     if not isinstance(value, dict):
         return {}
-    return dict(value)
+    return normalize_metadata(value)

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path, PurePath
 from typing import TypeAlias, cast
 
@@ -67,6 +68,8 @@ def normalize_metadata_value(value: object, *, field_name: str = "metadata") -> 
     """
     if value is None or isinstance(value, str | int | float | bool):
         return cast(JsonValue, value)
+    if isinstance(value, date | datetime):
+        return value.isoformat()
     if isinstance(value, PurePath):
         return str(value)
     if isinstance(value, Mapping):
@@ -97,8 +100,8 @@ def normalize_metadata_value(value: object, *, field_name: str = "metadata") -> 
 
     raise TypeError(
         f"{field_name} must be JSON-compatible; got {type(value).__name__}. "
-        "Supported values are scalars, pathlib paths, mappings, lists, tuples, sets, "
-        "frozensets, and objects with item() returning a supported scalar."
+        "Supported values are scalars, dates, datetimes, pathlib paths, mappings, "
+        "lists, tuples, sets, frozensets, and objects with item() returning a supported scalar."
     )
 
 

--- a/src/ogcat/repository.py
+++ b/src/ogcat/repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Protocol
 
 from ogcat.models import CatalogRecord
@@ -36,10 +36,10 @@ class CatalogRepository(Protocol):
         self,
         *,
         query: SearchQuery | None = None,
-        where: dict[str, object] | None = None,
-        contains: dict[str, object] | None = None,
-        regex: dict[str, str] | None = None,
-        match: dict[str, str] | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,

--- a/src/ogcat/search.py
+++ b/src/ogcat/search.py
@@ -50,6 +50,8 @@ class FieldPath:
 
     def __post_init__(self) -> None:
         """Validate field paths at construction time."""
+        if not isinstance(self.raw, str):
+            raise TypeError(f"Search field path must be a string, got {type(self.raw).__name__}.")
         if not self.raw:
             raise ValueError("Search field path cannot be empty.")
 
@@ -167,7 +169,9 @@ class SearchQuery:
     @classmethod
     def where(cls, filters: Mapping[str, Any] | None = None, **kwargs: Any) -> SearchQuery:
         """Build an equality query from keyword filters."""
-        combined = dict(filters or {})
+        combined: dict[str, Any] = {}
+        if filters is not None:
+            combined.update(_validate_filter_mapping("filters", filters))
         combined.update(kwargs)
         return cls.from_filters(where=combined)
 
@@ -183,25 +187,29 @@ class SearchQuery:
         missing: Sequence[str] | None = None,
     ) -> SearchQuery:
         """Build a query from simple filter mappings."""
+        where_items = _validate_filter_mapping("where", where)
+        contains_items = _validate_filter_mapping("contains", contains)
+        match_items = _validate_filter_mapping("match", match, require_string_values=True)
+        regex_items = _validate_filter_mapping("regex", regex, require_string_values=True)
+        exists_fields = _validate_field_sequence("exists", exists)
+        missing_fields = _validate_field_sequence("missing", missing)
+
         terms: list[SearchTerm] = []
         terms.extend(
-            SearchTerm.build(field=field, op=SearchOp.EQ, value=value)
-            for field, value in (where or {}).items()
+            SearchTerm.build(field=field, op=SearchOp.EQ, value=value) for field, value in where_items
         )
         terms.extend(
             SearchTerm.build(field=field, op=SearchOp.CONTAINS, value=value)
-            for field, value in (contains or {}).items()
+            for field, value in contains_items
         )
         terms.extend(
-            SearchTerm.build(field=field, op=SearchOp.MATCH, value=value)
-            for field, value in (match or {}).items()
+            SearchTerm.build(field=field, op=SearchOp.MATCH, value=value) for field, value in match_items
         )
         terms.extend(
-            SearchTerm.build(field=field, op=SearchOp.REGEX, value=value)
-            for field, value in (regex or {}).items()
+            SearchTerm.build(field=field, op=SearchOp.REGEX, value=value) for field, value in regex_items
         )
-        terms.extend(SearchTerm.build(field=field, op=SearchOp.EXISTS) for field in (exists or ()))
-        terms.extend(SearchTerm.build(field=field, op=SearchOp.MISSING) for field in (missing or ()))
+        terms.extend(SearchTerm.build(field=field, op=SearchOp.EXISTS) for field in exists_fields)
+        terms.extend(SearchTerm.build(field=field, op=SearchOp.MISSING) for field in missing_fields)
         return cls(tuple(terms))
 
     def and_(self, *queries: SearchQuery) -> SearchQuery:
@@ -215,6 +223,58 @@ class SearchQuery:
 def _normalise_field_path(dotted_path: str) -> str:
     """Translate user-friendly aliases to stored record paths."""
     return FieldPath(dotted_path).stored
+
+
+def _validate_filter_mapping(
+    argument_name: str,
+    value: Mapping[str, Any] | None,
+    *,
+    require_string_values: bool = False,
+) -> tuple[tuple[str, Any], ...]:
+    """Return validated mapping items for a search filter argument."""
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            f"{argument_name} must be a mapping of field names to expected values, "
+            f"got {type(value).__name__}."
+        )
+
+    items: list[tuple[str, Any]] = []
+    for field, expected in value.items():
+        if not isinstance(field, str):
+            raise TypeError(
+                f"{argument_name} must map string field names to expected values; "
+                f"got {type(field).__name__} field name."
+            )
+        if require_string_values and not isinstance(expected, str):
+            raise TypeError(
+                f"{argument_name}[{field!r}] must be a string pattern, got {type(expected).__name__}."
+            )
+        items.append((field, expected))
+    return tuple(items)
+
+
+def _validate_field_sequence(
+    argument_name: str,
+    value: Sequence[str] | None,
+) -> tuple[str, ...]:
+    """Return validated field names for exists/missing search arguments."""
+    if value is None:
+        return ()
+    if isinstance(value, str | bytes | bytearray):
+        raise TypeError(f"{argument_name} must be a sequence of field names, not a string or bytes value.")
+    if not isinstance(value, Sequence):
+        raise TypeError(f"{argument_name} must be a sequence of field names, got {type(value).__name__}.")
+
+    fields: list[str] = []
+    for index, field in enumerate(value):
+        if not isinstance(field, str):
+            raise TypeError(
+                f"{argument_name}[{index}] must be a field name string, got {type(field).__name__}."
+            )
+        fields.append(field)
+    return tuple(fields)
 
 
 def get_dotted(mapping: Mapping[str, Any], dotted_path: str) -> Any:
@@ -293,7 +353,12 @@ def _eq(left: Any, right: Any, ignore_case: bool) -> bool:
 
 
 def _contains(actual: Any, expected: Any, ignore_case: bool) -> bool:
-    """Return whether an actual value contains the expected value."""
+    """Return whether an actual value contains the expected value.
+
+    Strings use substring containment; sequences use membership, with list
+    expectations requiring every expected item; mappings use subset-like
+    key/value matching for mapping expectations; scalars fall back to equality.
+    """
     if isinstance(actual, str):
         needle = _stringify(expected)
         haystack = actual.casefold() if ignore_case else actual
@@ -359,10 +424,10 @@ def matches_record(
     record: CatalogRecord,
     *,
     query: SearchQuery | None = None,
-    where: dict[str, object] | None,
-    contains: dict[str, Any] | None,
-    regex: dict[str, str] | None,
-    match: dict[str, str] | None = None,
+    where: Mapping[str, object] | None,
+    contains: Mapping[str, Any] | None,
+    regex: Mapping[str, str] | None,
+    match: Mapping[str, str] | None = None,
     exists: Sequence[str] | None = None,
     missing: Sequence[str] | None = None,
     ignore_case: bool,

--- a/src/ogcat/tinydb_repository.py
+++ b/src/ogcat/tinydb_repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
@@ -77,10 +77,10 @@ class TinyDbCatalogRepository:
         self,
         *,
         query: SearchQuery | None = None,
-        where: dict[str, object] | None = None,
-        contains: dict[str, object] | None = None,
-        regex: dict[str, str] | None = None,
-        match: dict[str, str] | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,

--- a/src/ogcat/validation.py
+++ b/src/ogcat/validation.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Any
 
 from pydantic import StrictBool, StrictFloat, StrictInt, StrictStr, TypeAdapter, ValidationError
 
-from ogcat.models import CatalogRecord
+from ogcat.models import CatalogRecord, normalize_metadata
 from ogcat.spec import CatalogSpec, RecordSchema
 
 _TYPE_ADAPTERS: dict[str, TypeAdapter[Any]] = {
@@ -108,7 +109,7 @@ class ValidationReport:
         if not errors:
             return
         first = errors[0]
-        if first.code == "metadata.not_object":
+        if first.code in {"metadata.not_object", "metadata.not_json"}:
             raise TypeError(first.message)
         raise ValueError(_summarize_errors(errors))
 
@@ -181,13 +182,23 @@ def validate_metadata(
         Structured validation report.
     """
     report = ValidationReport()
-    if not isinstance(metadata, dict):
+    if not isinstance(metadata, Mapping):
         report.add(
             path="metadata",
             message=(
                 f"Metadata for schema {schema_name} must be a dictionary, got {type(metadata).__name__}"
             ),
             code="metadata.not_object",
+        )
+        return report
+    try:
+        metadata = normalize_metadata(metadata)
+    except (TypeError, ValueError) as exc:
+        report.add(
+            path="metadata",
+            message=str(exc),
+            code="metadata.not_json",
+            hint="Use JSON-compatible metadata values or values ogcat can normalize.",
         )
         return report
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -312,6 +312,126 @@ def test_add_file_uses_readable_list_metadata_in_naming_templates(tmp_path: Path
     record = catalog.add_file(source, metadata={"tags": ["a", "b", "c"]})
 
     assert _stored_path(record) == root / "files" / "a-b-c" / "a-b-c.nc"
+
+
+def test_add_file_normalizes_path_metadata_before_tinydb_insert(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "pathmeta.nc"
+    source.write_text("dummy", encoding="utf-8")
+    metadata_path = tmp_path / "metadata" / "config.json"
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+    db = cast(Any, catalog.repository)._db
+    original_insert = db.insert
+    captured_payloads: list[dict[str, Any]] = []
+
+    def capture_insert(payload: dict[str, Any]) -> int:
+        captured_payloads.append(payload)
+        user_metadata = payload["user_metadata"]
+        assert isinstance(user_metadata, dict)
+        assert isinstance(user_metadata["source_path"], str)
+        return original_insert(payload)
+
+    monkeypatch.setattr(db, "insert", capture_insert)
+
+    record = catalog.add_file(source, metadata={"source_path": metadata_path})
+
+    assert record.user_metadata["source_path"] == str(metadata_path)
+    assert captured_payloads[0]["user_metadata"]["source_path"] == str(metadata_path)
+
+
+def test_add_artifact_normalizes_nested_metadata_values(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={
+            "source_path": Path("raw") / "example.nc",
+            "nested": {
+                "tuple": ("co2", Path("sites") / "mhd"),
+                "set": {"z", "a"},
+                "frozenset": frozenset({2, 1}),
+                1: "integer key",
+            },
+        },
+        derived_metadata={"shape": (12, 4), "path": Path("derived.nc")},
+        naming_metadata={"parts": frozenset({"b", "a"})},
+    )
+
+    assert record.user_metadata == {
+        "source_path": "raw/example.nc",
+        "nested": {
+            "tuple": ["co2", "sites/mhd"],
+            "set": ["a", "z"],
+            "frozenset": [1, 2],
+            "1": "integer key",
+        },
+    }
+    assert record.derived_metadata["shape"] == [12, 4]
+    assert record.derived_metadata["path"] == "derived.nc"
+    assert record.naming_metadata["parts"] == ["a", "b"]
+
+
+def test_add_artifact_rejects_unsupported_metadata_objects(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(TypeError, match="metadata.unsupported must be JSON-compatible; got object"):
+        catalog.add_artifact(
+            record_type="external_reference",
+            locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+            metadata={"unsupported": object()},
+        )
+
+
+def test_plan_artifact_storage_normalizes_metadata_before_naming(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "planned.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{tags}",
+                filename_template="{source_path}{original_suffix}",
+            ),
+        ),
+    )
+
+    plan = catalog.plan_artifact_storage(
+        path=source,
+        metadata={"tags": ("a", "b"), "source_path": Path("named")},
+    )
+
+    assert plan.resolved_directory == "a-b"
+    assert plan.resolved_filename == "named.nc"
+
+
+def test_metadata_normalization_accepts_numpy_scalars_when_available(tmp_path: Path) -> None:
+    numpy = cast(Any, pytest.importorskip("numpy"))
+    scalar = numpy.int64(5)
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={"count": scalar},
+    )
+
+    assert record.user_metadata["count"] == 5
+    assert type(record.user_metadata["count"]) is int
 
 
 @pytest.mark.parametrize("field_name", ["id", "uuid", "operation_id"])

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,3 +1,4 @@
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -377,6 +378,23 @@ def test_add_artifact_normalizes_nested_metadata_values(tmp_path: Path) -> None:
     assert record.derived_metadata["shape"] == [12, 4]
     assert record.derived_metadata["path"] == "derived.nc"
     assert record.naming_metadata["parts"] == ["a", "b"]
+
+
+def test_add_artifact_normalizes_date_datetime_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/example.zarr"),
+        metadata={
+            "published": date(2024, 1, 2),
+            "observed_at": datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
+        },
+    )
+
+    assert record.user_metadata["published"] == "2024-01-02"
+    assert record.user_metadata["observed_at"] == "2024-01-02T03:04:05+00:00"
 
 
 def test_add_artifact_rejects_unsupported_metadata_objects(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, SearchOp, SearchQuery
 
 
@@ -143,10 +145,14 @@ def test_search_supports_list_membership_and_contains(tmp_path: Path) -> None:
     )
 
     by_contains = catalog.search(contains={"tags": "paris"})
+    by_contains_all = catalog.search(contains={"tags": ["paris", "obspack"]})
+    by_contains_missing = catalog.search(contains={"tags": ["paris", "missing"]})
     by_query_contains = catalog.search(query=SearchQuery.contains("tags", "obspack"))
     by_title_substring = catalog.search(contains={"title": "Paris"})
 
     assert [r.id for r in by_contains] == [tagged.id]
+    assert [r.id for r in by_contains_all] == [tagged.id]
+    assert by_contains_missing == []
     assert [r.id for r in by_query_contains] == [tagged.id]
     assert [r.id for r in by_title_substring] == [tagged.id]
 
@@ -160,9 +166,11 @@ def test_search_contains_supports_mapping_subset_and_unhashable_values(tmp_path:
     )
 
     by_subset = catalog.search(contains={"site": {"code": "MHD"}})
+    by_mismatch = catalog.search(contains={"site": {"code": "TAC"}})
     by_unhashable_key = catalog.search(contains={"site": ["code"]})
 
     assert [r.id for r in by_subset] == [record.id]
+    assert by_mismatch == []
     assert by_unhashable_key == []
 
 
@@ -234,3 +242,31 @@ def test_get_and_path_return_none_for_missing_record(tmp_path: Path) -> None:
 
     assert catalog.get("missing") is None
     assert catalog.path("missing") is None
+
+
+def test_search_rejects_set_where_filters(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+
+    with pytest.raises(TypeError, match="where must be a mapping of field names to expected values"):
+        catalog.search(where={"product", "gridfed"})  # type: ignore[arg-type]
+
+
+def test_search_rejects_bare_string_exists_filters(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+
+    with pytest.raises(TypeError, match="exists must be a sequence of field names"):
+        catalog.search(exists="site")  # type: ignore[arg-type]
+
+
+def test_search_query_from_filters_validates_filter_shapes() -> None:
+    with pytest.raises(TypeError, match="contains must be a mapping of field names to expected values"):
+        SearchQuery.from_filters(contains=["site"])  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match=r"regex\['version'\] must be a string pattern"):
+        SearchQuery.from_filters(regex={"version": 42})  # type: ignore[dict-item]
+
+    with pytest.raises(TypeError, match=r"match\['title'\] must be a string pattern"):
+        SearchQuery.from_filters(match={"title": ["Paris"]})  # type: ignore[dict-item]
+
+    with pytest.raises(TypeError, match="missing must be a sequence of field names"):
+        SearchQuery.from_filters(missing=b"site")  # type: ignore[arg-type]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -128,6 +128,22 @@ def test_validate_metadata_checks_supported_pydantic_type_labels() -> None:
     ]
 
 
+def test_validate_metadata_normalizes_values_before_type_checks() -> None:
+    schema = RecordSchema(
+        metadata_fields=[
+            MetadataFieldDescription(name="path", description="Source path.", value_types=["str"]),
+            MetadataFieldDescription(name="tags", description="Tags.", value_types=["list[str]"]),
+        ]
+    )
+
+    report = validate_metadata(
+        {"path": Path("raw/example.nc"), "tags": ("co2", "mhd")},
+        schema,
+    )
+
+    assert report.ok
+
+
 def test_validate_metadata_uses_strict_type_checks_with_any_supported_type() -> None:
     schema = RecordSchema(
         metadata_fields=[

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -133,11 +134,22 @@ def test_validate_metadata_normalizes_values_before_type_checks() -> None:
         metadata_fields=[
             MetadataFieldDescription(name="path", description="Source path.", value_types=["str"]),
             MetadataFieldDescription(name="tags", description="Tags.", value_types=["list[str]"]),
+            MetadataFieldDescription(name="published", description="Publication date.", value_types=["date"]),
+            MetadataFieldDescription(
+                name="observed_at",
+                description="Observation time.",
+                value_types=["datetime"],
+            ),
         ]
     )
 
     report = validate_metadata(
-        {"path": Path("raw/example.nc"), "tags": ("co2", "mhd")},
+        {
+            "path": Path("raw/example.nc"),
+            "tags": ("co2", "mhd"),
+            "published": date(2024, 1, 2),
+            "observed_at": datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
+        },
         schema,
     )
 


### PR DESCRIPTION
## Summary
- Added explicit validation for `Catalog.search()` and `SearchQuery.from_filters()` filter shapes so mappings and field sequences are enforced up front with clearer errors.
- Kept `contains` behavior intact while documenting its type-directed semantics for strings, sequences, mappings, and scalars.
- Added recursive JSON-compatible metadata normalization for user, derived, and naming metadata before validation, storage, and naming.
- Updated docs and coverage for path normalization, nested normalization, and the new search validation cases.

## Testing
- `uv run ruff check` passed.
- `uv run ruff format --check` passed.
- `uv run pyright` passed.
- `uv run pytest` passed (`246 passed, 1 skipped`).