### PR TITLE
Add record-set selection helpers and schema-based display defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ matches = catalog.search(where={"species": "CO2"})
 regex_matches = catalog.search(regex={"version": r"^v4\.[0-9]+$"})
 ```
 
+For selection-heavy workflows, use the small helpers around search:
+
+```python
+record = catalog.get_one(
+    where={
+        "product": "GridFED",
+        "sector": "TOTAL",
+        "species": "co2",
+    }
+)
+
+# For local paths, record.path() is often the easiest value to open.
+# For URI/urlpath records, use the locator value.
+# ds = xr.open_dataset(record.locator.value)
+
+ids = catalog.find_ids(
+    where={"provenance": "derived", "species": "co2"},
+    contains={"keywords": "paris_verification_games"},
+)
+```
+
 Field lookup supports both flattened names and explicit dotted paths:
 
 ```python
@@ -125,6 +146,10 @@ The CLI accepts both explicit flags and simple positional expressions:
 uv run ogcat search --catalog example-catalog species=CO2
 uv run ogcat search --catalog example-catalog tags:paris user.site.code? --json
 uv run ogcat search --catalog example-catalog 'locator.uri~s3://bucket/*.zarr' --match title=paris --ids
+uv run ogcat show "$(uv run ogcat search --catalog example-catalog species=CO2 --ids --limit 1)" --catalog example-catalog
+uv run ogcat path "$(uv run ogcat search --catalog example-catalog species=CO2 --ids --limit 1)" --catalog example-catalog
+uv run ogcat fields --catalog example-catalog --stored
+uv run ogcat fields --catalog example-catalog --values species
 ```
 
 Register simple hooks directly in Python:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ matches = catalog.search(where={"species": "CO2"})
 regex_matches = catalog.search(regex={"version": r"^v4\.[0-9]+$"})
 ```
 
+`search()` returns a `CatalogRecordSet` by default, so results can be indexed,
+iterated, previewed, or narrowed to selected fields. Pass `as_record_set=False`
+when you explicitly need a plain list.
+
 For selection-heavy workflows, use the small helpers around search:
 
 ```python
@@ -122,10 +126,12 @@ record = catalog.get_one(
 # For URI/urlpath records, use the locator value.
 # ds = xr.open_dataset(record.locator.value)
 
-ids = catalog.find_ids(
+results = catalog.search(
     where={"provenance": "derived", "species": "co2"},
     contains={"keywords": "paris_verification_games"},
 )
+ids = results.ids
+summary = results.select("id", "product", "species")
 ```
 
 Field lookup supports both flattened names and explicit dotted paths:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,6 +53,14 @@ ogcat search --catalog <root> [FILTER ...] [OPTIONS]
 **Compatibility flags** (also available):
 ``--where``, ``--contains``, ``--match``, ``--regex``, ``--exists``, ``--missing``, ``--ignore-case``
 
+Use ``--ids`` when piping search results into ID-based commands:
+
+```bash
+record_id=$(ogcat search --catalog <root> species=CO2 --ids --limit 1)
+ogcat show "$record_id" --catalog <root>
+ogcat path "$record_id" --catalog <root>
+```
+
 ### ``ogcat show``
 
 Print a single record.
@@ -79,8 +87,8 @@ ogcat info --catalog <root>
 
 ### ``ogcat fields``
 
-Print declared metadata fields from the catalog spec, or inspect fields found
-in stored records.
+Print schema-declared metadata fields from the catalog spec, or inspect fields
+found in stored records.
 
 ```
 ogcat fields --catalog <root> [--record-type TYPE] [--stored] [--values FIELD] [--json]
@@ -95,10 +103,14 @@ unique scalar values for one field.
 Update small, safe parts of ``catalog.json``.
 
 ```
+ogcat spec show-schema [TYPE] --catalog <root> [--json]
 ogcat spec add-schema NAME --catalog <root> --schema-json JSON_OR_PATH [--overwrite]
 ogcat spec set-default-schema NAME --catalog <root>
 ogcat spec set FIELD=VALUE ... --catalog <root>
 ```
+
+``ogcat spec show-schema --json`` prints the full serialisable schema,
+including ``display_fields`` when configured.
 
 ``ogcat spec set`` supports simple fields such as ``catalog_name``,
 ``default_operation``, and ``field_resolution_order``. ``files_root`` changes

--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -66,6 +66,7 @@ from ogcat import CatalogSpec, RecordSchema, MetadataFieldDescription
 spec = CatalogSpec(
     catalog_name="fluxes",
     default_schema=RecordSchema(
+        display_fields=["id", "species", "year", "path"],
         metadata_fields=[
             MetadataFieldDescription(
                 name="species",
@@ -83,6 +84,17 @@ spec = CatalogSpec(
     ),
 )
 ```
+
+`display_fields` declares the compact fields to show in search result previews
+and notebook dataframes:
+
+```python
+results = catalog.search(where={"species": "CO2"}, as_record_set=True)
+df = results.to_dataframe(fields="default")
+```
+
+Calling `results.to_dataframe()` with no fields still returns full record
+dictionaries for compatibility.
 
 Named schemas let one catalog hold different record types with different
 metadata expectations:
@@ -133,7 +145,7 @@ ogcat fields --catalog ./my-catalog --record-type surface
 ogcat fields --catalog ./my-catalog --json
 ```
 
-This prints the declared metadata fields from the catalog spec.
+This prints the schema-declared metadata fields from the catalog spec.
 
 To discover fields actually present in stored records, use:
 

--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -89,10 +89,12 @@ spec = CatalogSpec(
 and notebook dataframes:
 
 ```python
-results = catalog.search(where={"species": "CO2"}, as_record_set=True)
+results = catalog.search(where={"species": "CO2"})
+rows = results.rows()
 df = results.to_dataframe(fields="default")
 ```
 
+`to_dataframe()` requires pandas to be installed in the active environment.
 Calling `results.to_dataframe()` with no fields still returns full record
 dictionaries for compatibility.
 

--- a/docs/tutorials/basic-catalog.md
+++ b/docs/tutorials/basic-catalog.md
@@ -22,6 +22,7 @@ from ogcat import ArtifactLocator, Catalog, CatalogSpec, MetadataFieldDescriptio
 
 measurement_schema = RecordSchema(
     description="Managed local measurement files.",
+    display_fields=["id", "site", "species", "year", "path"],
     metadata_fields=[
         MetadataFieldDescription(name="title", description="Human-readable title.", required=True),
         MetadataFieldDescription(name="site", description="Site code.", required=True),
@@ -32,6 +33,7 @@ measurement_schema = RecordSchema(
 
 reference_schema = RecordSchema(
     description="References to external artifacts that ogcat does not copy.",
+    display_fields=["id", "kind", "topic", "locator.uri"],
     metadata_fields=[
         MetadataFieldDescription(name="title", description="Reference title.", required=True),
         MetadataFieldDescription(name="kind", description="Reference kind.", required=True),
@@ -92,14 +94,25 @@ with TemporaryDirectory(prefix="ogcat-tutorial-") as tmp:
 ```python
     ch4_records = catalog.search(where={"species": "CH4"})
     topic_matches = catalog.search(contains={"topic": "methane"}, ignore_case=True)
+    selected = catalog.get_one(where={"site": "MHD", "species": "CH4"})
+    record_ids = catalog.find_ids(where={"species": "CH4"})
+    display_df = catalog.search(where={"species": "CH4"}, as_record_set=True).to_dataframe(fields="default")
 
     print(ch4_records[0].path())
     print(topic_matches[0].locator.value)
+    print(selected.path())
+    print(record_ids)
+    print(display_df)
 ```
 
 Unqualified fields such as `species` and `topic` are resolved across top-level
 record fields, `user_metadata`, and `derived_metadata`. Use dotted paths such as
 `user_metadata.species` when you need to be explicit.
+
+When a `RecordSchema` defines `display_fields`, record-set previews and
+`to_dataframe(fields="default")` use those compact fields for notebook-style
+inspection. `to_dataframe()` with no fields still returns full record
+dictionaries.
 
 ## Modify metadata with the repository
 
@@ -126,4 +139,7 @@ intentionally changing them.
 uv run ogcat init /tmp/tutorial-catalog --name tutorial
 uv run ogcat add ./mhd_ch4_2024.txt --catalog /tmp/tutorial-catalog --meta title="MHD methane observations" site=MHD species=CH4 year=2024
 uv run ogcat search --catalog /tmp/tutorial-catalog species=CH4 --fields id,title,species,path
+uv run ogcat search --catalog /tmp/tutorial-catalog species=CH4 --ids
+uv run ogcat fields --catalog /tmp/tutorial-catalog --stored
+uv run ogcat fields --catalog /tmp/tutorial-catalog --values species
 ```

--- a/docs/tutorials/basic-catalog.md
+++ b/docs/tutorials/basic-catalog.md
@@ -95,24 +95,28 @@ with TemporaryDirectory(prefix="ogcat-tutorial-") as tmp:
     ch4_records = catalog.search(where={"species": "CH4"})
     topic_matches = catalog.search(contains={"topic": "methane"}, ignore_case=True)
     selected = catalog.get_one(where={"site": "MHD", "species": "CH4"})
-    record_ids = catalog.find_ids(where={"species": "CH4"})
-    display_df = catalog.search(where={"species": "CH4"}, as_record_set=True).to_dataframe(fields="default")
+    record_ids = ch4_records.ids
+    display_rows = ch4_records.rows()
 
     print(ch4_records[0].path())
     print(topic_matches[0].locator.value)
     print(selected.path())
     print(record_ids)
-    print(display_df)
+    print(display_rows)
 ```
 
 Unqualified fields such as `species` and `topic` are resolved across top-level
 record fields, `user_metadata`, and `derived_metadata`. Use dotted paths such as
 `user_metadata.species` when you need to be explicit.
 
+`search()` returns a `CatalogRecordSet` by default. It behaves like a sequence
+of records and also provides helpers such as `ids`, `rows()`, `preview()`, and
+`select(...)`.
+
 When a `RecordSchema` defines `display_fields`, record-set previews and
-`to_dataframe(fields="default")` use those compact fields for notebook-style
-inspection. `to_dataframe()` with no fields still returns full record
-dictionaries.
+`rows()` use those compact fields for notebook-style inspection. If pandas is
+available, `to_dataframe(fields="default")` uses the same fields.
+`to_dataframe()` with no fields still returns full record dictionaries.
 
 ## Modify metadata with the repository
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -709,6 +709,91 @@ class Catalog:
             return self.record_set(results)
         return results
 
+    def find(
+        self,
+        query: SearchQuery | None = None,
+        *,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
+        exists: Sequence[str] | None = None,
+        missing: Sequence[str] | None = None,
+        ignore_case: bool = False,
+    ) -> list[CatalogRecord]:
+        """Return matching records using the same filters as ``search``."""
+        return self.search(
+            query=query,
+            where=where,
+            contains=contains,
+            regex=regex,
+            match=match,
+            exists=exists,
+            missing=missing,
+            ignore_case=ignore_case,
+        )
+
+    def find_ids(
+        self,
+        query: SearchQuery | None = None,
+        *,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
+        exists: Sequence[str] | None = None,
+        missing: Sequence[str] | None = None,
+        ignore_case: bool = False,
+    ) -> list[str]:
+        """Return stable string IDs for records matching the search filters."""
+        return [
+            str(record.id)
+            for record in self.find(
+                query=query,
+                where=where,
+                contains=contains,
+                regex=regex,
+                match=match,
+                exists=exists,
+                missing=missing,
+                ignore_case=ignore_case,
+            )
+            if record.id is not None
+        ]
+
+    def get_one(
+        self,
+        query: SearchQuery | None = None,
+        *,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
+        exists: Sequence[str] | None = None,
+        missing: Sequence[str] | None = None,
+        ignore_case: bool = False,
+        allow_many: bool = False,
+    ) -> CatalogRecord:
+        """Return one matching record, raising clear errors for ambiguous searches."""
+        records = self.find(
+            query=query,
+            where=where,
+            contains=contains,
+            regex=regex,
+            match=match,
+            exists=exists,
+            missing=missing,
+            ignore_case=ignore_case,
+        )
+        if not records:
+            raise ValueError("get_one found no records matching the search filters.")
+        if len(records) > 1 and not allow_many:
+            raise ValueError(
+                f"get_one found multiple records ({len(records)}) matching the search filters. "
+                "Refine the filters or pass allow_many=True."
+            )
+        return records[0]
+
     def record_set(self, records: Sequence[CatalogRecord]) -> CatalogRecordSet:
         """Wrap records in a sequence-like container.
 
@@ -718,7 +803,16 @@ class Catalog:
         Returns:
             Record set using this catalog's field resolution order.
         """
-        return CatalogRecordSet(records, resolution_order=self.spec.field_resolution_order)
+        schema_display_fields = {
+            record_type: self.spec.get_schema(record_type).display_fields
+            for record_type in self.spec.list_record_schemas()
+        }
+        return CatalogRecordSet(
+            records,
+            resolution_order=self.spec.field_resolution_order,
+            schema_display_fields=schema_display_fields,
+            default_display_fields=self.spec.get_schema().display_fields,
+        )
 
     def describe(self) -> dict[str, object]:
         """Return a serialisable summary of catalog configuration and contents."""
@@ -741,7 +835,7 @@ class Catalog:
         }
 
     def list_metadata_fields(self, record_type: str | None = None) -> list[dict[str, JsonValue]]:
-        """Return serialisable metadata field descriptions for a schema."""
+        """Return serialisable schema-declared metadata field descriptions."""
         schema = self._select_schema(record_type, require_known=record_type is not None)
         return [field_description.to_dict() for field_description in schema.metadata_fields]
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -647,14 +647,14 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
-        as_record_set: Literal[False] = False,
-    ) -> list[CatalogRecord]: ...
+        as_record_set: Literal[True] = True,
+    ) -> CatalogRecordSet: ...
 
     @overload
     def search(
         self,
-        *,
         query: SearchQuery | None = None,
+        *,
         where: Mapping[str, object] | None = None,
         contains: Mapping[str, object] | None = None,
         regex: Mapping[str, str] | None = None,
@@ -662,8 +662,8 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
-        as_record_set: Literal[True],
-    ) -> CatalogRecordSet: ...
+        as_record_set: Literal[False],
+    ) -> list[CatalogRecord]: ...
 
     def search(
         self,
@@ -676,7 +676,7 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
-        as_record_set: bool = False,
+        as_record_set: bool = True,
     ) -> list[CatalogRecord] | CatalogRecordSet:
         """Search catalog records using backend-neutral query semantics.
 
@@ -689,10 +689,10 @@ class Catalog:
             exists: Fields that must be present.
             missing: Fields that must be absent.
             ignore_case: Whether string comparisons should be case-insensitive.
-            as_record_set: Return a ``CatalogRecordSet`` instead of a list.
+            as_record_set: Return a ``CatalogRecordSet``. Pass ``False`` for a list.
 
         Returns:
-            Matching records, either as a list or record-set view.
+            Matching records, as a record-set view by default or a list when requested.
         """
         results = self.repository.search(
             query=query,
@@ -709,58 +709,6 @@ class Catalog:
             return self.record_set(results)
         return results
 
-    def find(
-        self,
-        query: SearchQuery | None = None,
-        *,
-        where: Mapping[str, object] | None = None,
-        contains: Mapping[str, object] | None = None,
-        regex: Mapping[str, str] | None = None,
-        match: Mapping[str, str] | None = None,
-        exists: Sequence[str] | None = None,
-        missing: Sequence[str] | None = None,
-        ignore_case: bool = False,
-    ) -> list[CatalogRecord]:
-        """Return matching records using the same filters as ``search``."""
-        return self.search(
-            query=query,
-            where=where,
-            contains=contains,
-            regex=regex,
-            match=match,
-            exists=exists,
-            missing=missing,
-            ignore_case=ignore_case,
-        )
-
-    def find_ids(
-        self,
-        query: SearchQuery | None = None,
-        *,
-        where: Mapping[str, object] | None = None,
-        contains: Mapping[str, object] | None = None,
-        regex: Mapping[str, str] | None = None,
-        match: Mapping[str, str] | None = None,
-        exists: Sequence[str] | None = None,
-        missing: Sequence[str] | None = None,
-        ignore_case: bool = False,
-    ) -> list[str]:
-        """Return stable string IDs for records matching the search filters."""
-        return [
-            str(record.id)
-            for record in self.find(
-                query=query,
-                where=where,
-                contains=contains,
-                regex=regex,
-                match=match,
-                exists=exists,
-                missing=missing,
-                ignore_case=ignore_case,
-            )
-            if record.id is not None
-        ]
-
     def get_one(
         self,
         query: SearchQuery | None = None,
@@ -775,7 +723,7 @@ class Catalog:
         allow_many: bool = False,
     ) -> CatalogRecord:
         """Return one matching record, raising clear errors for ambiguous searches."""
-        records = self.find(
+        records = self.search(
             query=query,
             where=where,
             contains=contains,

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -16,7 +16,7 @@ from rich.table import Table
 
 from ogcat.catalog import Catalog
 from ogcat.models import CatalogRecord
-from ogcat.record_set import DEFAULT_RECORDSET_FIELDS, CatalogRecordSet
+from ogcat.record_set import CatalogRecordSet
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
 
@@ -29,7 +29,6 @@ app.add_typer(spec_app, name="spec")
 console = Console()
 error_console = Console(stderr=True)
 DEFAULT_SEARCH_LIMIT = 50
-DEFAULT_SEARCH_FIELDS: list[str] = list(DEFAULT_RECORDSET_FIELDS)
 SearchOutputFormat = Literal["table", "plain", "csv", "tsv", "pipe"]
 
 
@@ -427,10 +426,10 @@ def search(
     if all_results and limit is not None:
         raise typer.BadParameter("Use either --all or --limit, not both.")
     display_limit = limit if limit is not None else DEFAULT_SEARCH_LIMIT
-    display_fields = DEFAULT_SEARCH_FIELDS
+    display_fields: list[str] | None = None
     parsed_output_format: SearchOutputFormat = "table"
     if not any([json_mode, ids_only, paths_only]):
-        display_fields = _parse_fields_option(fields) or DEFAULT_SEARCH_FIELDS
+        display_fields = _parse_fields_option(fields)
         parsed_output_format = _parse_search_output_format(output_format)
     active_catalog = _open_catalog_or_fail(catalog)
     query = SearchQuery.from_filters(
@@ -474,15 +473,14 @@ def search(
         console.print("No records matched.")
         return
 
-    rows = _search_display_rows(
-        active_catalog.record_set(shown_results),
-        fields=display_fields,
-    )
+    record_set = active_catalog.record_set(shown_results)
+    resolved_display_fields = display_fields or record_set.default_fields()
+    rows = _search_display_rows(record_set, fields=resolved_display_fields)
 
     if parsed_output_format != "table":
         delimiters = {"plain": " ", "csv": ",", "tsv": "\t", "pipe": "|"}
         _print_delimited_search_output(
-            fields=display_fields,
+            fields=resolved_display_fields,
             rows=rows,
             delimiter=delimiters[parsed_output_format],
         )
@@ -499,7 +497,7 @@ def search(
             f"Showing {len(shown_results)} of {len(results)} matches. "
             "Use --limit N, --all, or --json for more."
         )
-    _print_search_table(fields=display_fields, rows=rows)
+    _print_search_table(fields=resolved_display_fields, rows=rows)
 
 
 @app.command()
@@ -663,10 +661,10 @@ def fields(
         return
 
     if not metadata_fields:
-        console.print("No metadata fields are defined in this catalog.")
+        console.print("No schema-declared metadata fields are defined in this catalog.")
         return
 
-    table = Table(title="metadata fields", expand=True)
+    table = Table(title="schema-declared metadata fields", expand=True)
     table.add_column("name")
     table.add_column("required")
     table.add_column("type")
@@ -685,6 +683,52 @@ def fields(
             "" if field_description.get("example") is None else json.dumps(field_description["example"]),
         )
 
+    console.print(table)
+
+
+@spec_app.command("show-schema")
+def spec_show_schema(
+    record_type: Annotated[
+        str | None,
+        typer.Argument(help="Record schema name. Omit to show the default schema."),
+    ] = None,
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print the schema as JSON."),
+    ] = False,
+) -> None:
+    """Show a full record schema."""
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        schema = active_catalog.get_schema(record_type)
+    except ValueError as exc:
+        _fail(str(exc))
+
+    if json_mode:
+        _print_json(schema)
+        return
+
+    metadata_fields = schema.get("metadata_fields", [])
+    if not isinstance(metadata_fields, list):
+        metadata_fields = []
+    display_fields = schema.get("display_fields", [])
+    if not isinstance(display_fields, list):
+        display_fields = []
+    metadata_field_names = [
+        str(field.get("name", "")) for field in metadata_fields if isinstance(field, dict)
+    ]
+
+    title = "default record schema" if record_type is None else f"record schema: {record_type}"
+    table = Table(title=title, show_header=False)
+    table.add_column("field")
+    table.add_column("value")
+    table.add_row("description", str(schema.get("description", "")))
+    table.add_row("directory template", str(schema.get("directory_template", "")))
+    table.add_row("filename template", str(schema.get("filename_template", "")))
+    table.add_row("display fields", ", ".join(str(field) for field in display_fields))
+    table.add_row("metadata fields", ", ".join(metadata_field_names))
+    table.add_row("allow unknown metadata", str(schema.get("allow_unknown_metadata", True)))
     console.print(table)
 
 

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -443,6 +443,7 @@ def search(
     results = active_catalog.search(
         query=query,
         ignore_case=ignore_case,
+        as_record_set=False,
     )
 
     if json_mode:

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from importlib import import_module
 from pathlib import Path
 from typing import Any, overload
@@ -14,6 +14,7 @@ from ogcat.models import CatalogRecord, JsonValue
 from ogcat.search import flatten_lookup, resolve_field
 
 DEFAULT_RECORDSET_FIELDS = ("id", "title", "product", "species", "path")
+HETEROGENEOUS_RECORDSET_BASE_FIELDS = ("id", "record_type", "path")
 
 
 def resolve_record_field(
@@ -57,9 +58,17 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
         records: Sequence[CatalogRecord],
         *,
         resolution_order: Sequence[str] | None = None,
+        schema_display_fields: Mapping[str, Sequence[str]] | None = None,
+        default_display_fields: Sequence[str] | None = None,
     ) -> None:
         self._records = tuple(records)
         self._resolution_order = tuple(resolution_order or ("top_level", "user_metadata", "derived_metadata"))
+        self._schema_display_fields = {
+            record_type: tuple(fields)
+            for record_type, fields in (schema_display_fields or {}).items()
+            if fields
+        }
+        self._default_display_fields = tuple(default_display_fields or ())
 
     def __len__(self) -> int:
         """Return the number of records in the set."""
@@ -77,6 +86,8 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
             return CatalogRecordSet(
                 self._records[index],
                 resolution_order=self._resolution_order,
+                schema_display_fields=self._schema_display_fields,
+                default_display_fields=self._default_display_fields,
             )
         return self._records[index]
 
@@ -88,7 +99,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
         """Return JSON-friendly rows for the selected fields."""
         return self.rows(fields)
 
-    def rows(self, fields: Sequence[str]) -> list[dict[str, JsonValue]]:
+    def rows(self, fields: Sequence[str] | str = "default") -> list[dict[str, JsonValue]]:
         """Return JSON-friendly rows for the selected fields.
 
         Args:
@@ -97,7 +108,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
         Returns:
             One dictionary per record.
         """
-        selected_fields = list(fields)
+        selected_fields = self._normalise_fields(fields)
         return [
             {
                 field: resolve_record_field(
@@ -110,7 +121,9 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
             for record in self._records
         ]
 
-    def display_rows(self, fields: Sequence[str], *, limit: int | None = None) -> list[list[str]]:
+    def display_rows(
+        self, fields: Sequence[str] | str = "default", *, limit: int | None = None
+    ) -> list[list[str]]:
         """Return CLI-style display rows for the selected fields.
 
         Args:
@@ -118,6 +131,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
             limit: Maximum number of records to format. Formats all records when omitted.
         """
         records = self._records if limit is None else self._records[:limit]
+        selected_fields = self._normalise_fields(fields)
         return [
             [
                 format_display_value(
@@ -127,7 +141,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
                         resolution_order=self._resolution_order,
                     )
                 )
-                for field in fields
+                for field in selected_fields
             ]
             for record in records
         ]
@@ -162,24 +176,24 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
     def preview(
         self,
         *,
-        fields: Sequence[str] = DEFAULT_RECORDSET_FIELDS,
+        fields: Sequence[str] | str = "default",
         limit: int = 10,
     ) -> Table:
         """Build a Rich table preview of the selected fields."""
         table = Table(title="ogcat search results")
-        field_names = list(fields)
+        field_names = self._normalise_fields(fields)
         for field in field_names:
             table.add_column(field, overflow="fold")
         for row in self.display_rows(field_names, limit=limit):
             table.add_row(*row)
         return table
 
-    def to_dataframe(self, fields: Sequence[str] | None = None) -> Any:
+    def to_dataframe(self, fields: Sequence[str] | str | None = None) -> Any:
         """Convert the records to a pandas DataFrame when pandas is available.
 
         Args:
-            fields: Optional selected fields. When omitted, full record
-                dictionaries are used.
+            fields: Optional selected fields. Pass ``"default"`` to use compact
+                display fields. When omitted, full record dictionaries are used.
 
         Returns:
             ``pandas.DataFrame`` containing the selected record data.
@@ -197,9 +211,45 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
         records = [record.to_dict() for record in self._records] if fields is None else self.rows(fields)
         return pd.DataFrame.from_records(records)
 
+    def to_display_dataframe(self, fields: Sequence[str] | str = "default") -> Any:
+        """Convert compact display rows to a pandas DataFrame."""
+        return self.to_dataframe(fields=fields)
+
+    def default_fields(self) -> list[str]:
+        """Return default display fields for this record set."""
+        if not self._records:
+            return list(DEFAULT_RECORDSET_FIELDS)
+
+        record_types = sorted({record.record_type for record in self._records})
+        if len(record_types) == 1:
+            return self._display_fields_for_record_type(record_types[0])
+
+        merged_fields: list[str] = []
+        _append_unique(merged_fields, HETEROGENEOUS_RECORDSET_BASE_FIELDS)
+        for record_type in record_types:
+            _append_unique(merged_fields, self._display_fields_for_record_type(record_type))
+        return merged_fields
+
     def __rich__(self) -> Table:
         """Return a Rich preview for terminals and notebooks."""
         return self.preview()
+
+    def _normalise_fields(self, fields: Sequence[str] | str) -> list[str]:
+        """Return selected fields, resolving the default display sentinel."""
+        if fields == "default":
+            return self.default_fields()
+        if isinstance(fields, str):
+            return [fields]
+        return list(fields)
+
+    def _display_fields_for_record_type(self, record_type: str) -> list[str]:
+        """Return display fields for a record type with global fallback."""
+        fields = self._schema_display_fields.get(record_type)
+        if fields:
+            return list(fields)
+        if self._default_display_fields:
+            return list(self._default_display_fields)
+        return list(DEFAULT_RECORDSET_FIELDS)
 
 
 def _nested_field_paths(mapping: dict[str, JsonValue], *, prefix: str) -> set[str]:
@@ -222,3 +272,10 @@ def _is_discoverable_value(value: object) -> bool:
 def _is_scalar_json_value(value: object) -> bool:
     """Return whether a value is safe to include in unique-value summaries."""
     return value is None or isinstance(value, str | int | float | bool)
+
+
+def _append_unique(target: list[str], fields: Sequence[str]) -> None:
+    """Append fields to a list, preserving the first occurrence."""
+    for field in fields:
+        if field not in target:
+            target.append(field)

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -95,6 +95,19 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
         """Iterate over records in insertion order."""
         return iter(self._records)
 
+    def __eq__(self, other: object) -> bool:
+        """Return whether this record set contains the same records as another sequence."""
+        if isinstance(other, CatalogRecordSet):
+            return self._records == other._records
+        if isinstance(other, Sequence) and not isinstance(other, str | bytes | bytearray):
+            return list(self._records) == list(other)
+        return NotImplemented
+
+    @property
+    def ids(self) -> list[str]:
+        """Return stable string IDs for records in this set."""
+        return [str(record.id) for record in self._records if record.id is not None]
+
     def select(self, *fields: str) -> list[dict[str, JsonValue]]:
         """Return JSON-friendly rows for the selected fields."""
         return self.rows(fields)

--- a/src/ogcat/record_set.py
+++ b/src/ogcat/record_set.py
@@ -101,7 +101,7 @@ class CatalogRecordSet(Sequence[CatalogRecord]):
             return self._records == other._records
         if isinstance(other, Sequence) and not isinstance(other, str | bytes | bytearray):
             return list(self._records) == list(other)
-        return NotImplemented
+        return False
 
     @property
     def ids(self) -> list[str]:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -22,6 +22,7 @@ class RecordSchema:
         directory_template: Optional storage directory template.
         filename_template: Optional storage filename template.
         metadata_fields: Described metadata fields.
+        display_fields: Preferred fields for compact search/result display.
         allow_unknown_metadata: Whether fields outside ``metadata_fields`` are
             allowed during strict validation.
     """
@@ -30,6 +31,7 @@ class RecordSchema:
     directory_template: str | None = None
     filename_template: str | None = None
     metadata_fields: list[MetadataFieldDescription] = field(default_factory=list)
+    display_fields: list[str] = field(default_factory=list)
     allow_unknown_metadata: bool = True
 
     def to_dict(self) -> dict[str, object]:
@@ -43,6 +45,8 @@ class RecordSchema:
             payload["directory_template"] = self.directory_template
         if self.filename_template is not None:
             payload["filename_template"] = self.filename_template
+        if self.display_fields:
+            payload["display_fields"] = list(self.display_fields)
         if not self.allow_unknown_metadata:
             payload["allow_unknown_metadata"] = False
         return payload
@@ -63,6 +67,7 @@ class RecordSchema:
                 None if data.get("filename_template") is None else str(data["filename_template"])
             ),
             metadata_fields=metadata_fields,
+            display_fields=_coerce_string_list(data.get("display_fields"), field_name="display_fields"),
             allow_unknown_metadata=bool(data.get("allow_unknown_metadata", True)),
         )
 
@@ -77,6 +82,7 @@ class RecordSchema:
                 fallback.filename_template if self.filename_template is None else self.filename_template
             ),
             metadata_fields=list(self.metadata_fields),
+            display_fields=list(self.display_fields or fallback.display_fields),
             allow_unknown_metadata=self.allow_unknown_metadata,
         )
 
@@ -282,3 +288,9 @@ def _coerce_object_list(value: object, *, field_name: str) -> list[object]:
     if not isinstance(value, list):
         raise TypeError(f"{field_name} must be a list")
     return value
+
+
+def _coerce_string_list(value: object, *, field_name: str) -> list[str]:
+    """Coerce a JSON-like list value to a string list."""
+    items = _coerce_object_list(value, field_name=field_name)
+    return [str(item) for item in items]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -287,6 +287,34 @@ def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
     assert "CTE-HR" not in stdout
 
 
+def test_search_uses_schema_display_fields_when_fields_are_omitted(tmp_path: Path) -> None:
+    """Default search output uses schema display fields for homogeneous results."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(display_fields=["id", "species", "locator.uri"]),
+            },
+        ),
+    )
+    record = catalog.add_artifact(
+        record_type="flux",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/flux.zarr"),
+        metadata={"species": "CO2", "product": "GridFED"},
+    )
+
+    result = runner.invoke(app, ["search", "--catalog", str(catalog.root), "--where", "species=CO2"])
+
+    assert result.exit_code == 0
+    stdout = strip_ansi(result.stdout)
+    assert "locator.uri" in stdout
+    assert "s3://bucket/flux.zarr" in stdout
+    assert _record_id(record) in stdout
+    assert "product" not in stdout
+    assert "GridFED" not in stdout
+
+
 def test_search_fields_supports_dotted_paths_and_locator_uri(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     catalog.add_artifact(
@@ -509,7 +537,7 @@ def test_fields_human_output(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     stdout = strip_ansi(result.stdout)
-    assert "metadata fields" in stdout
+    assert "schema-declared metadata fields" in stdout
     assert "species" in stdout
     assert "Gas species name used for grouping" in stdout
 
@@ -528,12 +556,15 @@ def test_fields_json_output(tmp_path: Path) -> None:
 def test_fields_stored_and_values_output(tmp_path: Path) -> None:
     catalog = _create_catalog(tmp_path)
 
+    stored_human_result = runner.invoke(app, ["fields", "--catalog", str(catalog.root), "--stored"])
     stored_result = runner.invoke(app, ["fields", "--catalog", str(catalog.root), "--stored", "--json"])
     values_result = runner.invoke(
         app,
         ["fields", "--catalog", str(catalog.root), "--values", "species", "--json"],
     )
 
+    assert stored_human_result.exit_code == 0
+    assert "stored record fields" in strip_ansi(stored_human_result.stdout)
     assert stored_result.exit_code == 0
     stored_payload = json.loads(strip_ansi(stored_result.stdout))
     assert "user_metadata.species" in stored_payload
@@ -548,7 +579,7 @@ def test_fields_human_output_handles_missing_field_descriptions(tmp_path: Path) 
     result = runner.invoke(app, ["fields", "--catalog", str(catalog.root)])
 
     assert result.exit_code == 0
-    assert "No metadata fields are defined in this catalog." in strip_ansi(result.stdout)
+    assert "No schema-declared metadata fields are defined in this catalog." in strip_ansi(result.stdout)
 
 
 def test_spec_cli_adds_schema_sets_default_and_updates_simple_fields(tmp_path: Path) -> None:
@@ -588,6 +619,34 @@ def test_spec_cli_adds_schema_sets_default_and_updates_simple_fields(tmp_path: P
     assert reopened.spec.default_record_schema == "paper"
     assert reopened.spec.catalog_name == "library"
     assert reopened.spec.field_resolution_order == ["user_metadata", "top_level"]
+
+
+def test_spec_cli_show_schema_json_includes_display_fields(tmp_path: Path) -> None:
+    """spec show-schema --json emits the full serialisable schema."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            record_schemas={
+                "flux": RecordSchema(
+                    display_fields=["id", "species", "locator.uri"],
+                    metadata_fields=[
+                        MetadataFieldDescription(name="species", description="Gas species."),
+                    ],
+                ),
+            },
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["spec", "show-schema", "flux", "--catalog", str(catalog.root), "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.stdout))
+    assert payload["display_fields"] == ["id", "species", "locator.uri"]
+    assert payload["metadata_fields"][0]["name"] == "species"
 
 
 def test_spec_cli_add_schema_accepts_file_path_with_outer_whitespace(tmp_path: Path) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -380,3 +380,25 @@ def test_record_schema_fallbacks_preserve_empty_templates() -> None:
 
     assert resolved.directory_template == ""
     assert resolved.filename_template == ""
+
+
+def test_record_schema_display_fields_round_trip() -> None:
+    """Record schemas preserve compact display field defaults."""
+    schema = RecordSchema(display_fields=["id", "species", "path"])
+
+    payload = schema.to_dict()
+    reloaded = RecordSchema.from_dict(payload)
+
+    assert payload["display_fields"] == ["id", "species", "path"]
+    assert reloaded.display_fields == ["id", "species", "path"]
+
+
+def test_record_schema_display_fields_fall_back_from_default_schema() -> None:
+    """Named schemas inherit default display fields when they do not define their own."""
+    spec = CatalogSpec(
+        catalog_name="files",
+        default_schema=RecordSchema(display_fields=["id", "title", "path"]),
+        record_schemas={"flux": RecordSchema(description="Flux records.")},
+    )
+
+    assert spec.get_schema("flux").display_fields == ["id", "title", "path"]

--- a/tests/test_record_set.py
+++ b/tests/test_record_set.py
@@ -27,10 +27,11 @@ def _create_catalog(tmp_path: Path) -> Catalog:
     return catalog
 
 
-def test_search_can_return_record_set_with_cli_style_field_selection(tmp_path: Path) -> None:
+def test_search_returns_record_set_with_cli_style_field_selection_by_default(tmp_path: Path) -> None:
+    """Search returns a record set with field-selection helpers by default."""
     catalog = _create_catalog(tmp_path)
 
-    results = catalog.search(where={"species": "CO2"}, as_record_set=True)
+    results = catalog.search(where={"species": "CO2"})
 
     assert isinstance(results, CatalogRecordSet)
     assert len(results) == 1
@@ -83,6 +84,15 @@ def test_record_set_to_dataframe_uses_selected_rows_when_pandas_is_available(
     frame = results.to_dataframe(fields=["id", "species"])
 
     assert frame == [{"id": results[0].id, "species": "CO2"}]
+
+
+def test_record_set_ids_returns_stable_string_ids(tmp_path: Path) -> None:
+    """Record-set IDs are convenient for show/path follow-up operations."""
+    catalog = _create_catalog(tmp_path)
+    results = catalog.search(as_record_set=True)
+
+    assert results.ids == [results[0].id]
+    assert all(isinstance(record_id, str) for record_id in results.ids)
 
 
 def test_record_set_to_dataframe_without_fields_keeps_full_records(

--- a/tests/test_record_set.py
+++ b/tests/test_record_set.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from rich.table import Table
 
 import ogcat.record_set as record_set_module
-from ogcat import ArtifactLocator, Catalog, CatalogRecordSet, CatalogSpec
+from ogcat import ArtifactLocator, Catalog, CatalogRecordSet, CatalogSpec, RecordSchema
 
 
 def _create_catalog(tmp_path: Path) -> Catalog:
@@ -83,6 +83,148 @@ def test_record_set_to_dataframe_uses_selected_rows_when_pandas_is_available(
     frame = results.to_dataframe(fields=["id", "species"])
 
     assert frame == [{"id": results[0].id, "species": "CO2"}]
+
+
+def test_record_set_to_dataframe_without_fields_keeps_full_records(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """to_dataframe() without fields keeps the existing full-record behavior."""
+    catalog = _create_catalog(tmp_path)
+    results = catalog.search(as_record_set=True)
+
+    class FakeDataFrame:
+        @classmethod
+        def from_records(cls, records: list[dict[str, object]]) -> list[dict[str, object]]:
+            return records
+
+    monkeypatch.setattr(
+        record_set_module,
+        "import_module",
+        lambda name: SimpleNamespace(DataFrame=FakeDataFrame),
+    )
+
+    frame = results.to_dataframe()
+
+    assert "user_metadata" in frame[0]
+    assert "locator" in frame[0]
+
+
+def test_record_set_uses_schema_display_defaults_for_homogeneous_results(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Homogeneous record sets use their schema display fields by default."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="fluxes",
+            record_schemas={
+                "flux": RecordSchema(display_fields=["id", "product", "species", "domain", "path"])
+            },
+        ),
+    )
+    record = catalog.add_artifact(
+        record_type="flux",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/flux.zarr"),
+        metadata={"product": "GridFED", "species": "co2", "domain": "EUROPE"},
+    )
+    results = catalog.search(where={"record_type": "flux"}, as_record_set=True)
+
+    class FakeDataFrame:
+        @classmethod
+        def from_records(cls, records: list[dict[str, object]]) -> list[dict[str, object]]:
+            return records
+
+    monkeypatch.setattr(
+        record_set_module,
+        "import_module",
+        lambda name: SimpleNamespace(DataFrame=FakeDataFrame),
+    )
+
+    frame = results.to_dataframe(fields="default")
+    preview = results.preview()
+
+    assert list(frame[0]) == ["id", "product", "species", "domain", "path"]
+    assert frame == [
+        {
+            "id": record.id,
+            "product": "GridFED",
+            "species": "co2",
+            "domain": "EUROPE",
+            "path": None,
+        }
+    ]
+    assert [column.header for column in preview.columns] == [
+        "id",
+        "product",
+        "species",
+        "domain",
+        "path",
+    ]
+
+
+def test_record_set_uses_deterministic_defaults_for_heterogeneous_results(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Heterogeneous defaults merge schema display fields and preserve missing values."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="mixed",
+            record_schemas={
+                "surface": RecordSchema(display_fields=["id", "site", "species", "path"]),
+                "flux": RecordSchema(display_fields=["id", "product", "species", "domain", "path"]),
+            },
+        ),
+    )
+    surface = catalog.add_artifact(
+        record_type="surface",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/surface.zarr"),
+        metadata={"site": "MHD", "species": "co2"},
+    )
+    flux = catalog.add_artifact(
+        record_type="flux",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/flux.zarr"),
+        metadata={"product": "GridFED", "species": "co2", "domain": "EUROPE"},
+    )
+    results = catalog.search(as_record_set=True)
+
+    class FakeDataFrame:
+        @classmethod
+        def from_records(cls, records: list[dict[str, object]]) -> list[dict[str, object]]:
+            return records
+
+    monkeypatch.setattr(
+        record_set_module,
+        "import_module",
+        lambda name: SimpleNamespace(DataFrame=FakeDataFrame),
+    )
+
+    rows = results.rows()
+    frame = results.to_display_dataframe()
+
+    assert list(rows[0]) == ["id", "record_type", "path", "product", "species", "domain", "site"]
+    assert rows == frame
+    assert rows[0] == {
+        "id": surface.id,
+        "record_type": "surface",
+        "path": None,
+        "product": None,
+        "species": "co2",
+        "domain": None,
+        "site": "MHD",
+    }
+    assert rows[1] == {
+        "id": flux.id,
+        "record_type": "flux",
+        "path": None,
+        "product": "GridFED",
+        "species": "co2",
+        "domain": "EUROPE",
+        "site": None,
+    }
 
 
 def test_record_set_rich_preview_returns_table(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -244,8 +244,8 @@ def test_get_and_path_return_none_for_missing_record(tmp_path: Path) -> None:
     assert catalog.path("missing") is None
 
 
-def test_find_and_find_ids_use_search_filters(tmp_path: Path) -> None:
-    """Selection helpers return records and stable string ids in search order."""
+def test_record_set_ids_use_search_filters(tmp_path: Path) -> None:
+    """Record-set IDs are stable strings in search order."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     co2 = catalog.add_artifact(
         record_type="external_reference",
@@ -258,18 +258,29 @@ def test_find_and_find_ids_use_search_filters(tmp_path: Path) -> None:
         metadata={"species": "ch4", "provenance": "derived", "keywords": ["baseline"]},
     )
 
-    records = catalog.find(
-        where={"provenance": "derived", "species": "co2"},
-        contains={"keywords": "paris_verification_games"},
-    )
-    ids = catalog.find_ids(
+    results = catalog.search(
         where={"provenance": "derived", "species": "co2"},
         contains={"keywords": "paris_verification_games"},
     )
 
-    assert records == [co2]
-    assert ids == [co2.id]
-    assert all(isinstance(record_id, str) for record_id in ids)
+    assert list(results) == [co2]
+    assert results.ids == [co2.id]
+    assert all(isinstance(record_id, str) for record_id in results.ids)
+
+
+def test_search_can_return_plain_list_when_requested(tmp_path: Path) -> None:
+    """Callers can opt out of the default record-set wrapper."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/co2.zarr"),
+        metadata={"species": "co2"},
+    )
+
+    results = catalog.search(where={"species": "co2"}, as_record_set=False)
+
+    assert results == [record]
+    assert isinstance(results, list)
 
 
 def test_get_one_returns_record_for_exactly_one_match(tmp_path: Path) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -244,6 +244,77 @@ def test_get_and_path_return_none_for_missing_record(tmp_path: Path) -> None:
     assert catalog.path("missing") is None
 
 
+def test_find_and_find_ids_use_search_filters(tmp_path: Path) -> None:
+    """Selection helpers return records and stable string ids in search order."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    co2 = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/co2.zarr"),
+        metadata={"species": "co2", "provenance": "derived", "keywords": ["paris_verification_games"]},
+    )
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/ch4.zarr"),
+        metadata={"species": "ch4", "provenance": "derived", "keywords": ["baseline"]},
+    )
+
+    records = catalog.find(
+        where={"provenance": "derived", "species": "co2"},
+        contains={"keywords": "paris_verification_games"},
+    )
+    ids = catalog.find_ids(
+        where={"provenance": "derived", "species": "co2"},
+        contains={"keywords": "paris_verification_games"},
+    )
+
+    assert records == [co2]
+    assert ids == [co2.id]
+    assert all(isinstance(record_id, str) for record_id in ids)
+
+
+def test_get_one_returns_record_for_exactly_one_match(tmp_path: Path) -> None:
+    """get_one returns the matching record for notebook-style lookup workflows."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/gridfed-total-co2.zarr"),
+        metadata={"product": "GridFED", "sector": "TOTAL", "species": "co2"},
+    )
+
+    selected = catalog.get_one(
+        where={
+            "product": "GridFED",
+            "sector": "TOTAL",
+            "species": "co2",
+        }
+    )
+
+    assert selected == record
+    assert selected.locator.value == "s3://bucket/gridfed-total-co2.zarr"
+
+
+def test_get_one_raises_clear_errors_for_zero_and_multiple_matches(tmp_path: Path) -> None:
+    """get_one reports empty and ambiguous selections clearly."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    first = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/first.zarr"),
+        metadata={"species": "co2"},
+    )
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/second.zarr"),
+        metadata={"species": "co2"},
+    )
+
+    with pytest.raises(ValueError, match="no records"):
+        catalog.get_one(where={"site": "NO_SUCH_SITE"})
+    with pytest.raises(ValueError, match="multiple records"):
+        catalog.get_one(where={"species": "co2"})
+
+    assert catalog.get_one(where={"species": "co2"}, allow_many=True) == first
+
+
 def test_search_rejects_set_where_filters(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
 


### PR DESCRIPTION
## Summary
- Make `Catalog.search()` return `CatalogRecordSet` by default, while preserving `as_record_set=False` for callers that explicitly need a plain list.
- Add `Catalog.get_one(...)` for exact record selection with clear zero/multiple-match errors.
- Add `CatalogRecordSet.ids` for stable ID selection from search results, alongside existing `select(...)`/`rows(...)` helpers.
- Extend `RecordSchema` with `display_fields` and use schema defaults for compact record-set previews and display rows/dataframes.
- Keep `CatalogRecordSet.to_dataframe()` backwards-compatible when called without fields; `fields="default"` and `to_display_dataframe()` remain display-oriented and require pandas.
- Improve CLI field discovery and schema inspection so schema-declared fields are distinct from stored record fields.
- Update docs and examples for search-to-select workflows, `fields --stored`, `fields --values`, and default display fields.

## Testing
- Added coverage for `get_one` zero/multiple/exact-match behavior.
- Added tests for default `search()` returning a record set and for opting into a plain list with `as_record_set=False`.
- Added tests for `CatalogRecordSet.ids`, schema display field round-tripping, homogeneous and heterogeneous record-set defaults, and CLI schema/field output.
- Added notebook-style dataframe tests for `record = catalog.get_one(...)` and `results.to_dataframe(fields="default")`.
- Local validation passed: `uv run ruff check`, `uv run ruff format --check`, `uv run pyright`, and `uv run pytest`.