### PR TITLE
Add public catalog metadata update APIs

### DIFF
--- a/docs/tutorials/basic-catalog.md
+++ b/docs/tutorials/basic-catalog.md
@@ -2,7 +2,7 @@
 
 This tutorial builds a small catalog with two named schemas, adds both managed
 files and external references, searches across records, and updates metadata
-through the repository API.
+through the catalog API.
 
 ## Setup
 
@@ -118,24 +118,50 @@ When a `RecordSchema` defines `display_fields`, record-set previews and
 available, `to_dataframe(fields="default")` uses the same fields.
 `to_dataframe()` with no fields still returns full record dictionaries.
 
-## Modify metadata with the repository
+## Repair metadata through the catalog API
 
-`Catalog.repository` is the low-level record store. Use it when you need to
-update an existing record in place.
+Use `Catalog.update_metadata()` when you need to repair or annotate user
+metadata after ingest. The update is normalized, validated against the record's
+schema, and written through the catalog transaction helpers.
 
 ```python
-    saved = catalog.get(measurement.id)
-    assert saved is not None
-    saved.user_metadata["quality_flag"] = "reviewed"
-    catalog.repository.update(saved)
+    updated_measurement = catalog.update_metadata(
+        measurement.id,
+        {"quality_flag": "reviewed"},
+        mode="shallow_merge",
+    )
 
     reviewed = catalog.search(where={"quality_flag": "reviewed"})
     assert reviewed[0].id == measurement.id
+    assert updated_measurement.user_metadata["quality_flag"] == "reviewed"
 ```
 
-Repository updates replace the stored record with the modified
-`CatalogRecord`. Keep record IDs and reserved fields intact unless you are
-intentionally changing them.
+Use `mode="replace"` when the new metadata should replace the whole
+`user_metadata` dictionary. Use `mode="shallow_merge"` when you want a
+top-level dictionary update that keeps existing top-level keys. Shallow merge
+does not recursively merge nested dictionaries; nested dictionaries supplied in
+the update replace existing nested dictionary values. Recursive or deep merge
+support is intentionally deferred.
+
+```python
+    corrected = catalog.update_metadata(
+        measurement.id,
+        {
+            "title": "Corrected MHD methane observations",
+            "site": "MHD",
+            "species": "CH4",
+            "year": 2024,
+            "quality_flag": "reviewed",
+        },
+        mode="replace",
+    )
+    assert corrected.user_metadata["title"] == "Corrected MHD methane observations"
+```
+
+Derived metadata can be repaired separately with
+`Catalog.update_derived_metadata()`, using the same replace and shallow-merge
+mode names. Prefer these public methods over mutating a `CatalogRecord` and
+calling `catalog.repository.update(...)` directly.
 
 ## CLI equivalents
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -45,6 +45,7 @@ DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
+MetadataUpdateMode = Literal["replace", "shallow_merge"]
 
 
 @dataclass(slots=True)
@@ -814,6 +815,81 @@ class Catalog:
             return None
         return record.path()
 
+    def update_metadata(
+        self,
+        record_id: object,
+        metadata: Mapping[Any, Any],
+        mode: MetadataUpdateMode = "replace",
+        *,
+        transaction: UnitOfWork | None = None,
+    ) -> CatalogRecord:
+        """Update a record's user metadata through validation and storage.
+
+        Args:
+            record_id: Existing record id.
+            metadata: Replacement metadata or top-level metadata updates.
+            mode: ``"replace"`` replaces the whole user metadata dictionary.
+                ``"shallow_merge"`` applies a top-level dictionary update;
+                nested dictionaries are replaced as values, not recursively
+                merged.
+            transaction: Optional caller-owned transaction. When supplied, the
+                previous record version is restored if the transaction rolls
+                back.
+
+        Returns:
+            Updated catalog record.
+
+        Raises:
+            TypeError: If metadata is not a dictionary.
+            ValueError: If the update mode is unsupported, or schema metadata
+                validation fails.
+            KeyError: If the record id does not exist.
+        """
+        return self._update_metadata_namespace(
+            record_id=record_id,
+            metadata=metadata,
+            mode=mode,
+            namespace="user_metadata",
+            transaction=transaction,
+        )
+
+    def update_derived_metadata(
+        self,
+        record_id: object,
+        derived_metadata: Mapping[Any, Any],
+        mode: MetadataUpdateMode = "replace",
+        *,
+        transaction: UnitOfWork | None = None,
+    ) -> CatalogRecord:
+        """Update a record's derived metadata through normalization and storage.
+
+        Args:
+            record_id: Existing record id.
+            derived_metadata: Replacement derived metadata or top-level updates.
+            mode: ``"replace"`` replaces the whole derived metadata dictionary.
+                ``"shallow_merge"`` applies a top-level dictionary update;
+                nested dictionaries are replaced as values, not recursively
+                merged.
+            transaction: Optional caller-owned transaction. When supplied, the
+                previous record version is restored if the transaction rolls
+                back.
+
+        Returns:
+            Updated catalog record.
+
+        Raises:
+            TypeError: If derived metadata is not a dictionary.
+            ValueError: If the update mode is unsupported.
+            KeyError: If the record id does not exist.
+        """
+        return self._update_metadata_namespace(
+            record_id=record_id,
+            metadata=derived_metadata,
+            mode=mode,
+            namespace="derived_metadata",
+            transaction=transaction,
+        )
+
     def add_record_schema(
         self,
         name: str,
@@ -1217,6 +1293,77 @@ class Catalog:
             record_type=record_type,
         ).raise_for_errors()
 
+    def _update_metadata_namespace(
+        self,
+        *,
+        record_id: object,
+        metadata: Mapping[Any, Any],
+        mode: MetadataUpdateMode,
+        namespace: Literal["user_metadata", "derived_metadata"],
+        transaction: UnitOfWork | None,
+    ) -> CatalogRecord:
+        """Update one metadata namespace using explicit replace or shallow merge."""
+        update_mode = _coerce_metadata_update_mode(mode)
+        record = self._require_record(record_id)
+        if namespace == "user_metadata":
+            schema_name = self._schema_name(record.record_type)
+            normalized_input = _coerce_metadata_input(metadata, schema_name=schema_name)
+            updated_metadata = _merge_metadata(
+                current=record.user_metadata,
+                updates=normalized_input,
+                mode=update_mode,
+            )
+            updated_metadata = _normalize_metadata_for_schema(
+                updated_metadata,
+                schema_name=schema_name,
+            )
+            schema = self._select_schema(record.record_type, require_known=False)
+            self._validate_metadata(
+                schema=schema,
+                metadata=updated_metadata,
+                record_type=record.record_type,
+            )
+            updated_record = replace(record, user_metadata=updated_metadata)
+        else:
+            normalized_input = normalize_metadata(metadata, field_name="derived_metadata")
+            updated_metadata = _merge_metadata(
+                current=record.derived_metadata,
+                updates=normalized_input,
+                mode=update_mode,
+            )
+            updated_record = replace(
+                record,
+                derived_metadata=normalize_metadata(
+                    updated_metadata,
+                    field_name="derived_metadata",
+                ),
+            )
+        return self._stage_or_commit_record_update(updated_record, transaction=transaction)
+
+    def _require_record(self, record_id: object) -> CatalogRecord:
+        """Return an existing record or raise a clear missing-record error."""
+        resolved_record_id = _coerce_record_id(record_id)
+        record = self.repository.get(resolved_record_id)
+        if record is None:
+            raise KeyError(f"Record not found: {resolved_record_id}")
+        return record
+
+    def _stage_or_commit_record_update(
+        self,
+        record: CatalogRecord,
+        *,
+        transaction: UnitOfWork | None,
+    ) -> CatalogRecord:
+        """Apply a record replacement through a caller-owned or internal transaction."""
+        if transaction is not None:
+            if transaction.repository is not self.repository:
+                raise ValueError("Transaction is bound to a different catalog repository.")
+            return transaction.update_staged_record(record)
+        with self.transaction() as unit_of_work:
+            updated = unit_of_work.update_staged_record(record)
+            unit_of_work.commit()
+            return updated
+
     def _metadata_validation_report(
         self,
         *,
@@ -1299,6 +1446,25 @@ def _coerce_record_id(record_id: object) -> str:
     if record_id is None:
         raise TypeError("record_id must not be None")
     return str(record_id)
+
+
+def _coerce_metadata_update_mode(mode: object) -> MetadataUpdateMode:
+    """Return a supported metadata update mode."""
+    if mode in {"replace", "shallow_merge"}:
+        return cast(MetadataUpdateMode, mode)
+    raise ValueError("metadata update mode must be 'replace' or 'shallow_merge'.")
+
+
+def _merge_metadata(
+    *,
+    current: MetadataDict,
+    updates: MetadataDict,
+    mode: MetadataUpdateMode,
+) -> MetadataDict:
+    """Return metadata after an explicit replace or top-level-only merge."""
+    if mode == "replace":
+        return dict(updates)
+    return {**current, **updates}
 
 
 def _reference_locator_and_path(

--- a/src/ogcat/transactions.py
+++ b/src/ogcat/transactions.py
@@ -146,6 +146,36 @@ class UnitOfWork:
         """Alias for ``insert_staged_record``."""
         return self.insert_staged_record(record)
 
+    def update_staged_record(self, record: CatalogRecord) -> CatalogRecord:
+        """Update a staged record and restore the previous version on rollback.
+
+        Args:
+            record: Replacement record to persist. It must include an existing
+                repository id.
+
+        Returns:
+            The replacement record.
+
+        Raises:
+            RuntimeError: If the transaction has already committed.
+            ValueError: If the replacement record has no id.
+            KeyError: If no stored record exists for the supplied id.
+        """
+        if self.state is OperationState.COMMITTED:
+            raise RuntimeError("Cannot update record after commit.")
+        if record.id is None:
+            raise ValueError("Cannot update a record without an id.")
+        previous = self.repository.get(record.id)
+        if previous is None:
+            raise KeyError(f"Record not found: {record.id}")
+        self.register_rollback(
+            lambda: self.repository.update(previous),
+            description=f"restore catalog record {record.id}",
+        )
+        self.repository.update(record)
+        self.state = OperationState.STAGED
+        return record
+
     def commit(self) -> None:
         """Commit staged work and discard rollback actions."""
         self._rollback_actions.clear()

--- a/tests/test_metadata_updates.py
+++ b/tests/test_metadata_updates.py
@@ -1,0 +1,200 @@
+"""Catalog metadata update API tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import ArtifactLocator, Catalog, CatalogRecord, CatalogSpec, MetadataFieldDescription, RecordSchema
+
+
+def _record_id(record: CatalogRecord) -> str:
+    """Return a persisted record id for test setup."""
+    assert record.id is not None
+    return record.id
+
+
+def _catalog(tmp_path: Path) -> Catalog:
+    """Create a small catalog for metadata update tests."""
+    return Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="updates"))
+
+
+def _reference_record(catalog: Catalog, *, metadata: dict[str, object] | None = None) -> CatalogRecord:
+    """Add a reference record with optional user metadata."""
+    return catalog.add_reference(
+        uri="https://example.org/data.nc",
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def test_update_metadata_replace_replaces_user_metadata(tmp_path: Path) -> None:
+    """replace mode swaps the whole user metadata dictionary."""
+    catalog = _catalog(tmp_path)
+    record = _reference_record(catalog, metadata={"title": "Old title", "species": "CO2"})
+
+    updated = catalog.update_metadata(
+        _record_id(record),
+        {"title": "New title", "quality_flag": "reviewed"},
+        mode="replace",
+    )
+
+    assert updated is not record
+    assert updated.user_metadata == {"title": "New title", "quality_flag": "reviewed"}
+    assert catalog.get(_record_id(record)) == updated
+
+
+def test_update_metadata_shallow_merge_updates_only_top_level_keys(tmp_path: Path) -> None:
+    """shallow_merge keeps existing top-level keys and replaces nested values."""
+    catalog = _catalog(tmp_path)
+    record = _reference_record(
+        catalog,
+        metadata={
+            "title": "Original title",
+            "review": {"status": "pending", "notes": ["needs QA"]},
+            "site": "MHD",
+        },
+    )
+
+    updated = catalog.update_metadata(
+        _record_id(record),
+        {"quality_flag": "reviewed", "review": {"status": "accepted"}},
+        mode="shallow_merge",
+    )
+
+    assert updated.user_metadata == {
+        "title": "Original title",
+        "review": {"status": "accepted"},
+        "site": "MHD",
+        "quality_flag": "reviewed",
+    }
+
+
+def test_update_derived_metadata_replace_and_shallow_merge(tmp_path: Path) -> None:
+    """Derived metadata supports the same replace and shallow merge modes."""
+    catalog = _catalog(tmp_path)
+    record = catalog.add_reference(
+        uri="https://example.org/data.nc",
+        derived_metadata={
+            "checksum": "old",
+            "netcdf": {"dims": {"time": 12}},
+        },
+    )
+
+    replaced = catalog.update_derived_metadata(
+        _record_id(record),
+        {"shape": (12, 4)},
+        mode="replace",
+    )
+    merged = catalog.update_derived_metadata(
+        _record_id(record),
+        {"netcdf": {"attrs": {"title": "demo"}}, "path": Path("derived.nc")},
+        mode="shallow_merge",
+    )
+
+    assert replaced.derived_metadata == {"shape": [12, 4]}
+    assert merged.derived_metadata == {
+        "shape": [12, 4],
+        "netcdf": {"attrs": {"title": "demo"}},
+        "path": "derived.nc",
+    }
+
+
+def test_update_metadata_normalizes_path_tuple_and_nested_values(tmp_path: Path) -> None:
+    """Metadata update normalizes Python values with the add-operation rules."""
+    catalog = _catalog(tmp_path)
+    record = _reference_record(catalog, metadata={"title": "Original title"})
+
+    updated = catalog.update_metadata(
+        _record_id(record),
+        {
+            "source_path": Path("raw") / "data.nc",
+            "tags": ("co2", Path("sites") / "mhd"),
+            1: {"parts": ("a", "b")},
+        },
+        mode="replace",
+    )
+
+    assert updated.user_metadata == {
+        "source_path": "raw/data.nc",
+        "tags": ["co2", "sites/mhd"],
+        "1": {"parts": ["a", "b"]},
+    }
+
+
+def test_update_metadata_replace_preserves_required_field_validation(tmp_path: Path) -> None:
+    """Invalid replacement metadata is rejected and the stored record is unchanged."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="validated",
+            record_schemas={
+                "measurement": RecordSchema(
+                    metadata_fields=[
+                        MetadataFieldDescription(
+                            name="title",
+                            description="Human-readable title.",
+                            required=True,
+                        ),
+                        MetadataFieldDescription(
+                            name="site",
+                            description="Site code.",
+                            required=True,
+                        ),
+                    ],
+                )
+            },
+        ),
+    )
+    record = catalog.add_artifact(
+        record_type="measurement",
+        locator=ArtifactLocator(kind="uri", value="https://example.org/data.nc"),
+        metadata={"title": "MHD data", "site": "MHD"},
+    )
+
+    with pytest.raises(ValueError, match="Missing required metadata for schema measurement: site"):
+        catalog.update_metadata(
+            _record_id(record),
+            {"title": "Retitled"},
+            mode="replace",
+        )
+
+    assert catalog.get(_record_id(record)) == record
+
+
+def test_update_metadata_missing_record_id_has_clear_error(tmp_path: Path) -> None:
+    """Missing update targets raise a clear record-not-found error."""
+    catalog = _catalog(tmp_path)
+
+    with pytest.raises(KeyError, match="Record not found: missing"):
+        catalog.update_metadata("missing", {"title": "No record"})
+
+
+def test_update_metadata_rolls_back_with_caller_owned_transaction(tmp_path: Path) -> None:
+    """Caller-owned transactions restore the previous record on rollback."""
+    catalog = _catalog(tmp_path)
+    record = _reference_record(catalog, metadata={"title": "Original title"})
+
+    with pytest.raises(RuntimeError, match="later operation failed"), catalog.transaction() as transaction:
+        updated = catalog.update_metadata(
+            _record_id(record),
+            {"title": "Updated title"},
+            transaction=transaction,
+        )
+        assert catalog.get(_record_id(record)) == updated
+        raise RuntimeError("later operation failed")
+
+    assert catalog.get(_record_id(record)) == record
+
+
+def test_update_metadata_rejects_unknown_mode(tmp_path: Path) -> None:
+    """Only replace and shallow_merge update modes are accepted."""
+    catalog = _catalog(tmp_path)
+    record = _reference_record(catalog, metadata={"title": "Original title"})
+
+    with pytest.raises(ValueError, match="metadata update mode must be 'replace' or 'shallow_merge'"):
+        catalog.update_metadata(
+            _record_id(record),
+            {"title": "Updated title"},
+            mode="deep_merge",  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary
- Added `Catalog.update_metadata()` and `Catalog.update_derived_metadata()` with explicit `replace` and `shallow_merge` modes.
- Wired metadata repairs through transaction-backed record replacement so callers no longer need to mutate records via `catalog.repository.update()`.
- Preserved normalization and schema validation on user metadata updates, with clear errors for missing record IDs.
- Updated the basic catalog tutorial to show the new repair workflow and note that deep merge is intentionally deferred.
- Added focused tests for replace/merge behavior, nested-value handling, validation failures, rollback, and invalid modes.

Closes #45 

## Testing
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`
- `uv run pytest`