### PR TITLE
Add verification-games workflow recipes to the docs

### DIFF
--- a/docs/concepts/metadata-and-validation.md
+++ b/docs/concepts/metadata-and-validation.md
@@ -43,6 +43,20 @@ all_tags = catalog.search(contains={"tags": ["paris", "europe"]})
 site = catalog.search(contains={"site": {"code": "MHD"}})
 ```
 
+For list-valued fields, membership is exact. This matters for suffixes:
+
+```python
+# Does not match a stored suffix list such as [".zip"].
+catalog.search(contains={"suffixes": "zip"})
+
+# Does match, because ".zip" is the exact stored list member.
+catalog.search(contains={"suffixes": ".zip"})
+```
+
+For file extensions and formats, prefer normalized metadata such as
+`format="zip"` or `derived_metadata.classification.format="zip"` over fuzzy
+suffix matching.
+
 The equivalent CLI forms are:
 
 ```bash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ searching records.
    :caption: Tutorials
 
    tutorials/basic-catalog
+   tutorials/verification-games-recipes
    tutorials/intermediate
    tutorials/advanced-real-world
    tutorials/artifact-workflows

--- a/docs/tutorials/verification-games-recipes.md
+++ b/docs/tutorials/verification-games-recipes.md
@@ -2,8 +2,8 @@
 
 These recipes condense common ogcat patterns from the verification-games
 notebooks into small copy/paste examples. They use temporary directories and
-fake local data, so they do not depend on the verification-games repositories
-or shared ACRG data paths.
+tiny synthetic local data, so they do not depend on the verification-games
+repositories or shared ACRG data paths.
 
 The examples are written as notebook-style cells that can be run in order. The
 xarray cells are optional; they require xarray and a local NetCDF or Zarr
@@ -26,6 +26,12 @@ from ogcat import (
     CatalogSpec,
     MetadataFieldDescription,
     RecordSchema,
+)
+from ogcat.example_data import (
+    EXAMPLE_FLUX_FILENAME,
+    example_flux_cdl,
+    example_flux_collection_path,
+    write_example_flux_netcdf_or_placeholder,
 )
 from ogcat.writers import memory_source, source_writer
 
@@ -66,6 +72,7 @@ spec = CatalogSpec(
             metadata_fields=[
                 *common_fields,
                 metadata_field("inputs", "Input record ids or external input labels."),
+                metadata_field("modifications", "Short description of processing changes."),
             ],
         ),
         "verification_games_obs": RecordSchema(
@@ -76,6 +83,7 @@ spec = CatalogSpec(
             metadata_fields=[
                 *common_fields,
                 metadata_field("inputs", "Input record ids or external input labels."),
+                metadata_field("modifications", "Short description of processing changes."),
                 metadata_field("site", "Observation or footprint site code."),
             ],
         ),
@@ -92,6 +100,15 @@ scratch_dir.mkdir()
 catalog = Catalog.create(root / "catalog", spec)
 catalog = Catalog.open(root / "catalog")
 print(catalog.describe()["record_schemas"])
+```
+
+The helper module used below provides a generic HPC-style path and a small
+CDL-style description based on the kinds of `ncdump -h` and `xr.Dataset`
+printouts used in the notebooks:
+
+```python
+print(example_flux_collection_path())
+print(example_flux_cdl())
 ```
 
 ## Choose the right add method
@@ -113,8 +130,7 @@ later. The file below is deliberately tiny; in a real workflow it might be a
 large GridFED zip, NetCDF file, or Zarr directory.
 
 ```python
-raw_path = external_dir / "gridfed_total_2021.nc"
-raw_path.write_text("fake external NetCDF placeholder\n", encoding="utf-8")
+raw_path = write_example_flux_netcdf_or_placeholder(external_dir / EXAMPLE_FLUX_FILENAME)
 
 raw_record = catalog.add_reference(
     raw_path,
@@ -206,23 +222,19 @@ print(selected.id, selected.locator.value)
 ```
 
 If xarray and a NetCDF writer backend are installed, this cell turns the fake
-path into a tiny real NetCDF and opens it through the selected record.
+path into a tiny real NetCDF and opens it through the selected record. If those
+optional pieces are missing, the helper writes a readable `.nc` placeholder and
+this cell reports that xarray cannot open it.
 
 ```python
 try:
-    import numpy as np
     import xarray as xr
 except ImportError:
     xr = None
 
 if xr is not None:
-    tiny = xr.Dataset(
-        {"flux": (("time", "lat", "lon"), np.ones((1, 1, 1), dtype="float32"))},
-        coords={"time": [0], "lat": [51.0], "lon": [-10.0]},
-        attrs={"title": "Tiny fake flux data"},
-    )
     try:
-        tiny.to_netcdf(raw_path)
+        write_example_flux_netcdf_or_placeholder(raw_path)
         with xr.open_dataset(selected.locator.value) as ds:
             print(dict(ds.sizes))
     except Exception as exc:
@@ -250,11 +262,13 @@ zarr_record = catalog.add_reference(
         "format": "zarr",
         "processing_stage": "forward_model_input",
         "inputs": [raw_record.id],
+        "modifications": "Stacked source fluxes and filled missing values before forward modelling.",
     },
     derived_metadata={
         "reader_hint": "xarray.open_zarr",
         "source_record_ids": [raw_record.id],
         "source_paths": [str(raw_record.locator.value)],
+        "modifications": "Stacked source fluxes and filled missing values before forward modelling.",
     },
     naming_metadata={"target_kind": "directory"},
 )
@@ -318,6 +332,7 @@ registered_stage = catalog.add_reference(
         "format": "zarr",
         "processing_stage": "forward_model_input",
         "inputs": [raw_record.id],
+        "modifications": "Stacked source fluxes into a forward-model input store.",
     },
     derived_metadata={
         "reader_hint": "xarray.open_zarr",
@@ -325,6 +340,7 @@ registered_stage = catalog.add_reference(
         "source_paths": [str(raw_record.locator.value)],
         "sizes": {"time": 1, "source": 1},
         "chunks": {"time": 1, "source": 1},
+        "modifications": "Stacked source fluxes into a forward-model input store.",
     },
     naming_metadata={"target_kind": "directory"},
 )
@@ -354,6 +370,7 @@ moved_output = catalog.add_file(
         "format": "text",
         "processing_stage": "raw_forward_model_output",
         "inputs": [registered_stage.id],
+        "modifications": "Computed footprint dot flux for one site-month before baseline correction.",
         "site": "MHD",
     },
 )
@@ -366,59 +383,74 @@ Use writer-backed `add_artifact(...)` when ogcat should plan the target path
 and domain code should create the artifact during the catalog operation.
 
 ```python
-summary_metadata = {
-    "title": "Tiny derived summary",
-    "product": "summary",
+normalised_flux_modifications = (
+    "Normalized the raw CO2 agriculture flux to a single CF-style flux variable "
+    "and preserved coordinate metadata for a small documentation example."
+)
+
+normalised_flux_metadata = {
+    "title": "Tiny normalized CO2 agriculture flux",
+    "product": "EDGAR",
     "species": "co2",
     "domain": "EUROPE",
     "year": 2021,
-    "keywords": ["summary"],
+    "keywords": ["agriculture", "normalized_total_flux"],
     "provenance": "derived",
-    "format": "json",
-    "processing_stage": "summary_statistics",
+    "format": "netcdf",
+    "processing_stage": "normalized_total_flux",
     "inputs": [raw_record.id],
+    "modifications": normalised_flux_modifications,
 }
 
-summary_target = catalog.root / catalog.spec.files_root / "summaries" / "tiny-summary.json"
-summary_plan = catalog.plan_artifact_storage(
+normalised_flux_target = catalog.root / catalog.spec.files_root / "flux" / "derived" / "tiny-normalized-flux.nc"
+normalised_flux_plan = catalog.plan_artifact_storage(
     record_type="derived_flux",
-    locator=ArtifactLocator.from_path(summary_target, relative_path="data/summaries/tiny-summary.json"),
+    locator=ArtifactLocator.from_path(
+        normalised_flux_target,
+        relative_path="data/flux/derived/tiny-normalized-flux.nc",
+    ),
     target_kind="file",
     write_mode="write",
-    metadata=summary_metadata,
+    metadata=normalised_flux_metadata,
 )
 
 
-def write_summary(source, target: Path) -> dict[str, object]:
-    """Write a tiny JSON-like summary and return derived metadata."""
-    target.write_text('{"mean_flux": 1.0}\n', encoding="utf-8")
+def write_normalised_flux(source, target: Path) -> dict[str, object]:
+    """Write a tiny NetCDF-shaped flux artifact and return derived metadata."""
+    write_example_flux_netcdf_or_placeholder(target)
     return {
-        "reader_hint": "pathlib.Path.read_text",
+        "reader_hint": "xarray.open_dataset",
         "source_record_ids": source.metadata["source_record_ids"],
         "source_paths": source.metadata["source_paths"],
-        "processing_stage": "summary_statistics",
+        "output_variables": ["flux"],
+        "sizes": {"time": 1, "lat": 2, "lon": 3},
+        "units": "kg m-2 s-1",
+        "processing_stage": "normalized_total_flux",
+        "history": source.metadata["modifications"],
+        "modifications": source.metadata["modifications"],
     }
 
 
-summary_record = catalog.add_artifact(
+normalised_flux_record = catalog.add_artifact(
     record_type="derived_flux",
-    storage_plan=summary_plan,
-    metadata=summary_metadata,
+    storage_plan=normalised_flux_plan,
+    metadata=normalised_flux_metadata,
     source=memory_source(
-        {"mean_flux": 1.0},
-        kind="summary_payload",
+        {"stage": "normalized_total_flux"},
+        kind="normalised_flux_payload",
         metadata={
             "source_record_ids": [raw_record.id],
             "source_paths": [str(raw_record.locator.value)],
+            "modifications": normalised_flux_modifications,
         },
     ),
     artifact_writer=source_writer(
-        write_summary,
+        write_normalised_flux,
         target_kind="file",
-        source_kind="summary_payload",
+        source_kind="normalised_flux_payload",
     ),
 )
-print(summary_record.path())
+print(normalised_flux_record.path())
 ```
 
 ## Raw and derived metadata conventions
@@ -431,6 +463,7 @@ Use user metadata for fields that users search and select on:
 | `inputs` | Store input record ids, external labels, or both. Keep values JSON-compatible. |
 | `processing_stage` | Name the workflow stage, such as `downloaded`, `normalized_total_flux`, or `forward_model_input`. |
 | `format` | Store the normalised format users search for, such as `netcdf`, `zarr`, `zip`, or `text`. |
+| `modifications` | Store a short, human-readable processing note that explains what changed and why. For NetCDF outputs, also append the same idea to the dataset `history` attribute. |
 | `reader_hint` | Prefer this in derived metadata when it describes how to reopen the artifact, such as `xarray.open_dataset` or `xarray.open_zarr`. |
 
 Use derived metadata for facts extracted from or produced alongside the
@@ -444,6 +477,20 @@ derived_metadata = {
     "output_variables": ["flux"],
     "sizes": {"time": 1, "lat": 1, "lon": 1},
     "chunks": {"time": 1, "lat": 1, "lon": 1},
+    "modifications": "Regridded source fluxes and filled missing values with 0.0.",
+}
+```
+
+For multi-input products, named source paths are often easier to audit months
+later than a bare list:
+
+```python
+scenario_source_paths = {
+    "primary_o2": "/hpc/shared/atmos/verification-games/data/raw/PARIS_ATEN_O2.nc",
+    "FF": str(raw_record.locator.value),
+    "GPP": "/hpc/shared/atmos/some_flux_collection/sib4_gpp_2021.nc",
+    "TER": "/hpc/shared/atmos/some_flux_collection/sib4_ter_2021.nc",
+    "ocean": "/hpc/shared/atmos/some_flux_collection/cesm_scaled_ocean_2021.nc",
 }
 ```
 

--- a/docs/tutorials/verification-games-recipes.md
+++ b/docs/tutorials/verification-games-recipes.md
@@ -1,0 +1,519 @@
+# Tutorial: verification-games workflow recipes
+
+These recipes condense common ogcat patterns from the verification-games
+notebooks into small copy/paste examples. They use temporary directories and
+fake local data, so they do not depend on the verification-games repositories
+or shared ACRG data paths.
+
+The examples are written as notebook-style cells that can be run in order. The
+xarray cells are optional; they require xarray and a local NetCDF or Zarr
+backend in the active environment.
+
+## Create and reopen a local catalog
+
+Start by creating a tiny catalog with named schemas for raw fluxes, derived
+fluxes, and model output. The schema fields are intentionally broad: they make
+common search and display workflows easy without forcing every project to use
+the same metadata vocabulary.
+
+```python
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogSpec,
+    MetadataFieldDescription,
+    RecordSchema,
+)
+from ogcat.writers import memory_source, source_writer
+
+
+def metadata_field(name: str, description: str, *, required: bool = False) -> MetadataFieldDescription:
+    """Return a concise metadata field description."""
+    return MetadataFieldDescription(name=name, description=description, required=required)
+
+
+common_fields = [
+    metadata_field("title", "Short human-readable description."),
+    metadata_field("product", "Product, model, or inventory family.", required=True),
+    metadata_field("species", "Species or atmospheric quantity."),
+    metadata_field("domain", "Spatial domain."),
+    metadata_field("year", "Single year or compact year range."),
+    metadata_field("keywords", "Search keywords."),
+    metadata_field("provenance", "raw or derived.", required=True),
+    metadata_field("format", "Normalised format such as netcdf, zarr, or text.", required=True),
+    metadata_field("processing_stage", "Workflow stage that produced this artifact."),
+]
+
+spec = CatalogSpec(
+    catalog_name="verification-games-demo",
+    files_root="data",
+    record_schemas={
+        "raw_flux": RecordSchema(
+            description="Raw or externally supplied flux data.",
+            display_fields=["id", "product", "species", "year", "path"],
+            directory_template="flux/raw",
+            filename_template="{title_slug|original_stem}{original_suffix}",
+            metadata_fields=common_fields,
+        ),
+        "derived_flux": RecordSchema(
+            description="Processed flux data and intermediate products.",
+            display_fields=["id", "product", "processing_stage", "format", "path"],
+            directory_template="flux/derived",
+            filename_template="{title_slug|original_stem}{original_suffix}",
+            metadata_fields=[
+                *common_fields,
+                metadata_field("inputs", "Input record ids or external input labels."),
+            ],
+        ),
+        "verification_games_obs": RecordSchema(
+            description="Synthetic observation or forward-model output.",
+            display_fields=["id", "species", "domain", "processing_stage", "path"],
+            directory_template="verification_games_obs",
+            filename_template="{title_slug|original_stem}{original_suffix}",
+            metadata_fields=[
+                *common_fields,
+                metadata_field("inputs", "Input record ids or external input labels."),
+                metadata_field("site", "Observation or footprint site code."),
+            ],
+        ),
+    },
+)
+
+work = TemporaryDirectory(prefix="ogcat-verification-games-")
+root = Path(work.name)
+external_dir = root / "external"
+scratch_dir = root / "scratch"
+external_dir.mkdir()
+scratch_dir.mkdir()
+
+catalog = Catalog.create(root / "catalog", spec)
+catalog = Catalog.open(root / "catalog")
+print(catalog.describe()["record_schemas"])
+```
+
+## Choose the right add method
+
+| Method | Use it when | Storage effect |
+| --- | --- | --- |
+| `add_reference(...)` | The artifact already exists and should stay where it is. | Records a local path, URI, or URL path; does not copy, move, or write data. |
+| `add_file(...)` | ogcat should manage a local copy or move a finished file into catalog storage. | Copies or moves one local file into the catalog `files_root`. |
+| `add_artifact(...)` with a `StoragePlan` and writer | Domain code should create the output while ogcat handles planning, record creation, and rollback hooks. | The writer materialises the planned file or directory, then ogcat records it. |
+
+For the detailed storage model, see
+[Locators and storage](../concepts/locators-and-storage.md).
+
+## Add an existing path as a reference
+
+Use `add_reference(...)` for mounted shared files, generated outputs that have
+already been moved into place, or remote identifiers that domain code will open
+later. The file below is deliberately tiny; in a real workflow it might be a
+large GridFED zip, NetCDF file, or Zarr directory.
+
+```python
+raw_path = external_dir / "gridfed_total_2021.nc"
+raw_path.write_text("fake external NetCDF placeholder\n", encoding="utf-8")
+
+raw_record = catalog.add_reference(
+    raw_path,
+    record_type="raw_flux",
+    metadata={
+        "title": "GridFED TOTAL 2021 raw file",
+        "product": "GridFED",
+        "species": ["co2", "o2"],
+        "domain": "global",
+        "year": 2021,
+        "keywords": ["fossil", "ff"],
+        "provenance": "raw",
+        "format": "netcdf",
+        "processing_stage": "downloaded",
+    },
+)
+
+print(raw_record.id, raw_record.locator.value)
+```
+
+URI references use the same method when ogcat should not interpret or inspect
+the target:
+
+```python
+catalog.add_reference(
+    uri="https://example.org/data/gridfed-total-2020.nc",
+    record_type="raw_flux",
+    metadata={
+        "title": "Remote GridFED TOTAL 2020 raw file",
+        "product": "GridFED",
+        "species": ["co2", "o2"],
+        "domain": "global",
+        "year": 2020,
+        "keywords": ["fossil", "ff", "remote"],
+        "provenance": "raw",
+        "format": "netcdf",
+        "processing_stage": "remote_catalogue_entry",
+    },
+)
+```
+
+## Add a managed copy
+
+Use `add_file(...)` when the catalog should own the stored file. The default
+operation is a copy; pass `operation="move"` when the scratch file should be
+removed after a successful catalog add.
+
+```python
+note_path = scratch_dir / "mhd_co2_screening.txt"
+note_path.write_text("small screening output\n", encoding="utf-8")
+
+managed_record = catalog.add_file(
+    note_path,
+    record_type="verification_games_obs",
+    metadata={
+        "title": "MHD CO2 screening output",
+        "product": "screening",
+        "species": "co2",
+        "domain": "EUROPE",
+        "year": 2021,
+        "keywords": ["screening", "copy"],
+        "provenance": "derived",
+        "format": "text",
+        "processing_stage": "screened_site_output",
+        "inputs": [raw_record.id],
+        "site": "MHD",
+    },
+)
+
+print(managed_record.path())
+```
+
+## Search, get one record, and open with xarray
+
+The notebooks often search with enough metadata to identify exactly one input,
+then open the record's locator with xarray.
+
+```python
+selected = catalog.get_one(
+    where={
+        "product": "GridFED",
+        "year": 2021,
+        "provenance": "raw",
+        "format": "netcdf",
+    },
+    contains={"keywords": "fossil"},
+)
+print(selected.id, selected.locator.value)
+```
+
+If xarray and a NetCDF writer backend are installed, this cell turns the fake
+path into a tiny real NetCDF and opens it through the selected record.
+
+```python
+try:
+    import numpy as np
+    import xarray as xr
+except ImportError:
+    xr = None
+
+if xr is not None:
+    tiny = xr.Dataset(
+        {"flux": (("time", "lat", "lon"), np.ones((1, 1, 1), dtype="float32"))},
+        coords={"time": [0], "lat": [51.0], "lon": [-10.0]},
+        attrs={"title": "Tiny fake flux data"},
+    )
+    try:
+        tiny.to_netcdf(raw_path)
+        with xr.open_dataset(selected.locator.value) as ds:
+            print(dict(ds.sizes))
+    except Exception as exc:
+        print(f"xarray NetCDF example skipped: {exc}")
+```
+
+For a Zarr artifact, use the same record lookup and the stored
+`reader_hint`:
+
+```python
+zarr_path = scratch_dir / "staged_flux.zarr"
+zarr_path.mkdir(exist_ok=True)
+
+zarr_record = catalog.add_reference(
+    zarr_path,
+    record_type="derived_flux",
+    metadata={
+        "title": "Staged flux Zarr",
+        "product": "PARIS_CTE-HR_filled_fluxes_staged",
+        "species": ["co2", "o2"],
+        "domain": "EUROPE",
+        "year": "202012-202112",
+        "keywords": ["flux_stage", "forward_model_input"],
+        "provenance": "derived",
+        "format": "zarr",
+        "processing_stage": "forward_model_input",
+        "inputs": [raw_record.id],
+    },
+    derived_metadata={
+        "reader_hint": "xarray.open_zarr",
+        "source_record_ids": [raw_record.id],
+        "source_paths": [str(raw_record.locator.value)],
+    },
+    naming_metadata={"target_kind": "directory"},
+)
+
+if zarr_record.derived_metadata.get("reader_hint") == "xarray.open_zarr":
+    print(f"Open with xr.open_zarr({zarr_record.locator.value!r})")
+```
+
+## Search and display fields
+
+`search(...)` returns a `CatalogRecordSet` by default. Use `rows(...)` for
+JSON-friendly notebook output, `display_rows(...)` for terminal-style strings,
+or `to_dataframe(...)` when pandas is installed.
+
+```python
+derived = catalog.search(
+    where={"provenance": "derived"},
+    contains={"keywords": "forward_model_input"},
+    as_record_set=True,
+)
+
+fields = ["id", "product", "processing_stage", "format", "path"]
+print(derived.rows(fields))
+print(derived.display_rows(fields))
+
+try:
+    df = derived.to_dataframe(fields)
+    print(df)
+except ImportError:
+    print("Install pandas to use CatalogRecordSet.to_dataframe().")
+```
+
+For record-set details, see
+[Search and record sets](../api/search.rst).
+
+## Store generated artifacts after computation
+
+A common notebook pattern is to do heavy work outside ogcat, then register the
+small set of final outputs serially.
+
+### Register an already-written artifact
+
+When the computation has already written and validated the output path, record
+it with `add_reference(...)` and store provenance in metadata.
+
+```python
+staged_output = scratch_dir / "already_written_stage.zarr"
+staged_output.mkdir(exist_ok=True)
+
+registered_stage = catalog.add_reference(
+    staged_output,
+    record_type="derived_flux",
+    metadata={
+        "title": "Already-written staged flux store",
+        "product": "PARIS_CTE-HR_filled_fluxes_staged",
+        "species": ["co2", "o2"],
+        "domain": "EUROPE",
+        "year": "202012-202112",
+        "keywords": ["flux_stage", "filled_nan_zero"],
+        "provenance": "derived",
+        "format": "zarr",
+        "processing_stage": "forward_model_input",
+        "inputs": [raw_record.id],
+    },
+    derived_metadata={
+        "reader_hint": "xarray.open_zarr",
+        "source_record_ids": [raw_record.id],
+        "source_paths": [str(raw_record.locator.value)],
+        "sizes": {"time": 1, "source": 1},
+        "chunks": {"time": 1, "source": 1},
+    },
+    naming_metadata={"target_kind": "directory"},
+)
+```
+
+### Move a finished file into managed storage
+
+When the output is a single finished file in scratch space, use
+`add_file(..., operation="move")`.
+
+```python
+finished_path = scratch_dir / "mhd_pollution_event.txt"
+finished_path.write_text("finished fake model output\n", encoding="utf-8")
+
+moved_output = catalog.add_file(
+    finished_path,
+    record_type="verification_games_obs",
+    operation="move",
+    metadata={
+        "title": "MHD pollution event intermediate",
+        "product": "modelled_pollution_event",
+        "species": "co2_o2",
+        "domain": "EUROPE",
+        "year": "202101",
+        "keywords": ["pollution_events", "intermediate"],
+        "provenance": "derived",
+        "format": "text",
+        "processing_stage": "raw_forward_model_output",
+        "inputs": [registered_stage.id],
+        "site": "MHD",
+    },
+)
+print(finished_path.exists(), moved_output.path())
+```
+
+### Let a writer create the artifact
+
+Use writer-backed `add_artifact(...)` when ogcat should plan the target path
+and domain code should create the artifact during the catalog operation.
+
+```python
+summary_metadata = {
+    "title": "Tiny derived summary",
+    "product": "summary",
+    "species": "co2",
+    "domain": "EUROPE",
+    "year": 2021,
+    "keywords": ["summary"],
+    "provenance": "derived",
+    "format": "json",
+    "processing_stage": "summary_statistics",
+    "inputs": [raw_record.id],
+}
+
+summary_target = catalog.root / catalog.spec.files_root / "summaries" / "tiny-summary.json"
+summary_plan = catalog.plan_artifact_storage(
+    record_type="derived_flux",
+    locator=ArtifactLocator.from_path(summary_target, relative_path="data/summaries/tiny-summary.json"),
+    target_kind="file",
+    write_mode="write",
+    metadata=summary_metadata,
+)
+
+
+def write_summary(source, target: Path) -> dict[str, object]:
+    """Write a tiny JSON-like summary and return derived metadata."""
+    target.write_text('{"mean_flux": 1.0}\n', encoding="utf-8")
+    return {
+        "reader_hint": "pathlib.Path.read_text",
+        "source_record_ids": source.metadata["source_record_ids"],
+        "source_paths": source.metadata["source_paths"],
+        "processing_stage": "summary_statistics",
+    }
+
+
+summary_record = catalog.add_artifact(
+    record_type="derived_flux",
+    storage_plan=summary_plan,
+    metadata=summary_metadata,
+    source=memory_source(
+        {"mean_flux": 1.0},
+        kind="summary_payload",
+        metadata={
+            "source_record_ids": [raw_record.id],
+            "source_paths": [str(raw_record.locator.value)],
+        },
+    ),
+    artifact_writer=source_writer(
+        write_summary,
+        target_kind="file",
+        source_kind="summary_payload",
+    ),
+)
+print(summary_record.path())
+```
+
+## Raw and derived metadata conventions
+
+Use user metadata for fields that users search and select on:
+
+| Field | Suggested use |
+| --- | --- |
+| `provenance` | Use `"raw"` for original or externally supplied data and `"derived"` for processed outputs. |
+| `inputs` | Store input record ids, external labels, or both. Keep values JSON-compatible. |
+| `processing_stage` | Name the workflow stage, such as `downloaded`, `normalized_total_flux`, or `forward_model_input`. |
+| `format` | Store the normalised format users search for, such as `netcdf`, `zarr`, `zip`, or `text`. |
+| `reader_hint` | Prefer this in derived metadata when it describes how to reopen the artifact, such as `xarray.open_dataset` or `xarray.open_zarr`. |
+
+Use derived metadata for facts extracted from or produced alongside the
+artifact:
+
+```python
+derived_metadata = {
+    "reader_hint": "xarray.open_dataset",
+    "source_record_ids": [raw_record.id],
+    "source_paths": [str(raw_record.locator.value)],
+    "output_variables": ["flux"],
+    "sizes": {"time": 1, "lat": 1, "lon": 1},
+    "chunks": {"time": 1, "lat": 1, "lon": 1},
+}
+```
+
+## Discover fields
+
+Field discovery is available from Python and the CLI.
+
+```python
+print(catalog.list_metadata_fields(record_type="derived_flux"))
+print(catalog.list_record_fields())
+print(catalog.unique_values("species"))
+```
+
+The equivalent commands are:
+
+```bash
+uv run ogcat fields --catalog /path/to/catalog --record-type derived_flux
+uv run ogcat fields --catalog /path/to/catalog --stored
+uv run ogcat fields --catalog /path/to/catalog --values species
+```
+
+Schema-declared fields describe what the catalog expects. Stored fields show
+what actually appears in records, including nested paths such as
+`derived_metadata.reader_hint`. Unique values list scalar values only; list and
+mapping metadata are intentionally skipped.
+
+## Contains semantics
+
+`contains` means different things depending on the stored value type:
+
+- strings use substring matching;
+- lists and other sequences require exact membership, and list expectations
+  require every expected item to be present;
+- mappings use submapping matching;
+- scalar values fall back to equality.
+
+```python
+zip_path = external_dir / "gridfed_total_2021.zip"
+zip_path.write_text("fake zip placeholder\n", encoding="utf-8")
+
+zip_record = catalog.add_reference(
+    zip_path,
+    record_type="raw_flux",
+    metadata={
+        "title": "GridFED TOTAL 2021 zip",
+        "product": "GridFED",
+        "species": ["co2", "o2"],
+        "domain": "global",
+        "year": 2021,
+        "keywords": ["fossil", "archive"],
+        "provenance": "raw",
+        "format": "zip",
+        "processing_stage": "downloaded",
+    },
+)
+
+assert catalog.search(contains={"suffixes": "zip"}) == []
+assert catalog.search(contains={"suffixes": ".zip"})[0].id == zip_record.id
+assert catalog.search(contains={"keywords": ["fossil", "archive"]})[0].id == zip_record.id
+assert catalog.search(contains={"user_metadata": {"product": "GridFED"}})
+```
+
+For suffixes and file formats, prefer normalised metadata such as
+`format="zip"` or `derived_metadata.classification.format="zip"` over fuzzy
+suffix matching. The broader search rules are documented in
+[Metadata and validation](../concepts/metadata-and-validation.md) and
+[Search and record sets](../api/search.rst).
+
+When you are done with the temporary example catalog:
+
+```python
+work.cleanup()
+```

--- a/docs/tutorials/verification-games-recipes.md
+++ b/docs/tutorials/verification-games-recipes.md
@@ -494,70 +494,9 @@ scenario_source_paths = {
 }
 ```
 
-## Discover fields
-
-Field discovery is available from Python and the CLI.
-
-```python
-print(catalog.list_metadata_fields(record_type="derived_flux"))
-print(catalog.list_record_fields())
-print(catalog.unique_values("species"))
-```
-
-The equivalent commands are:
-
-```bash
-uv run ogcat fields --catalog /path/to/catalog --record-type derived_flux
-uv run ogcat fields --catalog /path/to/catalog --stored
-uv run ogcat fields --catalog /path/to/catalog --values species
-```
-
-Schema-declared fields describe what the catalog expects. Stored fields show
-what actually appears in records, including nested paths such as
-`derived_metadata.reader_hint`. Unique values list scalar values only; list and
-mapping metadata are intentionally skipped.
-
-## Contains semantics
-
-`contains` means different things depending on the stored value type:
-
-- strings use substring matching;
-- lists and other sequences require exact membership, and list expectations
-  require every expected item to be present;
-- mappings use submapping matching;
-- scalar values fall back to equality.
-
-```python
-zip_path = external_dir / "gridfed_total_2021.zip"
-zip_path.write_text("fake zip placeholder\n", encoding="utf-8")
-
-zip_record = catalog.add_reference(
-    zip_path,
-    record_type="raw_flux",
-    metadata={
-        "title": "GridFED TOTAL 2021 zip",
-        "product": "GridFED",
-        "species": ["co2", "o2"],
-        "domain": "global",
-        "year": 2021,
-        "keywords": ["fossil", "archive"],
-        "provenance": "raw",
-        "format": "zip",
-        "processing_stage": "downloaded",
-    },
-)
-
-assert catalog.search(contains={"suffixes": "zip"}) == []
-assert catalog.search(contains={"suffixes": ".zip"})[0].id == zip_record.id
-assert catalog.search(contains={"keywords": ["fossil", "archive"]})[0].id == zip_record.id
-assert catalog.search(contains={"user_metadata": {"product": "GridFED"}})
-```
-
-For suffixes and file formats, prefer normalised metadata such as
-`format="zip"` or `derived_metadata.classification.format="zip"` over fuzzy
-suffix matching. The broader search rules are documented in
-[Metadata and validation](../concepts/metadata-and-validation.md) and
-[Search and record sets](../api/search.rst).
+For general field-discovery and search-containment rules, see
+[Metadata and validation](../concepts/metadata-and-validation.md),
+[Search and record sets](../api/search.rst), and [CLI](../cli.md).
 
 When you are done with the temporary example catalog:
 

--- a/src/ogcat/example_data.py
+++ b/src/ogcat/example_data.py
@@ -1,0 +1,184 @@
+"""Small example-data helpers for documentation snippets."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+EXAMPLE_HPC_ROOT = Path("/hpc/shared/atmos")
+"""Generic HPC-style root used in documentation examples."""
+
+EXAMPLE_FLUX_COLLECTION_RELATIVE_PATH = Path("fluxes/EUROPE/CO2/edgarv8/agriculture")
+"""Relative collection path for realistic flux examples."""
+
+EXAMPLE_FLUX_FILENAME = "EUROPE-co2-edgarv8-agriculture-2012.nc"
+"""Filename for the tiny example flux artifact."""
+
+_EXAMPLE_FLUX_CDL = """netcdf EUROPE-co2-edgarv8-agriculture-2012 {
+dimensions:
+    time = 1 ;
+    lat = 2 ;
+    lon = 3 ;
+variables:
+    double time(time) ;
+        time:standard_name = "time" ;
+        time:units = "days since 2012-01-01 00:00:00" ;
+    float lat(lat) ;
+        lat:standard_name = "latitude" ;
+        lat:units = "degrees_north" ;
+    float lon(lon) ;
+        lon:standard_name = "longitude" ;
+        lon:units = "degrees_east" ;
+    float flux(time, lat, lon) ;
+        flux:standard_name = "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon" ;
+        flux:units = "kg m-2 s-1" ;
+        flux:cell_methods = "time: mean" ;
+
+// global attributes:
+    :title = "Tiny fake CO2 agriculture flux over Europe" ;
+    :institution = "ogcat documentation examples" ;
+    :source = "synthetic test data" ;
+    :Conventions = "CF-1.8" ;
+    :history = "Created from a tiny synthetic flux grid; normalized to a single flux variable." ;
+}
+"""
+"""CDL-style text describing the tiny flux example."""
+
+PLACEHOLDER_TEXT = (
+    "Dummy .nc placeholder for ogcat documentation examples.\n\n"
+    "Optional xarray, numpy, or a writable NetCDF backend was unavailable, so this is plain text.\n\n"
+    f"{_EXAMPLE_FLUX_CDL}"
+)
+"""Text written when optional NetCDF dependencies are unavailable."""
+
+
+def example_flux_collection_path(root: Path | str | None = None) -> Path:
+    """Return the directory path for the example flux collection.
+
+    The returned path is suitable for examples that catalog an external
+    HPC-style collection of flux files.
+
+    Args:
+        root: Optional HPC root directory. When omitted, ``EXAMPLE_HPC_ROOT`` is used.
+
+    Returns:
+        Full directory path containing the tiny example flux artifact.
+    """
+    base = Path(root) if root is not None else EXAMPLE_HPC_ROOT
+    return base / EXAMPLE_FLUX_COLLECTION_RELATIVE_PATH
+
+
+def example_flux_cdl() -> str:
+    """Return CDL-style text for the tiny example flux artifact.
+
+    Returns:
+        CDL-style text with realistic flux dimensions, variable metadata, and
+        CF-style global attributes.
+    """
+    return _EXAMPLE_FLUX_CDL
+
+
+def write_example_flux_netcdf_or_placeholder(path: Path | str) -> Path:
+    """Write a tiny realistic flux NetCDF artifact or text placeholder.
+
+    The function writes a real NetCDF file when optional ``xarray``, ``numpy``,
+    and a usable NetCDF writer backend are available. If any optional dependency
+    or backend is missing, it writes a small text placeholder with a ``.nc``
+    suffix so examples can run in a minimal ogcat installation.
+
+    Args:
+        path: Destination artifact path.
+
+    Returns:
+        The destination path that was written.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if _write_netcdf_if_available(target):
+        return target
+
+    target.write_text(PLACEHOLDER_TEXT, encoding="utf-8")
+    return target
+
+
+def _write_netcdf_if_available(path: Path) -> bool:
+    """Write a small real NetCDF file if optional dependencies are available."""
+    try:
+        np = importlib.import_module("numpy")
+        xr = importlib.import_module("xarray")
+    except ImportError:
+        return False
+
+    dataset = _tiny_flux_dataset(np=np, xr=xr)
+    try:
+        dataset.to_netcdf(path)
+    except Exception:
+        if path.exists():
+            path.unlink()
+        return False
+    return True
+
+
+def _tiny_flux_dataset(*, np: Any, xr: Any) -> Any:
+    """Build the in-memory xarray dataset used for real NetCDF examples."""
+    return xr.Dataset(
+        data_vars={
+            "flux": (
+                ("time", "lat", "lon"),
+                np.array(
+                    [
+                        [
+                            [1.1e-9, 1.3e-9, 1.2e-9],
+                            [9.0e-10, 1.0e-9, 1.4e-9],
+                        ]
+                    ],
+                    dtype="float32",
+                ),
+                {
+                    "standard_name": "surface_upward_mass_flux_of_carbon_dioxide_expressed_as_carbon",
+                    "units": "kg m-2 s-1",
+                    "cell_methods": "time: mean",
+                },
+            ),
+        },
+        coords={
+            "time": (
+                "time",
+                np.array(["2012-01-16"], dtype="datetime64[D]"),
+                {"standard_name": "time"},
+            ),
+            "lat": (
+                "lat",
+                np.array([50.0, 51.0], dtype="float32"),
+                {"standard_name": "latitude", "units": "degrees_north"},
+            ),
+            "lon": (
+                "lon",
+                np.array([-2.0, -1.0, 0.0], dtype="float32"),
+                {"standard_name": "longitude", "units": "degrees_east"},
+            ),
+        },
+        attrs={
+            "title": "Tiny fake CO2 agriculture flux over Europe",
+            "institution": "ogcat documentation examples",
+            "source": "synthetic test data",
+            "Conventions": "CF-1.8",
+            "history": (
+                "Created from a tiny synthetic flux grid; normalized to a single "
+                "flux variable for ogcat docs."
+            ),
+        },
+    )
+
+
+__all__ = [
+    "EXAMPLE_FLUX_COLLECTION_RELATIVE_PATH",
+    "EXAMPLE_FLUX_FILENAME",
+    "EXAMPLE_HPC_ROOT",
+    "PLACEHOLDER_TEXT",
+    "example_flux_cdl",
+    "example_flux_collection_path",
+    "write_example_flux_netcdf_or_placeholder",
+]

--- a/src/ogcat/example_data.py
+++ b/src/ogcat/example_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -112,12 +113,24 @@ def _write_netcdf_if_available(path: Path) -> bool:
         return False
 
     dataset = _tiny_flux_dataset(np=np, xr=xr)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.stem}.",
+        suffix=path.suffix or ".nc",
+        delete=False,
+    ) as temp_file:
+        temp_path = Path(temp_file.name)
+
+    wrote_temp = False
     try:
-        dataset.to_netcdf(path)
-    except Exception:
-        if path.exists():
-            path.unlink()
+        dataset.to_netcdf(temp_path)
+        wrote_temp = True
+    except (ImportError, OSError, RuntimeError, ValueError):
         return False
+    finally:
+        if not wrote_temp:
+            temp_path.unlink(missing_ok=True)
+    temp_path.replace(path)
     return True
 
 

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+import ogcat.example_data as example_data
+
+
+def test_example_flux_collection_path_uses_generic_hpc_root() -> None:
+    """The example collection path looks like realistic HPC storage."""
+    path = example_data.example_flux_collection_path()
+
+    assert path == example_data.EXAMPLE_HPC_ROOT / example_data.EXAMPLE_FLUX_COLLECTION_RELATIVE_PATH
+    assert path.as_posix() == "/hpc/shared/atmos/fluxes/EUROPE/CO2/edgarv8/agriculture"
+
+
+def test_example_flux_collection_path_accepts_custom_root(tmp_path: Path) -> None:
+    """Callers can place the realistic collection under a temporary root."""
+    assert (
+        example_data.example_flux_collection_path(tmp_path)
+        == tmp_path / example_data.EXAMPLE_FLUX_COLLECTION_RELATIVE_PATH
+    )
+
+
+def test_example_flux_cdl_describes_flux_dimensions_and_metadata() -> None:
+    """The CDL text includes recognizable flux dimensions, units, and attrs."""
+    cdl = example_data.example_flux_cdl()
+
+    assert "dimensions:" in cdl
+    assert "time = 1" in cdl
+    assert "lat = 2" in cdl
+    assert "lon = 3" in cdl
+    assert "float flux(time, lat, lon)" in cdl
+    assert "kg m-2 s-1" in cdl
+    assert "CF-1.8" in cdl
+    assert "history" in cdl
+
+
+def test_write_example_flux_netcdf_or_placeholder_falls_back_without_optional_xarray(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A minimal install writes a readable .nc placeholder instead of failing."""
+    real_import_module = importlib.import_module
+
+    def import_without_optional_netcdf(name: str, package: str | None = None) -> ModuleType:
+        if name in {"numpy", "xarray"}:
+            raise ImportError(name)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(example_data.importlib, "import_module", import_without_optional_netcdf)
+
+    target = tmp_path / example_data.EXAMPLE_FLUX_FILENAME
+    written = example_data.write_example_flux_netcdf_or_placeholder(target)
+
+    assert written == target
+    assert target.read_text(encoding="utf-8") == example_data.PLACEHOLDER_TEXT
+    assert "Dummy .nc placeholder" in example_data.PLACEHOLDER_TEXT

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -58,3 +58,26 @@ def test_write_example_flux_netcdf_or_placeholder_falls_back_without_optional_xa
     assert written == target
     assert target.read_text(encoding="utf-8") == example_data.PLACEHOLDER_TEXT
     assert "Dummy .nc placeholder" in example_data.PLACEHOLDER_TEXT
+
+
+def test_netcdf_write_failure_keeps_existing_destination(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed optional NetCDF write does not delete an existing file."""
+
+    class FailingDataset:
+        """Dataset double that fails after writing a partial temp file."""
+
+        def to_netcdf(self, path: Path) -> None:
+            path.write_text("partial output\n", encoding="utf-8")
+            raise OSError("backend unavailable")
+
+    monkeypatch.setattr(example_data.importlib, "import_module", lambda name: object())
+    monkeypatch.setattr(example_data, "_tiny_flux_dataset", lambda *, np, xr: FailingDataset())
+
+    target = tmp_path / example_data.EXAMPLE_FLUX_FILENAME
+    target.write_text("pre-existing data\n", encoding="utf-8")
+
+    assert example_data._write_netcdf_if_available(target) is False
+    assert target.read_text(encoding="utf-8") == "pre-existing data\n"
+    assert list(tmp_path.glob(f".{target.stem}.*{target.suffix}")) == []

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -157,6 +157,21 @@ def test_search_supports_list_membership_and_contains(tmp_path: Path) -> None:
     assert [r.id for r in by_title_substring] == [tagged.id]
 
 
+def test_search_contains_suffixes_requires_exact_list_member(tmp_path: Path) -> None:
+    """Suffix contains searches require the exact stored suffix string."""
+    archive = tmp_path / "gridfed.zip"
+    archive.write_text("not a real archive", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_reference(
+        archive,
+        metadata={"product": "GridFED", "format": "zip"},
+    )
+
+    assert catalog.search(contains={"suffixes": "zip"}) == []
+    assert [r.id for r in catalog.search(contains={"suffixes": ".zip"})] == [record.id]
+    assert [r.id for r in catalog.search(where={"format": "zip"})] == [record.id]
+
+
 def test_search_contains_supports_mapping_subset_and_unhashable_values(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     record = catalog.add_artifact(


### PR DESCRIPTION
## Summary
- Add a new verification-games recipes tutorial with small self-contained examples for local catalogs, `add_reference`, `add_file`, `get_one`, search/display workflows, and writer-backed artifact registration.
- Document raw vs derived metadata conventions and field discovery in both Python and the CLI.
- Clarify `contains` behavior for list-valued fields in the concepts docs and add a regression test for exact suffix membership.

## Testing
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pyright`
- `uv run pytest` 
- `uv run sphinx-build docs docs/_build/html`