### PR TITLE
[codex] Add artifact classification metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,17 @@ Unqualified field names are resolved in this order:
 
 If you need to bypass flattened lookup, use an explicit dotted path such as `user_metadata.species` or `derived_metadata.netcdf.dims.time`. The shorter `user.species` and `derived.netcdf.dims.time` aliases are also accepted.
 
+Newly added records also store cheap artifact classification under
+`derived_metadata.classification`. It is inferred from locator/path shape,
+suffixes, and safe local archive member names, not from expensive data reads.
+Selected classification fields can be searched unqualified:
+
+```python
+catalog.search(where={"format": "zip"})
+catalog.search(where={"artifact_kind": "zarr_store"})
+catalog.search(where={"derived_metadata.classification.inner_format": "netcdf"})
+```
+
 Current search is intentionally small. It does not support numeric range queries or richer expressions such as `>`, `<`, `>=`, `<=`, or boolean query composition.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -258,10 +258,14 @@ If you need to bypass flattened lookup, use an explicit dotted path such as `use
 Newly added records also store cheap artifact classification under
 `derived_metadata.classification`. It is inferred from locator/path shape,
 suffixes, and safe local archive member names, not from expensive data reads.
-Selected classification fields can be searched unqualified:
+The normalized `format` value is intentionally not the same thing as the file
+suffix. For example, `.csv`, `.json`, `.md`, `.tsv`, and `.txt` are all
+classified as `format="text"`; use `suffixes` when you need the literal suffix
+list. Selected classification fields can be searched unqualified:
 
 ```python
 catalog.search(where={"format": "zip"})
+catalog.search(where={"format": "text"})
 catalog.search(where={"artifact_kind": "zarr_store"})
 catalog.search(where={"derived_metadata.classification.inner_format": "netcdf"})
 ```

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -31,7 +31,25 @@ fixed set of reserved fields plus three metadata namespaces.
     netCDF files this includes dimension names and sizes when ``xarray`` is
     installed. Derived metadata is normalized with the same JSON-compatible
     rules before storage. Do not rely on derived metadata being present for
-    every file type.
+    every file type. New records include a cheap
+    ``derived_metadata.classification`` namespace with normalized artifact
+    fields such as ``artifact_kind``, ``format``, ``archive_format``, and
+    ``inner_format``. This classification is based on locators, path suffixes,
+    local directory shape, and safe archive member names; it is separate from
+    content metadata extraction.
+
+    Classification uses this initial vocabulary:
+
+    | Field | Values |
+    |-------|--------|
+    | ``artifact_kind`` | ``file``, ``directory``, ``zarr_store``, ``archive``, ``remote_resource``, ``opaque`` |
+    | ``format`` | ``netcdf``, ``zarr``, ``zip``, ``gzip``, ``tar``, ``text``, ``unknown`` |
+    | ``archive_format`` | ``zip``, ``gzip``, or ``tar`` when the artifact is an archive or compressed file |
+    | ``inner_format`` | The safely inferred inner format for simple suffix chains such as ``.nc.gz`` or local zip archives with one file |
+
+    Text-like suffixes such as ``.txt``, ``.csv``, ``.tsv``, and ``.json`` are
+    intentionally classified as the broad ``text`` format until ogcat needs a
+    more detailed text subtype vocabulary.
 
 ``naming_metadata``
 :   Internal metadata used to evaluate directory and filename templates.  You
@@ -49,6 +67,13 @@ looks in this order:
 Use an explicit dotted path to target a specific namespace:
 ``user_metadata.species``, ``derived_metadata.netcdf.dims.time``, or the
 short aliases ``user.species`` and ``derived.netcdf.dims.time``.
+
+Selected classification fields also have a flattened fallback after ordinary
+``derived_metadata`` lookup, so searches such as ``where={"format": "zip"}``
+and ``where={"artifact_kind": "zarr_store"}`` work for classified records.
+Use dotted paths such as
+``derived_metadata.classification.inner_format`` when you need to bypass normal
+namespace precedence.
 
 ## Python API
 

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -47,9 +47,12 @@ fixed set of reserved fields plus three metadata namespaces.
     | ``archive_format`` | ``zip``, ``gzip``, or ``tar`` when the artifact is an archive or compressed file |
     | ``inner_format`` | The safely inferred inner format for simple suffix chains such as ``.nc.gz`` or local zip archives with one file |
 
-    Text-like suffixes such as ``.txt``, ``.csv``, ``.tsv``, and ``.json`` are
+    ``format`` is a normalized class, not the literal suffix. Text-like
+    suffixes such as ``.csv``, ``.json``, ``.md``, ``.tsv``, and ``.txt`` are
     intentionally classified as the broad ``text`` format until ogcat needs a
-    more detailed text subtype vocabulary.
+    more detailed text subtype vocabulary. Use the classification ``suffixes``
+    field or the record's top-level ``suffixes`` field when you need to search
+    or display the literal suffix list.
 
 ``naming_metadata``
 :   Internal metadata used to evaluate directory and filename templates.  You

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,6 +1,7 @@
 """Public package interface for ogcat."""
 
 from ogcat.catalog import Catalog
+from ogcat.classification import classify_artifact
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.plugins import PluginRegistry
@@ -49,6 +50,7 @@ __all__ = [
     "CatalogRecord",
     "CatalogRecordSet",
     "CatalogSpec",
+    "classify_artifact",
     "CopyArtifactWriter",
     "FsspecStorageAdapter",
     "FunctionArtifactWriter",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
+from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import (
     ArtifactWriter,
@@ -1223,6 +1224,7 @@ class Catalog:
                     )
             else:
                 artifact_writer.write(hook_context, hook_context.source, canonical_locator)
+            _add_classification_metadata(hook_context, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
             self.hook_manager.extract_metadata(hook_context)
@@ -1504,6 +1506,24 @@ def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
         warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
         metadata["hook_warnings"] = warnings_metadata
     return normalize_metadata(metadata, field_name="derived_metadata")
+
+
+def _add_classification_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
+    """Add cheap artifact classification metadata without overwriting caller values."""
+    classification = classify_artifact(
+        locator,
+        original_path=context.original_path,
+        original_filename=context.original_filename,
+        suffixes=context.suffixes,
+    )
+    existing = context.derived_metadata.get(CLASSIFICATION_METADATA_KEY)
+    if isinstance(existing, Mapping):
+        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = {
+            **classification,
+            **existing,
+        }
+    elif existing is None:
+        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
 
 
 def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:

--- a/src/ogcat/classification.py
+++ b/src/ogcat/classification.py
@@ -1,0 +1,210 @@
+"""Cheap artifact classification helpers."""
+
+from __future__ import annotations
+
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+from typing import cast
+from urllib.parse import urlsplit
+
+from ogcat.models import ArtifactLocator, JsonValue, MetadataDict
+
+CLASSIFICATION_METADATA_KEY = "classification"
+CLASSIFICATION_SEARCH_FIELDS = frozenset(
+    {
+        "artifact_kind",
+        "format",
+        "archive_format",
+        "inner_format",
+    }
+)
+
+_ARCHIVE_SUFFIX_FORMATS = {
+    ".zip": "zip",
+    ".gz": "gzip",
+    ".gzip": "gzip",
+    ".tar": "tar",
+    ".tgz": "tar",
+    ".tbz": "tar",
+    ".tbz2": "tar",
+    ".txz": "tar",
+}
+_NETCDF_SUFFIXES = {".nc", ".nc3", ".nc4", ".cdf"}
+_TEXT_SUFFIXES = {".asc", ".ascii", ".csv", ".dat", ".json", ".md", ".text", ".tsv", ".txt"}
+_ZARR_SUFFIXES = {".zarr"}
+
+
+def classify_artifact(
+    locator: ArtifactLocator,
+    *,
+    original_path: str | Path | None = None,
+    original_filename: str | None = None,
+    suffixes: Sequence[str] | None = None,
+) -> MetadataDict:
+    """Infer normalized, cheap artifact classification metadata.
+
+    The classifier uses locator text, path suffixes, and local path shape. It
+    does not open NetCDF, HDF5, Zarr, or other scientific data payloads. For
+    local zip files it may read the central directory to identify a single
+    member's suffix without extracting file content.
+
+    Args:
+        locator: Stored artifact locator.
+        original_path: Optional original source path or URI.
+        original_filename: Optional original source filename.
+        suffixes: Optional suffix list to preserve in the classification.
+
+    Returns:
+        JSON-compatible metadata for ``derived_metadata["classification"]``.
+    """
+    resolved_suffixes = _resolve_suffixes(
+        suffixes=suffixes,
+        locator=locator,
+        original_path=original_path,
+        original_filename=original_filename,
+    )
+    local_path = locator.as_path()
+    local_is_dir = _is_local_directory(local_path)
+    archive_format = _archive_format(resolved_suffixes)
+    format_name = _format_from_suffixes(resolved_suffixes)
+    artifact_kind = _artifact_kind(
+        locator=locator,
+        suffixes=resolved_suffixes,
+        local_is_dir=local_is_dir,
+        archive_format=archive_format,
+    )
+
+    metadata: MetadataDict = {
+        "artifact_kind": artifact_kind,
+        "format": format_name,
+        "suffixes": cast(JsonValue, list(resolved_suffixes)),
+    }
+    if archive_format is not None:
+        metadata["archive_format"] = archive_format
+        inner_format = _inner_format_from_suffix_chain(resolved_suffixes)
+        if inner_format is not None:
+            metadata["inner_format"] = inner_format
+    if archive_format == "zip" and local_path is not None:
+        inner_format = _zip_single_member_inner_format(local_path)
+        if inner_format is not None:
+            metadata["inner_format"] = inner_format
+
+    return metadata
+
+
+def _resolve_suffixes(
+    *,
+    suffixes: Sequence[str] | None,
+    locator: ArtifactLocator,
+    original_path: str | Path | None,
+    original_filename: str | None,
+) -> list[str]:
+    """Return suffixes from explicit metadata or cheap locator/path parsing."""
+    if suffixes:
+        return [str(suffix) for suffix in suffixes]
+
+    candidates: list[str | Path] = []
+    if original_filename:
+        candidates.append(original_filename)
+    if original_path is not None:
+        candidates.append(original_path)
+    if locator.value:
+        candidates.append(locator.value)
+
+    for candidate in candidates:
+        inferred = _suffixes_from_candidate(candidate, locator_kind=locator.kind)
+        if inferred:
+            return inferred
+    return []
+
+
+def _suffixes_from_candidate(candidate: str | Path, *, locator_kind: str) -> list[str]:
+    """Infer suffixes from one local or URI-like locator candidate."""
+    if isinstance(candidate, Path):
+        return list(candidate.suffixes)
+    value = str(candidate)
+    if locator_kind in {"uri", "urlpath"} or "://" in value:
+        parsed_path = urlsplit(value).path
+        if "::" in parsed_path:
+            parsed_path = parsed_path.rsplit("::", 1)[-1]
+        return list(PurePosixPath(parsed_path).suffixes)
+    return list(Path(value).suffixes)
+
+
+def _is_local_directory(path: Path | None) -> bool:
+    """Return whether a path-backed locator currently points at a directory."""
+    if path is None:
+        return False
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
+def _artifact_kind(
+    *,
+    locator: ArtifactLocator,
+    suffixes: Sequence[str],
+    local_is_dir: bool,
+    archive_format: str | None,
+) -> str:
+    """Return the normalized artifact kind."""
+    if archive_format is not None:
+        return "archive"
+    if _has_suffix(suffixes, _ZARR_SUFFIXES):
+        return "zarr_store"
+    if locator.kind == "path":
+        return "directory" if local_is_dir else "file"
+    if locator.kind in {"uri", "urlpath"}:
+        return "remote_resource"
+    return "opaque"
+
+
+def _archive_format(suffixes: Sequence[str]) -> str | None:
+    """Return the outer archive or compression format from suffixes."""
+    if not suffixes:
+        return None
+    return _ARCHIVE_SUFFIX_FORMATS.get(suffixes[-1].casefold())
+
+
+def _format_from_suffixes(suffixes: Sequence[str]) -> str:
+    """Return the normalized safe format name for suffixes."""
+    if not suffixes:
+        return "unknown"
+    archive_format = _archive_format(suffixes)
+    if archive_format is not None:
+        return archive_format
+    if _has_suffix(suffixes, _ZARR_SUFFIXES):
+        return "zarr"
+    if _has_suffix(suffixes, _NETCDF_SUFFIXES):
+        return "netcdf"
+    if _has_suffix(suffixes, _TEXT_SUFFIXES):
+        return "text"
+    return "unknown"
+
+
+def _inner_format_from_suffix_chain(suffixes: Sequence[str]) -> str | None:
+    """Return an inner format implied by a multi-part suffix chain."""
+    if len(suffixes) < 2:
+        return None
+    inner_format = _format_from_suffixes(suffixes[:-1])
+    return None if inner_format == "unknown" else inner_format
+
+
+def _zip_single_member_inner_format(path: Path) -> str | None:
+    """Return the single file member's format for a local zip archive."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = [member.filename for member in archive.infolist() if not member.is_dir()]
+    except (OSError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        return None
+    if len(names) != 1:
+        return None
+    inner_format = _format_from_suffixes(PurePosixPath(names[0]).suffixes)
+    return None if inner_format == "unknown" else inner_format
+
+
+def _has_suffix(suffixes: Sequence[str], expected: set[str]) -> bool:
+    """Return whether suffixes contain one of the expected suffixes."""
+    return any(suffix.casefold() in expected for suffix in suffixes)

--- a/src/ogcat/search.py
+++ b/src/ogcat/search.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 from fnmatch import fnmatchcase
 from typing import Any
 
+from ogcat.classification import CLASSIFICATION_METADATA_KEY, CLASSIFICATION_SEARCH_FIELDS
 from ogcat.models import CatalogRecord
 
 _RESERVED_FIELDS = {
@@ -338,8 +339,22 @@ def resolve_field(
             continue
         if field in namespace:
             return FieldLookup(found=True, value=namespace[field])
+        if namespace_name == "derived_metadata":
+            classification_lookup = _resolve_classification_field(namespace, field)
+            if classification_lookup.found:
+                return classification_lookup
 
     return FieldLookup(found=False)
+
+
+def _resolve_classification_field(derived_metadata: Mapping[str, Any], field: str) -> FieldLookup:
+    """Resolve selected flattened fields from derived classification metadata."""
+    if field not in CLASSIFICATION_SEARCH_FIELDS:
+        return FieldLookup(found=False)
+    classification = derived_metadata.get(CLASSIFICATION_METADATA_KEY)
+    if not isinstance(classification, Mapping) or field not in classification:
+        return FieldLookup(found=False)
+    return FieldLookup(found=True, value=classification[field])
 
 
 def _stringify(value: Any) -> str:

--- a/tests/test_artifact_classification.py
+++ b/tests/test_artifact_classification.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from ogcat import ArtifactLocator, Catalog, CatalogSpec
+from ogcat.models import CatalogRecord, MetadataDict
+
+
+def _classification(record: CatalogRecord) -> MetadataDict:
+    """Return the classification metadata for a test record."""
+    classification = record.derived_metadata["classification"]
+    assert isinstance(classification, dict)
+    return classification
+
+
+def test_add_file_classifies_netcdf_suffix(tmp_path: Path) -> None:
+    """A managed .nc file should get cheap NetCDF classification metadata."""
+    source = tmp_path / "source.nc"
+    source.write_text("not really netcdf", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source)
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "file"
+    assert classification["format"] == "netcdf"
+    assert classification["suffixes"] == [".nc"]
+    assert record.suffixes == [".nc"]
+
+
+def test_add_reference_classifies_zarr_directory(tmp_path: Path) -> None:
+    """A .zarr directory should be classified as a Zarr store."""
+    zarr_store = tmp_path / "output.zarr"
+    zarr_store.mkdir()
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(zarr_store, record_type="derived_artifact")
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "zarr_store"
+    assert classification["format"] == "zarr"
+    assert classification["suffixes"] == [".zarr"]
+
+
+def test_add_reference_classifies_zip_archive_with_single_netcdf_member(tmp_path: Path) -> None:
+    """A local zip with one .nc member should expose archive and inner formats."""
+    archive_path = tmp_path / "data.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("data.nc", "not really netcdf")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(archive_path)
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "archive"
+    assert classification["format"] == "zip"
+    assert classification["archive_format"] == "zip"
+    assert classification["inner_format"] == "netcdf"
+
+
+def test_add_reference_classifies_gzipped_netcdf_suffix_chain(tmp_path: Path) -> None:
+    """A .nc.gz path should expose gzip as the archive and NetCDF as the inner format."""
+    source = tmp_path / "data.nc.gz"
+    source.write_bytes(b"compressed-ish")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(source)
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "archive"
+    assert classification["format"] == "gzip"
+    assert classification["archive_format"] == "gzip"
+    assert classification["inner_format"] == "netcdf"
+    assert record.suffixes == [".nc", ".gz"]
+
+
+def test_add_artifact_classifies_path_locator(tmp_path: Path) -> None:
+    """The lower-level add_artifact API should attach classification metadata."""
+    source = tmp_path / "artifact.nc"
+    source.write_text("not really netcdf", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator.path(source),
+        suffixes=source.suffixes,
+    )
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "file"
+    assert classification["format"] == "netcdf"
+
+
+def test_remote_uri_classification_uses_locator_text_without_filesystem_access(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Remote URI classification should not stat a local filesystem path."""
+
+    def fail_is_dir(self: Path) -> bool:
+        raise AssertionError(f"unexpected filesystem access for {self}")
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    monkeypatch.setattr(Path, "is_dir", fail_is_dir)
+
+    record = catalog.add_reference(uri="https://example.org/data/example.nc?token=abc")
+
+    classification = _classification(record)
+    assert record.suffixes == []
+    assert classification["artifact_kind"] == "remote_resource"
+    assert classification["format"] == "netcdf"
+    assert classification["suffixes"] == [".nc"]
+
+
+def test_urlpath_classification_uses_locator_text_without_filesystem_access(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """URL-path classification should infer Zarr stores without local stat calls."""
+
+    def fail_is_dir(self: Path) -> bool:
+        raise AssertionError(f"unexpected filesystem access for {self}")
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    monkeypatch.setattr(Path, "is_dir", fail_is_dir)
+
+    record = catalog.add_reference(urlpath="s3://bucket/data/example.zarr")
+
+    classification = _classification(record)
+    assert record.suffixes == []
+    assert classification["artifact_kind"] == "zarr_store"
+    assert classification["format"] == "zarr"
+    assert classification["suffixes"] == [".zarr"]
+
+
+def test_unknown_suffix_classifies_unknown_format(tmp_path: Path) -> None:
+    """Unrecognized suffixes should get an unknown format instead of a guess."""
+    source = tmp_path / "artifact.custom"
+    source.write_text("opaque", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_reference(source)
+
+    classification = _classification(record)
+    assert classification["artifact_kind"] == "file"
+    assert classification["format"] == "unknown"
+    assert classification["suffixes"] == [".custom"]
+
+
+def test_search_supports_flattened_classification_fields(tmp_path: Path) -> None:
+    """Search should resolve common classification fields without dotted paths."""
+    netcdf_path = tmp_path / "data.nc"
+    netcdf_path.write_text("not really netcdf", encoding="utf-8")
+    zarr_store = tmp_path / "output.zarr"
+    zarr_store.mkdir()
+    archive_path = tmp_path / "data.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("data.nc", "not really netcdf")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    netcdf = catalog.add_reference(netcdf_path)
+    zarr = catalog.add_reference(zarr_store)
+    archive = catalog.add_reference(archive_path)
+
+    assert [record.id for record in catalog.search(where={"format": "netcdf"})] == [netcdf.id]
+    assert [record.id for record in catalog.search(where={"format": "zip"})] == [archive.id]
+    assert [record.id for record in catalog.search(where={"artifact_kind": "zarr_store"})] == [zarr.id]
+    assert [record.id for record in catalog.search(where={"archive_format": "zip"})] == [archive.id]
+    assert [record.id for record in catalog.search(where={"inner_format": "netcdf"})] == [archive.id]
+    assert [
+        record.id
+        for record in catalog.search(where={"derived_metadata.classification.archive_format": "zip"})
+    ] == [archive.id]

--- a/tests/test_catalog_fluxes_example.py
+++ b/tests/test_catalog_fluxes_example.py
@@ -195,7 +195,10 @@ def test_build_catalog_from_listing_creates_external_reference_records(
     assert records[0].record_type == "external_reference"
     assert records[0].storage_mode == "external"
     assert records[0].user_metadata["discovery_mode"] == "listing"
-    assert records[0].derived_metadata == {}
+    classification = records[0].derived_metadata["classification"]
+    assert isinstance(classification, dict)
+    assert classification["format"] == "netcdf"
+    assert classification["artifact_kind"] == "file"
 
 
 def test_build_catalog_from_mounted_scan_adds_filesystem_metadata(

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -72,7 +72,10 @@ def test_add_file_keeps_working_for_netcdf_suffix_without_xarray(
 
     record = catalog.add_file(source)
 
-    assert record.derived_metadata == {}
+    assert "netcdf" not in record.derived_metadata
+    classification = record.derived_metadata["classification"]
+    assert isinstance(classification, dict)
+    assert classification["format"] == "netcdf"
 
 
 def test_add_file_extracts_small_netcdf_metadata_when_xarray_is_available(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a cheap `ogcat.classification` helper that classifies artifacts from locators, suffixes, local directory shape, and safe zip member names.
- Store normalized classification metadata under `derived_metadata["classification"]` for add_file, add_reference, add_artifact, and batch add_artifacts paths.
- Add flattened search fallback for `format`, `artifact_kind`, `archive_format`, and `inner_format` while preserving dotted-path access.
- Document the classification vocabulary and add regression coverage for NetCDF, Zarr stores, zip/gzip archives, remote locators, unknown formats, and search examples.

Closes #62.

## Validation

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`
- `uv run pytest`