### PR TITLE
Add reference records and tighten notebook-friendly catalog APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Use whichever of these is available and configured. Do not add a new type checke
 
 ## Tests
 
+- New tests should include a short docstring describing the behavior or
+  regression they cover.
 - Run focused tests while developing.
 - Before pushing or opening a PR, run the full test suite if it is reasonably quick.
 - If the full suite takes more than about a minute, use judgement: run the relevant subset and explain what was not run.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ descriptions, and locating stored paths.
 - local catalogs centred on managed file ingest
 - a self-describing catalog layout with `catalog.json`, `db.json`, and `files/`
 - path-based managed ingest using `copy` or `move`
-- reference records for existing local paths and explicit URI/urlpath locators
+- reference records for existing local paths, URIs, and explicit URI/urlpath locators
 - flexible JSON-serialisable user metadata
 - simple derived metadata extraction for supported file types
 - template-based storage naming
@@ -149,9 +149,9 @@ See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for h
 rollback, and transaction examples.
 
 Use `add_file()` when ogcat should manage a local copy or move into the catalog's `files/` tree.
-Use `add_reference()` when the artifact already exists and ogcat should only record a local path or
-explicit `ArtifactLocator`. Use `add_artifact()` with an `OperationSource` and artifact writer when
-a plugin or helper should materialise new data before the record is written.
+Use `add_reference()` when the artifact already exists and ogcat should only record a local path,
+URI, URL path, or explicit `ArtifactLocator`. Use `add_artifact()` with an `OperationSource` and
+artifact writer when a plugin or helper should materialise new data before the record is written.
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
 
@@ -257,8 +257,9 @@ uv run python -m http.server 8000
 
 Current storage is still centred on path-based managed ingest for the MVP. Files added with
 `add_file()` are copied or moved into the catalog's `files/` tree, and the resulting stored path is
-recorded in the catalog database alongside metadata and naming information. Existing paths and
-explicit URI/urlpath locators can be recorded with `add_reference()` without copying or moving data.
+recorded in the catalog database alongside metadata and naming information. Existing paths, URIs,
+and explicit URI/urlpath locators can be recorded with `add_reference()` without copying or moving
+data.
 
 Records now also include a minimal locator block:
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 `ogcat` is a lightweight artifact catalog with a managed-file MVP. Today it provides a
 self-describing on-disk catalog layout, a small Python API, and a CLI for creating catalogs,
-adding files by copy or move, listing metadata field descriptions, and locating stored paths.
+adding files by copy or move, recording existing artifact references, listing metadata field
+descriptions, and locating stored paths.
 
 ## Scope
 
 - local catalogs centred on managed file ingest
 - a self-describing catalog layout with `catalog.json`, `db.json`, and `files/`
 - path-based managed ingest using `copy` or `move`
+- reference records for existing local paths and explicit URI/urlpath locators
 - flexible JSON-serialisable user metadata
 - simple derived metadata extraction for supported file types
 - template-based storage naming
@@ -146,10 +148,10 @@ catalog = Catalog.create("example-catalog", spec, plugins=plugins)
 See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for hook lifecycle,
 rollback, and transaction examples.
 
-In this hook model, `add_artifact()` records an artifact locator but does not write artifact data by
-default. Pass an `OperationSource` and artifact writer to `add_artifact()` when a plugin or helper
-should materialise data before the record is written. `add_file()` is the bundled local-file
-operation that uses the same writer path to copy or move data before writing the record.
+Use `add_file()` when ogcat should manage a local copy or move into the catalog's `files/` tree.
+Use `add_reference()` when the artifact already exists and ogcat should only record a local path or
+explicit `ArtifactLocator`. Use `add_artifact()` with an `OperationSource` and artifact writer when
+a plugin or helper should materialise new data before the record is written.
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
 
@@ -253,9 +255,10 @@ uv run python -m http.server 8000
 
 ## Storage Model
 
-Current storage is still path-based managed ingest for the MVP. Files are copied or moved into the
-catalog's `files/` tree, and the resulting stored path is recorded in the catalog database
-alongside metadata and naming information.
+Current storage is still centred on path-based managed ingest for the MVP. Files added with
+`add_file()` are copied or moved into the catalog's `files/` tree, and the resulting stored path is
+recorded in the catalog database alongside metadata and naming information. Existing paths and
+explicit URI/urlpath locators can be recorded with `add_reference()` without copying or moving data.
 
 Records now also include a minimal locator block:
 

--- a/docs/concepts/hooks-and-plugins.md
+++ b/docs/concepts/hooks-and-plugins.md
@@ -43,6 +43,19 @@ plugins = PluginRegistry([TitleFromFilenameHook()])
 catalog = Catalog.create("./my-catalog", spec, plugins=plugins)
 ```
 
+For ad hoc notebook workflows, you can also pass any iterable of hook objects
+directly as ``hooks=`` or ``plugins=``:
+
+```python
+catalog = Catalog.open("./my-catalog", hooks=[TitleFromFilenameHook()])
+```
+
+``Catalog.open()`` and ``Catalog.create()`` validate hook inputs immediately.
+Each supplied hook object must implement at least one supported hook method
+listed above, and any matching hook method must be callable. This stricter
+validation means inert sentinel objects and no-op objects with no hook methods
+are rejected instead of being silently skipped.
+
 You can also register hooks after catalog creation:
 
 ```python

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -28,6 +28,19 @@ the file ended up there.
 Other project-specific kinds can be stored using :meth:`ogcat.ArtifactLocator`
 directly, but ogcat does not interpret them beyond recording the string value.
 
+## Choosing an add method
+
+Use the three catalog add methods for different storage responsibilities:
+
+- ``Catalog.add_file(...)`` is for managed local ingest. It copies or moves a
+  local source into the catalog's ``files/`` tree.
+- ``Catalog.add_reference(...)`` is for artifacts that already exist. It records
+  a local path, URI locator, or URL-path locator without copying, moving, or
+  writing artifact data.
+- ``Catalog.add_artifact(...)`` with a ``StoragePlan`` and an artifact writer is
+  for workflow outputs. ogcat plans and records the artifact, while the writer
+  performs the actual filesystem or storage operation.
+
 ## Managed files
 
 ``catalog.add_file()`` copies or moves the source file into the catalog's
@@ -122,35 +135,32 @@ filesystem side effects and rollback registration.
 
 ## External references
 
-To catalog a file that should stay in place, use ``add_artifact()`` with a
-path locator and ``record_type="external_reference"``.
+To catalog a file that should stay in place, use ``add_reference()``. For local
+paths, ogcat infers the path locator, original filename, suffixes, and original
+path. The file is not copied or moved, and it does not need to be under the
+catalog's managed ``files/`` root.
 
 ```python
-from ogcat import ArtifactLocator
-
-catalog.add_artifact(
-    record_type="external_reference",
-    locator=ArtifactLocator.from_path("/data/shared/flux.nc"),
+catalog.add_reference(
+    "/data/shared/flux.nc",
     metadata={"species": "CO2"},
 )
 ```
-
-The file is not copied or moved.  ogcat records only the path and the
-metadata.
 
 For non-local references, use a ``uri`` locator when ogcat should not check or
 manage the target:
 
 ```python
-catalog.add_artifact(
-    record_type="external_reference",
-    locator=ArtifactLocator(kind="uri", value="ftp://example.org/data/file.nc"),
-    storage_mode="external",
+from ogcat import ArtifactLocator
+
+catalog.add_reference(
+    ArtifactLocator(kind="uri", value="ftp://example.org/data/file.nc"),
 )
 ```
 
-Use ``ArtifactLocator.from_urlpath(...)`` when the location should be interpreted
-by fsspec-backed storage adapters.  Install the optional dependency with
+Use ``ArtifactLocator.from_urlpath(...)`` with ``add_reference(...)`` when the
+location should be interpreted by fsspec-backed storage adapters. Install the
+optional dependency with
 ``ogcat[fsspec]`` before a writer performs fsspec-backed storage work.
 
 ## Catalog layout

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -35,8 +35,8 @@ Use the three catalog add methods for different storage responsibilities:
 - ``Catalog.add_file(...)`` is for managed local ingest. It copies or moves a
   local source into the catalog's ``files/`` tree.
 - ``Catalog.add_reference(...)`` is for artifacts that already exist. It records
-  a local path, URI locator, or URL-path locator without copying, moving, or
-  writing artifact data.
+  a local path, URI, URI locator, or URL-path locator without copying, moving,
+  or writing artifact data.
 - ``Catalog.add_artifact(...)`` with a ``StoragePlan`` and an artifact writer is
   for workflow outputs. ogcat plans and records the artifact, while the writer
   performs the actual filesystem or storage operation.
@@ -148,19 +148,16 @@ catalog.add_reference(
 ```
 
 For non-local references, use a ``uri`` locator when ogcat should not check or
-manage the target:
+manage the target. URI-looking strings are recorded as ``uri`` references; use
+``uri=`` when that is clearer at the call site:
 
 ```python
-from ogcat import ArtifactLocator
-
-catalog.add_reference(
-    ArtifactLocator(kind="uri", value="ftp://example.org/data/file.nc"),
-)
+catalog.add_reference(uri="ftp://example.org/data/file.nc")
 ```
 
-Use ``ArtifactLocator.from_urlpath(...)`` with ``add_reference(...)`` when the
-location should be interpreted by fsspec-backed storage adapters. Install the
-optional dependency with
+Use ``ArtifactLocator.from_urlpath(...)`` or ``urlpath=`` with
+``add_reference(...)`` when the location should be interpreted by fsspec-backed
+storage adapters. Install the optional dependency with
 ``ogcat[fsspec]`` before a writer performs fsspec-backed storage work.
 
 ## Catalog layout

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -113,18 +113,15 @@ locator and metadata but does not copy or inspect the archive.
 from datetime import date
 from pathlib import Path
 
-from ogcat import ArtifactLocator
-
 downloaded_zip = Path("~/Downloads/bab75005df9571750d518b0aacdedb35.zip").expanduser()
 ads_dataset = (
     "https://ads.atmosphere.copernicus.eu/datasets/"
     "cams-global-greenhouse-gas-inversion?tab=overview"
 )
 
-raw_zip_record = catalog.add_artifact(
+raw_zip_record = catalog.add_reference(
+    downloaded_zip,
     record_type="raw_download",
-    locator=ArtifactLocator.from_path(downloaded_zip),
-    storage_mode="external",
     metadata={
         "species": "co2",
         "product": "cams",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from operator import index as operator_index
 from pathlib import Path
-from typing import Any, Literal, SupportsIndex, cast, overload
+from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.hooks import ArtifactWriter, HookManager, OperationContext, OperationSource
+from ogcat.hooks import HOOK_METHOD_NAMES, ArtifactWriter, HookManager, OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.plugins import PluginRegistry
@@ -37,9 +36,8 @@ ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
-PluginInput = PluginRegistry | list[object] | tuple[object, ...] | None
-HookInput = HookManager | list[object] | tuple[object, ...] | None
-RecordIdInput = str | SupportsIndex
+PluginInput = PluginRegistry | Iterable[object] | None
+HookInput = HookManager | Iterable[object] | None
 
 
 @dataclass(slots=True)
@@ -73,9 +71,9 @@ class Catalog:
         Args:
             root: Directory to create or reuse for the catalog.
             spec: Catalog specification to persist.
-            plugins: Optional plugin registry, or list/tuple of hook objects,
+            plugins: Optional plugin registry, or iterable of hook objects,
                 used to build a hook manager.
-            hooks: Optional hook manager, or list/tuple of hook objects. Pass
+            hooks: Optional hook manager, or iterable of hook objects. Pass
                 either ``plugins`` or ``hooks``.
 
         Returns:
@@ -110,9 +108,9 @@ class Catalog:
 
         Args:
             root: Existing catalog root containing ``catalog.json``.
-            plugins: Optional plugin registry, or list/tuple of hook objects,
+            plugins: Optional plugin registry, or iterable of hook objects,
                 used to build a hook manager.
-            hooks: Optional hook manager, or list/tuple of hook objects. Pass
+            hooks: Optional hook manager, or iterable of hook objects. Pass
                 either ``plugins`` or ``hooks``.
 
         Returns:
@@ -482,8 +480,10 @@ class Catalog:
 
     def add_reference(
         self,
-        reference: str | Path | ArtifactLocator,
+        reference: str | Path | ArtifactLocator | None = None,
         *,
+        uri: str | None = None,
+        urlpath: str | None = None,
         record_type: str = "external_reference",
         metadata: Mapping[Any, Any] | None = None,
         original_path: str | Path | None = None,
@@ -503,7 +503,12 @@ class Catalog:
         managed files root.
 
         Args:
-            reference: Local filesystem path or explicit artifact locator.
+            reference: Local filesystem path, URI-like string, or explicit
+                artifact locator.
+            uri: Optional explicit URI reference. Pass exactly one of
+                ``reference``, ``uri``, or ``urlpath``.
+            urlpath: Optional explicit fsspec-style URL-path reference. Pass
+                exactly one of ``reference``, ``uri``, or ``urlpath``.
             record_type: Logical type of record to create.
             metadata: JSON-compatible user metadata.
             original_path: Optional source path or URI override. Inferred for
@@ -521,7 +526,7 @@ class Catalog:
         Returns:
             Persisted or staged reference record.
         """
-        locator, local_path = _reference_locator_and_path(reference)
+        locator, local_path = _reference_locator_and_path(reference, uri=uri, urlpath=urlpath)
         resolved_original_path = original_path
         resolved_original_filename = original_filename
         resolved_suffixes = suffixes
@@ -749,11 +754,11 @@ class Catalog:
         """Return available named record schema names."""
         return self.spec.list_record_schemas()
 
-    def get(self, record_id: RecordIdInput) -> CatalogRecord | None:
-        """Get a record by string or integer-like id."""
+    def get(self, record_id: object) -> CatalogRecord | None:
+        """Get a record by id after coercing public input with ``str()``."""
         return self.repository.get(_coerce_record_id(record_id))
 
-    def path(self, record_id: RecordIdInput) -> Path | None:
+    def path(self, record_id: object) -> Path | None:
         """Return the stored path for a path-backed record, if present."""
         record = self.get(record_id)
         if record is None:
@@ -1218,20 +1223,6 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     return TinyDbCatalogRepository(root / spec.db_path)
 
 
-_HOOK_METHOD_NAMES = (
-    "before_validate_metadata",
-    "after_validate_metadata",
-    "resolve_artifact_locator",
-    "before_record_write",
-    "after_record_write",
-    "extract_metadata",
-    "before_commit",
-    "after_commit",
-    "on_error",
-    "on_rollback",
-)
-
-
 def _coerce_hook_manager(
     *,
     plugins: PluginInput,
@@ -1244,32 +1235,40 @@ def _coerce_hook_manager(
         if isinstance(hooks, HookManager):
             _validate_hook_objects(hooks.hooks, label="hooks")
             return hooks
-        if isinstance(hooks, (list, tuple)):
-            return HookManager(_validate_hook_objects(hooks, label="hooks"))
-        raise TypeError(
-            f"hooks must be a HookManager or a list/tuple of hook objects, got {type(hooks).__name__}"
-        )
+        return HookManager(_coerce_hook_iterable(hooks, label="hooks"))
     if plugins is not None:
         if isinstance(plugins, PluginRegistry):
             _validate_hook_objects(plugins.hooks, label="plugins")
             return plugins.hook_manager()
-        if isinstance(plugins, (list, tuple)):
-            registry = PluginRegistry(_validate_hook_objects(plugins, label="plugins"))
-            return registry.hook_manager()
-        raise TypeError(
-            f"plugins must be a PluginRegistry or a list/tuple of hook objects, got {type(plugins).__name__}"
-        )
+        registry = PluginRegistry(_coerce_hook_iterable(plugins, label="plugins"))
+        return registry.hook_manager()
     return HookManager()
 
 
-def _validate_hook_objects(hooks: Sequence[object], *, label: str) -> list[object]:
+def _coerce_hook_iterable(value: object, *, label: str) -> list[object]:
+    """Return a validated list of hooks from an iterable input."""
+    expected = (
+        "a HookManager or iterable of hook objects"
+        if label == "hooks"
+        else "a PluginRegistry or iterable of hook objects"
+    )
+    if isinstance(value, str | bytes):
+        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}")
+    try:
+        hooks = iter(cast(Iterable[object], value))
+    except TypeError as exc:
+        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}") from exc
+    return _validate_hook_objects(hooks, label=label)
+
+
+def _validate_hook_objects(hooks: Iterable[object], *, label: str) -> list[object]:
     """Validate hook objects and return a defensive list copy."""
     validated = list(hooks)
-    method_list = ", ".join(_HOOK_METHOD_NAMES)
+    method_list = ", ".join(HOOK_METHOD_NAMES)
     missing = object()
     for index, hook in enumerate(validated):
         implemented_methods: list[str] = []
-        for method_name in _HOOK_METHOD_NAMES:
+        for method_name in HOOK_METHOD_NAMES:
             method = getattr(hook, method_name, missing)
             if method is missing:
                 continue
@@ -1287,32 +1286,37 @@ def _validate_hook_objects(hooks: Sequence[object], *, label: str) -> list[objec
     return validated
 
 
-def _coerce_record_id(record_id: RecordIdInput) -> str:
+def _coerce_record_id(record_id: object) -> str:
     """Return a repository id string from public record-id input."""
-    if isinstance(record_id, str):
-        return record_id
-    if isinstance(record_id, bool):
-        raise TypeError("record_id must be a string or integer-like value, got bool")
-    try:
-        return str(operator_index(record_id))
-    except TypeError as exc:
-        raise TypeError(
-            f"record_id must be a string or integer-like value, got {type(record_id).__name__}"
-        ) from exc
+    if record_id is None:
+        raise TypeError("record_id must not be None")
+    return str(record_id)
 
 
 def _reference_locator_and_path(
-    reference: str | Path | ArtifactLocator,
+    reference: str | Path | ArtifactLocator | None,
+    *,
+    uri: str | None,
+    urlpath: str | None,
 ) -> tuple[ArtifactLocator, Path | None]:
     """Return the locator and local path metadata for a reference input."""
+    supplied = [value is not None for value in (reference, uri, urlpath)]
+    if sum(supplied) != 1:
+        raise ValueError("Pass exactly one of reference, uri, or urlpath.")
+    if uri is not None:
+        return ArtifactLocator(kind="uri", value=str(uri)), None
+    if urlpath is not None:
+        return ArtifactLocator.from_urlpath(str(urlpath)), None
+    assert reference is not None
     if isinstance(reference, ArtifactLocator):
-        return reference, reference.as_path()
+        path = reference.as_path()
+        if path is None:
+            return reference, None
+        resolved_path = path.expanduser().resolve()
+        return ArtifactLocator.from_path(resolved_path, relative_path=reference.relative_path), resolved_path
     if isinstance(reference, str):
         if "://" in reference:
-            raise ValueError(
-                "URI references must be passed as an ArtifactLocator, for example "
-                "ArtifactLocator(kind='uri', value=...) or ArtifactLocator.from_urlpath(...)."
-            )
+            return ArtifactLocator(kind="uri", value=reference), None
         path = Path(reference).expanduser().resolve()
         return ArtifactLocator.from_path(path), path
     path = Path(reference).expanduser().resolve()

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -12,7 +12,14 @@ from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.hooks import HOOK_METHOD_NAMES, ArtifactWriter, HookManager, OperationContext, OperationSource
+from ogcat.hooks import (
+    ArtifactWriter,
+    HookManager,
+    OperationContext,
+    OperationSource,
+    coerce_hook_iterable,
+    validate_hook_objects,
+)
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.plugins import PluginRegistry
@@ -1233,57 +1240,16 @@ def _coerce_hook_manager(
         raise ValueError("Pass either plugins or hooks, not both.")
     if hooks is not None:
         if isinstance(hooks, HookManager):
-            _validate_hook_objects(hooks.hooks, label="hooks")
+            validate_hook_objects(hooks.hooks, label="hooks")
             return hooks
-        return HookManager(_coerce_hook_iterable(hooks, label="hooks"))
+        return HookManager(coerce_hook_iterable(hooks, label="hooks"))
     if plugins is not None:
         if isinstance(plugins, PluginRegistry):
-            _validate_hook_objects(plugins.hooks, label="plugins")
+            validate_hook_objects(plugins.hooks, label="plugins")
             return plugins.hook_manager()
-        registry = PluginRegistry(_coerce_hook_iterable(plugins, label="plugins"))
+        registry = PluginRegistry(coerce_hook_iterable(plugins, label="plugins"))
         return registry.hook_manager()
     return HookManager()
-
-
-def _coerce_hook_iterable(value: object, *, label: str) -> list[object]:
-    """Return a validated list of hooks from an iterable input."""
-    expected = (
-        "a HookManager or iterable of hook objects"
-        if label == "hooks"
-        else "a PluginRegistry or iterable of hook objects"
-    )
-    if isinstance(value, str | bytes):
-        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}")
-    try:
-        hooks = iter(cast(Iterable[object], value))
-    except TypeError as exc:
-        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}") from exc
-    return _validate_hook_objects(hooks, label=label)
-
-
-def _validate_hook_objects(hooks: Iterable[object], *, label: str) -> list[object]:
-    """Validate hook objects and return a defensive list copy."""
-    validated = list(hooks)
-    method_list = ", ".join(HOOK_METHOD_NAMES)
-    missing = object()
-    for index, hook in enumerate(validated):
-        implemented_methods: list[str] = []
-        for method_name in HOOK_METHOD_NAMES:
-            method = getattr(hook, method_name, missing)
-            if method is missing:
-                continue
-            if not callable(method):
-                raise TypeError(
-                    f"{label} item {index} has non-callable hook method "
-                    f"{method_name!r}; got {type(method).__name__}"
-                )
-            implemented_methods.append(method_name)
-        if not implemented_methods:
-            raise TypeError(
-                f"{label} item {index} must provide at least one callable hook method "
-                f"({method_list}); got {type(hook).__name__}"
-            )
-    return validated
 
 
 def _coerce_record_id(record_id: object) -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -7,8 +7,9 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from operator import index as operator_index
 from pathlib import Path
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, SupportsIndex, cast, overload
 from uuid import uuid4
 
 from ogcat.extractors import extract_derived_metadata
@@ -36,6 +37,9 @@ ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
+PluginInput = PluginRegistry | list[object] | tuple[object, ...] | None
+HookInput = HookManager | list[object] | tuple[object, ...] | None
+RecordIdInput = str | SupportsIndex
 
 
 @dataclass(slots=True)
@@ -61,16 +65,18 @@ class Catalog:
         root: str | Path,
         spec: CatalogSpec,
         *,
-        plugins: PluginRegistry | None = None,
-        hooks: HookManager | None = None,
+        plugins: PluginInput = None,
+        hooks: HookInput = None,
     ) -> Catalog:
         """Create a catalog directory and write its specification.
 
         Args:
             root: Directory to create or reuse for the catalog.
             spec: Catalog specification to persist.
-            plugins: Optional plugin registry used to build a hook manager.
-            hooks: Optional hook manager. Pass either ``plugins`` or ``hooks``.
+            plugins: Optional plugin registry, or list/tuple of hook objects,
+                used to build a hook manager.
+            hooks: Optional hook manager, or list/tuple of hook objects. Pass
+                either ``plugins`` or ``hooks``.
 
         Returns:
             Open catalog instance bound to ``root``.
@@ -79,6 +85,7 @@ class Catalog:
             ValueError: If the configured backend is unsupported, or both
                 ``plugins`` and ``hooks`` are supplied.
         """
+        hook_manager = _coerce_hook_manager(plugins=plugins, hooks=hooks)
         root_path = Path(root).expanduser().resolve()
         root_path.mkdir(parents=True, exist_ok=True)
         spec.write(root_path / "catalog.json")
@@ -88,7 +95,7 @@ class Catalog:
             root=root_path,
             spec=spec,
             repository=repository,
-            hook_manager=_coerce_hook_manager(plugins=plugins, hooks=hooks),
+            hook_manager=hook_manager,
         )
 
     @classmethod
@@ -96,15 +103,17 @@ class Catalog:
         cls,
         root: str | Path,
         *,
-        plugins: PluginRegistry | None = None,
-        hooks: HookManager | None = None,
+        plugins: PluginInput = None,
+        hooks: HookInput = None,
     ) -> Catalog:
         """Open an existing catalog from disk.
 
         Args:
             root: Existing catalog root containing ``catalog.json``.
-            plugins: Optional plugin registry used to build a hook manager.
-            hooks: Optional hook manager. Pass either ``plugins`` or ``hooks``.
+            plugins: Optional plugin registry, or list/tuple of hook objects,
+                used to build a hook manager.
+            hooks: Optional hook manager, or list/tuple of hook objects. Pass
+                either ``plugins`` or ``hooks``.
 
         Returns:
             Open catalog instance bound to ``root``.
@@ -114,6 +123,7 @@ class Catalog:
             ValueError: If the configured backend is unsupported, or both
                 ``plugins`` and ``hooks`` are supplied.
         """
+        hook_manager = _coerce_hook_manager(plugins=plugins, hooks=hooks)
         root_path = Path(root).expanduser().resolve()
         spec = CatalogSpec.read(root_path / "catalog.json")
         repository = _open_repository(root_path, spec)
@@ -121,7 +131,7 @@ class Catalog:
             root=root_path,
             spec=spec,
             repository=repository,
-            hook_manager=_coerce_hook_manager(plugins=plugins, hooks=hooks),
+            hook_manager=hook_manager,
         )
 
     def add_file(
@@ -470,6 +480,74 @@ class Catalog:
                 schema=schema,
             )
 
+    def add_reference(
+        self,
+        reference: str | Path | ArtifactLocator,
+        *,
+        record_type: str = "external_reference",
+        metadata: Mapping[Any, Any] | None = None,
+        original_path: str | Path | None = None,
+        original_filename: str | None = None,
+        suffixes: list[str] | None = None,
+        derived_metadata: Mapping[Any, Any] | None = None,
+        naming_metadata: Mapping[Any, Any] | None = None,
+        time_added: str | None = None,
+        source: OperationSource | None = None,
+        transaction: UnitOfWork | None = None,
+    ) -> CatalogRecord:
+        """Record an existing path or locator without materialising storage.
+
+        ``add_reference()`` is a convenience wrapper around ``add_artifact()``
+        for artifacts that already exist. It records a reference only: no file
+        is copied, moved, created, or required to live under the catalog's
+        managed files root.
+
+        Args:
+            reference: Local filesystem path or explicit artifact locator.
+            record_type: Logical type of record to create.
+            metadata: JSON-compatible user metadata.
+            original_path: Optional source path or URI override. Inferred for
+                local path references when omitted.
+            original_filename: Optional source filename override. Inferred for
+                local path references when omitted.
+            suffixes: Optional source suffix list override. Inferred for local
+                path references when omitted.
+            derived_metadata: Optional derived metadata to persist.
+            naming_metadata: Optional naming metadata to persist.
+            time_added: Optional timestamp override.
+            source: Optional operation source for hooks.
+            transaction: Optional caller-owned unit of work.
+
+        Returns:
+            Persisted or staged reference record.
+        """
+        locator, local_path = _reference_locator_and_path(reference)
+        resolved_original_path = original_path
+        resolved_original_filename = original_filename
+        resolved_suffixes = suffixes
+        if local_path is not None:
+            if resolved_original_path is None:
+                resolved_original_path = local_path
+            if resolved_original_filename is None:
+                resolved_original_filename = local_path.name
+            if resolved_suffixes is None:
+                resolved_suffixes = local_path.suffixes
+
+        return self.add_artifact(
+            record_type=record_type,
+            locator=locator,
+            metadata=metadata,
+            storage_mode="reference",
+            original_path=resolved_original_path,
+            original_filename=resolved_original_filename,
+            suffixes=resolved_suffixes,
+            derived_metadata=derived_metadata,
+            naming_metadata=naming_metadata,
+            time_added=time_added,
+            source=source,
+            transaction=transaction,
+        )
+
     @contextmanager
     def transaction(self) -> Iterator[UnitOfWork]:
         """Create a best-effort unit of work for composed catalog operations.
@@ -671,11 +749,11 @@ class Catalog:
         """Return available named record schema names."""
         return self.spec.list_record_schemas()
 
-    def get(self, record_id: str) -> CatalogRecord | None:
-        """Get a record by id."""
-        return self.repository.get(record_id)
+    def get(self, record_id: RecordIdInput) -> CatalogRecord | None:
+        """Get a record by string or integer-like id."""
+        return self.repository.get(_coerce_record_id(record_id))
 
-    def path(self, record_id: str) -> Path | None:
+    def path(self, record_id: RecordIdInput) -> Path | None:
         """Return the stored path for a path-backed record, if present."""
         record = self.get(record_id)
         if record is None:
@@ -1140,19 +1218,105 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     return TinyDbCatalogRepository(root / spec.db_path)
 
 
+_HOOK_METHOD_NAMES = (
+    "before_validate_metadata",
+    "after_validate_metadata",
+    "resolve_artifact_locator",
+    "before_record_write",
+    "after_record_write",
+    "extract_metadata",
+    "before_commit",
+    "after_commit",
+    "on_error",
+    "on_rollback",
+)
+
+
 def _coerce_hook_manager(
     *,
-    plugins: PluginRegistry | None,
-    hooks: HookManager | None,
+    plugins: PluginInput,
+    hooks: HookInput,
 ) -> HookManager:
     """Resolve optional plugin or hook registration inputs."""
     if hooks is not None and plugins is not None:
         raise ValueError("Pass either plugins or hooks, not both.")
     if hooks is not None:
-        return hooks
+        if isinstance(hooks, HookManager):
+            _validate_hook_objects(hooks.hooks, label="hooks")
+            return hooks
+        if isinstance(hooks, (list, tuple)):
+            return HookManager(_validate_hook_objects(hooks, label="hooks"))
+        raise TypeError(
+            f"hooks must be a HookManager or a list/tuple of hook objects, got {type(hooks).__name__}"
+        )
     if plugins is not None:
-        return plugins.hook_manager()
+        if isinstance(plugins, PluginRegistry):
+            _validate_hook_objects(plugins.hooks, label="plugins")
+            return plugins.hook_manager()
+        if isinstance(plugins, (list, tuple)):
+            registry = PluginRegistry(_validate_hook_objects(plugins, label="plugins"))
+            return registry.hook_manager()
+        raise TypeError(
+            f"plugins must be a PluginRegistry or a list/tuple of hook objects, got {type(plugins).__name__}"
+        )
     return HookManager()
+
+
+def _validate_hook_objects(hooks: Sequence[object], *, label: str) -> list[object]:
+    """Validate hook objects and return a defensive list copy."""
+    validated = list(hooks)
+    method_list = ", ".join(_HOOK_METHOD_NAMES)
+    missing = object()
+    for index, hook in enumerate(validated):
+        implemented_methods: list[str] = []
+        for method_name in _HOOK_METHOD_NAMES:
+            method = getattr(hook, method_name, missing)
+            if method is missing:
+                continue
+            if not callable(method):
+                raise TypeError(
+                    f"{label} item {index} has non-callable hook method "
+                    f"{method_name!r}; got {type(method).__name__}"
+                )
+            implemented_methods.append(method_name)
+        if not implemented_methods:
+            raise TypeError(
+                f"{label} item {index} must provide at least one callable hook method "
+                f"({method_list}); got {type(hook).__name__}"
+            )
+    return validated
+
+
+def _coerce_record_id(record_id: RecordIdInput) -> str:
+    """Return a repository id string from public record-id input."""
+    if isinstance(record_id, str):
+        return record_id
+    if isinstance(record_id, bool):
+        raise TypeError("record_id must be a string or integer-like value, got bool")
+    try:
+        return str(operator_index(record_id))
+    except TypeError as exc:
+        raise TypeError(
+            f"record_id must be a string or integer-like value, got {type(record_id).__name__}"
+        ) from exc
+
+
+def _reference_locator_and_path(
+    reference: str | Path | ArtifactLocator,
+) -> tuple[ArtifactLocator, Path | None]:
+    """Return the locator and local path metadata for a reference input."""
+    if isinstance(reference, ArtifactLocator):
+        return reference, reference.as_path()
+    if isinstance(reference, str):
+        if "://" in reference:
+            raise ValueError(
+                "URI references must be passed as an ArtifactLocator, for example "
+                "ArtifactLocator(kind='uri', value=...) or ArtifactLocator.from_urlpath(...)."
+            )
+        path = Path(reference).expanduser().resolve()
+        return ArtifactLocator.from_path(path), path
+    path = Path(reference).expanduser().resolve()
+    return ArtifactLocator.from_path(path), path
 
 
 def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -554,7 +554,7 @@ def path(
     resolved = record.path()
     if resolved is None:
         _fail(f"Record is not path-backed: {record_id}")
-    console.print(str(resolved))
+    typer.echo(str(resolved))
 
 
 @app.command()

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -33,6 +33,19 @@ from ogcat.storage import StoragePlan
 from ogcat.transactions import RollbackAction
 from ogcat.validation import ValidationReport
 
+HOOK_METHOD_NAMES = (
+    "before_validate_metadata",
+    "after_validate_metadata",
+    "resolve_artifact_locator",
+    "before_record_write",
+    "after_record_write",
+    "extract_metadata",
+    "before_commit",
+    "after_commit",
+    "on_error",
+    "on_rollback",
+)
+
 
 @dataclass(slots=True)
 class HookWarning:
@@ -383,6 +396,7 @@ __all__ = [
     "BeforeRecordWriteHook",
     "ErrorHook",
     "ExtractMetadataHook",
+    "HOOK_METHOD_NAMES",
     "HookManager",
     "HookWarning",
     "OperationContext",

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -15,6 +15,11 @@ merges returned derived metadata, records non-fatal after-commit failures as
 warnings, and preserves the original exception when error or rollback hooks
 fail.
 
+``HOOK_METHOD_NAMES`` is the validation source of truth for ad hoc hook object
+inputs. When adding a lifecycle protocol to this module, add its method name to
+that tuple so ``Catalog.open()`` and ``Catalog.create()`` accept hooks that only
+implement the new stage.
+
 Artifact writers use the same context model. Any object satisfying
 :class:`ArtifactWriter` can materialise an :class:`ogcat.models.ArtifactLocator`
 from an :class:`OperationSource` before the catalog record is committed.
@@ -45,6 +50,68 @@ HOOK_METHOD_NAMES = (
     "on_error",
     "on_rollback",
 )
+
+
+def coerce_hook_iterable(value: object, *, label: str) -> list[object]:
+    """Return a validated list of hooks from an iterable input.
+
+    Args:
+        value: Candidate iterable of hook objects.
+        label: User-facing input name used in error messages.
+
+    Returns:
+        Validated hook objects as a defensive list copy.
+
+    Raises:
+        TypeError: If the value is not an iterable of hook objects.
+    """
+    expected = (
+        "a HookManager or iterable of hook objects"
+        if label == "hooks"
+        else "a PluginRegistry or iterable of hook objects"
+    )
+    if isinstance(value, str | bytes):
+        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}")
+    if not isinstance(value, Iterable):
+        raise TypeError(f"{label} must be {expected}, got {type(value).__name__}")
+    return validate_hook_objects(value, label=label)
+
+
+def validate_hook_objects(hooks: Iterable[object], *, label: str) -> list[object]:
+    """Validate hook objects and return a defensive list copy.
+
+    Args:
+        hooks: Hook objects to validate.
+        label: User-facing input name used in error messages.
+
+    Returns:
+        Validated hook objects as a defensive list copy.
+
+    Raises:
+        TypeError: If any hook object has no supported hook methods or a
+            matching hook method is not callable.
+    """
+    validated = list(hooks)
+    method_list = ", ".join(HOOK_METHOD_NAMES)
+    missing = object()
+    for index, hook in enumerate(validated):
+        implemented_methods: list[str] = []
+        for method_name in HOOK_METHOD_NAMES:
+            method = getattr(hook, method_name, missing)
+            if method is missing:
+                continue
+            if not callable(method):
+                raise TypeError(
+                    f"{label} item {index} has non-callable hook method "
+                    f"{method_name!r}; got {type(method).__name__}"
+                )
+            implemented_methods.append(method_name)
+        if not implemented_methods:
+            raise TypeError(
+                f"{label} item {index} must provide at least one callable hook method "
+                f"({method_list}); got {type(hook).__name__}"
+            )
+    return validated
 
 
 @dataclass(slots=True)
@@ -404,4 +471,6 @@ __all__ = [
     "ResolveArtifactLocatorHook",
     "RollbackHook",
     "RollbackRegistrar",
+    "coerce_hook_iterable",
+    "validate_hook_objects",
 ]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -770,6 +770,8 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
 
 
 def test_catalog_get_and_path_accept_stringable_record_ids(tmp_path: Path) -> None:
+    """Record lookup should coerce public record-id inputs with str()."""
+
     class RecordId:
         def __str__(self) -> str:
             return "50"
@@ -795,6 +797,8 @@ def test_catalog_get_and_path_accept_stringable_record_ids(tmp_path: Path) -> No
 
 
 def test_add_reference_records_local_path_without_copying_or_moving(tmp_path: Path) -> None:
+    """Local references should record path metadata without file side effects."""
+
     source_dir = tmp_path / "source"
     source_dir.mkdir()
     source = source_dir / "archive.tar.gz"
@@ -819,6 +823,8 @@ def test_add_reference_resolves_relative_path_locators(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Path locators should be normalized like direct local path inputs."""
+
     source = tmp_path / "relative.nc"
     source.write_text("raw", encoding="utf-8")
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
@@ -835,6 +841,8 @@ def test_add_reference_resolves_relative_path_locators(
 
 
 def test_add_reference_records_uri_locator_references(tmp_path: Path) -> None:
+    """URI locators should be recorded as reference records without path metadata."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     locator = ArtifactLocator(kind="uri", value="https://example.org/data/example.nc")
 
@@ -849,6 +857,8 @@ def test_add_reference_records_uri_locator_references(tmp_path: Path) -> None:
 
 
 def test_add_reference_records_uri_string_references(tmp_path: Path) -> None:
+    """URI-looking strings should be recorded as URI reference locators."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     record = catalog.add_reference("https://example.org/data/example.nc")
@@ -859,6 +869,8 @@ def test_add_reference_records_uri_string_references(tmp_path: Path) -> None:
 
 
 def test_add_reference_records_uri_keyword_references(tmp_path: Path) -> None:
+    """The uri keyword should record an explicit URI reference locator."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     record = catalog.add_reference(uri="https://example.org/data/example.nc")
@@ -868,6 +880,8 @@ def test_add_reference_records_uri_keyword_references(tmp_path: Path) -> None:
 
 
 def test_add_reference_records_urlpath_locator_references(tmp_path: Path) -> None:
+    """URL-path locators should be recorded unchanged as reference records."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     locator = ArtifactLocator.from_urlpath("s3://bucket/data/example.zarr")
 
@@ -878,6 +892,8 @@ def test_add_reference_records_urlpath_locator_references(tmp_path: Path) -> Non
 
 
 def test_add_reference_records_urlpath_keyword_references(tmp_path: Path) -> None:
+    """The urlpath keyword should record an fsspec URL-path reference locator."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     record = catalog.add_reference(urlpath="s3://bucket/data/example.zarr")
@@ -887,6 +903,8 @@ def test_add_reference_records_urlpath_keyword_references(tmp_path: Path) -> Non
 
 
 def test_add_reference_requires_one_reference_input(tmp_path: Path) -> None:
+    """Reference creation should reject missing or ambiguous locator inputs."""
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     with pytest.raises(ValueError, match="Pass exactly one of reference, uri, or urlpath"):
@@ -896,6 +914,8 @@ def test_add_reference_requires_one_reference_input(tmp_path: Path) -> None:
 
 
 def test_add_reference_allows_explicit_local_path_metadata(tmp_path: Path) -> None:
+    """Explicit local reference metadata should override inferred metadata."""
+
     source = tmp_path / "raw" / "example.nc"
     source.parent.mkdir()
     source.write_text("raw", encoding="utf-8")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -769,7 +769,11 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
     assert catalog.path(_record_id(record)) is None
 
 
-def test_catalog_get_and_path_accept_integer_like_record_ids(tmp_path: Path) -> None:
+def test_catalog_get_and_path_accept_stringable_record_ids(tmp_path: Path) -> None:
+    class RecordId:
+        def __str__(self) -> str:
+            return "50"
+
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     records = catalog.add_artifacts(
         [
@@ -785,6 +789,9 @@ def test_catalog_get_and_path_accept_integer_like_record_ids(tmp_path: Path) -> 
     assert _record_id(record) == "50"
     assert catalog.get(50) == catalog.get("50") == record
     assert catalog.path(50) == catalog.path("50") == tmp_path / "references" / "record-49.nc"
+    assert catalog.get(RecordId()) == record
+    with pytest.raises(TypeError, match="record_id must not be None"):
+        catalog.get(None)
 
 
 def test_add_reference_records_local_path_without_copying_or_moving(tmp_path: Path) -> None:
@@ -808,6 +815,25 @@ def test_add_reference_records_local_path_without_copying_or_moving(tmp_path: Pa
     assert list((catalog.root / catalog.spec.files_root).rglob("archive.tar.gz")) == []
 
 
+def test_add_reference_resolves_relative_path_locators(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "relative.nc"
+    source.write_text("raw", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    monkeypatch.chdir(tmp_path)
+
+    record = catalog.add_reference(ArtifactLocator.path("relative.nc"))
+
+    resolved_source = source.resolve()
+    assert record.locator == ArtifactLocator.path(resolved_source)
+    assert record.path() == resolved_source
+    assert record.original_path == str(resolved_source)
+    assert record.original_filename == "relative.nc"
+    assert record.suffixes == [".nc"]
+
+
 def test_add_reference_records_uri_locator_references(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     locator = ArtifactLocator(kind="uri", value="https://example.org/data/example.nc")
@@ -822,6 +848,25 @@ def test_add_reference_records_uri_locator_references(tmp_path: Path) -> None:
     assert record.suffixes == []
 
 
+def test_add_reference_records_uri_string_references(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference("https://example.org/data/example.nc")
+
+    assert record.locator == ArtifactLocator(kind="uri", value="https://example.org/data/example.nc")
+    assert record.storage_mode == "reference"
+    assert record.path() is None
+
+
+def test_add_reference_records_uri_keyword_references(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(uri="https://example.org/data/example.nc")
+
+    assert record.locator == ArtifactLocator(kind="uri", value="https://example.org/data/example.nc")
+    assert record.storage_mode == "reference"
+
+
 def test_add_reference_records_urlpath_locator_references(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     locator = ArtifactLocator.from_urlpath("s3://bucket/data/example.zarr")
@@ -830,6 +875,24 @@ def test_add_reference_records_urlpath_locator_references(tmp_path: Path) -> Non
 
     assert record.locator == locator
     assert record.storage_mode == "reference"
+
+
+def test_add_reference_records_urlpath_keyword_references(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(urlpath="s3://bucket/data/example.zarr")
+
+    assert record.locator == ArtifactLocator.from_urlpath("s3://bucket/data/example.zarr")
+    assert record.storage_mode == "reference"
+
+
+def test_add_reference_requires_one_reference_input(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(ValueError, match="Pass exactly one of reference, uri, or urlpath"):
+        catalog.add_reference()
+    with pytest.raises(ValueError, match="Pass exactly one of reference, uri, or urlpath"):
+        catalog.add_reference("local.nc", uri="https://example.org/data/example.nc")
 
 
 def test_add_reference_allows_explicit_local_path_metadata(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -769,6 +769,87 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
     assert catalog.path(_record_id(record)) is None
 
 
+def test_catalog_get_and_path_accept_integer_like_record_ids(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    records = catalog.add_artifacts(
+        [
+            {
+                "record_type": "external_reference",
+                "locator": ArtifactLocator.path(tmp_path / "references" / f"record-{index}.nc"),
+            }
+            for index in range(50)
+        ]
+    )
+    record = records[-1]
+
+    assert _record_id(record) == "50"
+    assert catalog.get(50) == catalog.get("50") == record
+    assert catalog.path(50) == catalog.path("50") == tmp_path / "references" / "record-49.nc"
+
+
+def test_add_reference_records_local_path_without_copying_or_moving(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "archive.tar.gz"
+    source.write_text("raw", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(source, metadata={"species": "CO2"})
+
+    resolved_source = source.resolve()
+    assert record.record_type == "external_reference"
+    assert record.storage_mode == "reference"
+    assert record.locator == ArtifactLocator.path(resolved_source)
+    assert record.path() == resolved_source
+    assert record.original_path == str(resolved_source)
+    assert record.original_filename == "archive.tar.gz"
+    assert record.suffixes == [".tar", ".gz"]
+    assert source.read_text(encoding="utf-8") == "raw"
+    assert list((catalog.root / catalog.spec.files_root).rglob("archive.tar.gz")) == []
+
+
+def test_add_reference_records_uri_locator_references(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    locator = ArtifactLocator(kind="uri", value="https://example.org/data/example.nc")
+
+    record = catalog.add_reference(locator, metadata={"title": "remote data"})
+
+    assert record.locator == locator
+    assert record.storage_mode == "reference"
+    assert record.path() is None
+    assert record.original_path is None
+    assert record.original_filename is None
+    assert record.suffixes == []
+
+
+def test_add_reference_records_urlpath_locator_references(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    locator = ArtifactLocator.from_urlpath("s3://bucket/data/example.zarr")
+
+    record = catalog.add_reference(locator)
+
+    assert record.locator == locator
+    assert record.storage_mode == "reference"
+
+
+def test_add_reference_allows_explicit_local_path_metadata(tmp_path: Path) -> None:
+    source = tmp_path / "raw" / "example.nc"
+    source.parent.mkdir()
+    source.write_text("raw", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(
+        source,
+        original_path="logical://source/example",
+        original_filename="renamed.dat",
+        suffixes=[".dat"],
+    )
+
+    assert record.original_path == "logical://source/example"
+    assert record.original_filename == "renamed.dat"
+    assert record.suffixes == [".dat"]
+
+
 def test_add_artifacts_supports_batch_artifact_creation(tmp_path: Path) -> None:
     root = tmp_path / "catalog"
     catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -462,6 +462,20 @@ def test_show_json_output(tmp_path: Path) -> None:
     assert payload["user_metadata"]["title"] == "Anthropogenic test flux"
 
 
+def test_show_and_path_commands_handle_numeric_looking_ids(tmp_path: Path) -> None:
+    catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
+    record_id = _record_id(record)
+
+    show_result = runner.invoke(app, ["show", record_id, "--catalog", str(catalog.root), "--json"])
+    path_result = runner.invoke(app, ["path", record_id, "--catalog", str(catalog.root)])
+
+    assert show_result.exit_code == 0
+    assert json.loads(strip_ansi(show_result.stdout))["id"] == record_id
+    assert path_result.exit_code == 0
+    assert strip_ansi(path_result.stdout).strip() == str(record.path())
+
+
 def test_info_human_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -463,6 +463,8 @@ def test_show_json_output(tmp_path: Path) -> None:
 
 
 def test_show_and_path_commands_handle_numeric_looking_ids(tmp_path: Path) -> None:
+    """Show and path commands should handle TinyDB numeric-looking record ids."""
+
     catalog = _create_catalog(tmp_path)
     record = catalog.search()[0]
     record_id = _record_id(record)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -41,6 +41,8 @@ def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
 
 
 def test_hook_iterable_convenience_invokes_hooks(tmp_path: Path) -> None:
+    """Hook generator inputs should be accepted and dispatched."""
+
     calls: list[str] = []
 
     class Hook:
@@ -61,6 +63,8 @@ def test_hook_iterable_convenience_invokes_hooks(tmp_path: Path) -> None:
 
 
 def test_hook_list_convenience_invokes_hooks(tmp_path: Path) -> None:
+    """Hook list inputs should be accepted and dispatched."""
+
     calls: list[str] = []
 
     class Hook:
@@ -77,6 +81,8 @@ def test_hook_list_convenience_invokes_hooks(tmp_path: Path) -> None:
 
 
 def test_plugin_iterable_convenience_invokes_hooks_on_open(tmp_path: Path) -> None:
+    """Plugin iterable inputs should build a hook manager on open."""
+
     calls: list[str] = []
 
     class Hook:
@@ -92,6 +98,8 @@ def test_plugin_iterable_convenience_invokes_hooks_on_open(tmp_path: Path) -> No
 
 
 def test_create_rejects_invalid_hook_inputs_immediately(tmp_path: Path) -> None:
+    """Invalid hooks inputs should fail before catalog files are created."""
+
     with pytest.raises(TypeError, match="hooks must be a HookManager or iterable of hook objects"):
         Catalog.create(
             tmp_path / "catalog",
@@ -103,6 +111,8 @@ def test_create_rejects_invalid_hook_inputs_immediately(tmp_path: Path) -> None:
 
 
 def test_open_rejects_invalid_plugin_inputs_immediately(tmp_path: Path) -> None:
+    """Invalid plugins inputs should fail while opening the catalog."""
+
     created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
 
     with pytest.raises(TypeError, match="plugins must be a PluginRegistry or iterable of hook objects"):
@@ -110,6 +120,8 @@ def test_open_rejects_invalid_plugin_inputs_immediately(tmp_path: Path) -> None:
 
 
 def test_open_rejects_non_hook_objects_in_hook_manager_immediately(tmp_path: Path) -> None:
+    """Hook managers should reject entries with no supported hook methods."""
+
     created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
 
     with pytest.raises(TypeError, match="hooks item 0 must provide at least one callable hook method"):
@@ -117,6 +129,8 @@ def test_open_rejects_non_hook_objects_in_hook_manager_immediately(tmp_path: Pat
 
 
 def test_create_rejects_both_plugins_and_hooks(tmp_path: Path) -> None:
+    """Catalog creation should preserve the plugins-or-hooks exclusivity rule."""
+
     class Hook:
         def before_validate_metadata(self, context: OperationContext) -> None:
             pass

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -40,7 +40,27 @@ def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
     assert calls == ["add_file"]
 
 
-def test_hook_sequence_convenience_invokes_hooks(tmp_path: Path) -> None:
+def test_hook_iterable_convenience_invokes_hooks(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(context.operation_type)
+
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        hooks=(Hook() for _ in range(1)),
+    )
+    source = tmp_path / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog.add_file(source)
+
+    assert calls == ["add_file"]
+
+
+def test_hook_list_convenience_invokes_hooks(tmp_path: Path) -> None:
     calls: list[str] = []
 
     class Hook:
@@ -56,7 +76,7 @@ def test_hook_sequence_convenience_invokes_hooks(tmp_path: Path) -> None:
     assert calls == ["add_file"]
 
 
-def test_plugin_sequence_convenience_invokes_hooks_on_open(tmp_path: Path) -> None:
+def test_plugin_iterable_convenience_invokes_hooks_on_open(tmp_path: Path) -> None:
     calls: list[str] = []
 
     class Hook:
@@ -64,7 +84,7 @@ def test_plugin_sequence_convenience_invokes_hooks_on_open(tmp_path: Path) -> No
             calls.append(context.operation_type)
 
     created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
-    catalog = Catalog.open(created.root, plugins=(Hook(),))
+    catalog = Catalog.open(created.root, plugins=(Hook() for _ in range(1)))
 
     catalog.add_reference(ArtifactLocator(kind="uri", value="https://example.org/data.nc"))
 
@@ -72,7 +92,7 @@ def test_plugin_sequence_convenience_invokes_hooks_on_open(tmp_path: Path) -> No
 
 
 def test_create_rejects_invalid_hook_inputs_immediately(tmp_path: Path) -> None:
-    with pytest.raises(TypeError, match="hooks must be a HookManager or a list/tuple of hook objects"):
+    with pytest.raises(TypeError, match="hooks must be a HookManager or iterable of hook objects"):
         Catalog.create(
             tmp_path / "catalog",
             CatalogSpec(catalog_name="files"),
@@ -85,7 +105,7 @@ def test_create_rejects_invalid_hook_inputs_immediately(tmp_path: Path) -> None:
 def test_open_rejects_invalid_plugin_inputs_immediately(tmp_path: Path) -> None:
     created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
 
-    with pytest.raises(TypeError, match="plugins must be a PluginRegistry or a list/tuple of hook objects"):
+    with pytest.raises(TypeError, match="plugins must be a PluginRegistry or iterable of hook objects"):
         Catalog.open(created.root, plugins="not plugins")  # type: ignore[arg-type]
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,6 +10,7 @@ from ogcat import (
     ArtifactLocator,
     Catalog,
     CatalogSpec,
+    HookManager,
     HookWarning,
     MetadataFieldDescription,
     PluginRegistry,
@@ -37,6 +38,76 @@ def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
     catalog.add_file(source)
 
     assert calls == ["add_file"]
+
+
+def test_hook_sequence_convenience_invokes_hooks(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(context.operation_type)
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"), hooks=[Hook()])
+    source = tmp_path / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog.add_file(source)
+
+    assert calls == ["add_file"]
+
+
+def test_plugin_sequence_convenience_invokes_hooks_on_open(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append(context.operation_type)
+
+    created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    catalog = Catalog.open(created.root, plugins=(Hook(),))
+
+    catalog.add_reference(ArtifactLocator(kind="uri", value="https://example.org/data.nc"))
+
+    assert calls == ["add_artifact"]
+
+
+def test_create_rejects_invalid_hook_inputs_immediately(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="hooks must be a HookManager or a list/tuple of hook objects"):
+        Catalog.create(
+            tmp_path / "catalog",
+            CatalogSpec(catalog_name="files"),
+            hooks="not hooks",  # type: ignore[arg-type]
+        )
+
+    assert not (tmp_path / "catalog" / "catalog.json").exists()
+
+
+def test_open_rejects_invalid_plugin_inputs_immediately(tmp_path: Path) -> None:
+    created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(TypeError, match="plugins must be a PluginRegistry or a list/tuple of hook objects"):
+        Catalog.open(created.root, plugins="not plugins")  # type: ignore[arg-type]
+
+
+def test_open_rejects_non_hook_objects_in_hook_manager_immediately(tmp_path: Path) -> None:
+    created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(TypeError, match="hooks item 0 must provide at least one callable hook method"):
+        Catalog.open(created.root, hooks=HookManager([object()]))
+
+
+def test_create_rejects_both_plugins_and_hooks(tmp_path: Path) -> None:
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            pass
+
+    with pytest.raises(ValueError, match="Pass either plugins or hooks, not both"):
+        Catalog.create(
+            tmp_path / "catalog",
+            CatalogSpec(catalog_name="files"),
+            plugins=PluginRegistry([Hook()]),
+            hooks=HookManager([Hook()]),
+        )
 
 
 def test_hooks_run_in_registration_order(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Added `Catalog.add_reference()` for recording existing local paths, URI locators, and urlpath locators without copying or moving data.
- Made `Catalog.get()` and `Catalog.path()` accept integer-like ids by coercing to strings at the API boundary, while keeping stored ids as strings.
- Validated `Catalog.open()` / `Catalog.create()` hook and plugin inputs immediately, including list/tuple convenience inputs, and kept the exclusive `plugins` vs `hooks` rule.
- Updated CLI and docs to distinguish managed ingest, reference records, and writer-backed artifact creation.

## Testing
- Added regression coverage for integer-like ids, reference recording, hook/plugin validation, list/tuple hook convenience, and CLI `show`/`path` behavior.
- `uv run ruff check` passed.
- `uv run ruff format --check` passed.
- `uv run pyright` passed.
- `uv run pytest` passed (`259 passed, 1 skipped`).