### PR TITLE
Add catalog-scoped audit logging and structured log inspection

### DIFF
--- a/docs/adr/0001-operation-scoped-hook-lifecycle-observation.md
+++ b/docs/adr/0001-operation-scoped-hook-lifecycle-observation.md
@@ -1,0 +1,197 @@
+# ADR 0001: Operation-Scoped Hook Lifecycle Observation
+
+- **Status**: Proposed
+- **Date**: 2026-05-14
+- **Related issues**: [openghg/ogcat#75](https://github.com/openghg/ogcat/issues/75)
+
+## Context
+
+`ogcat` hooks are currently defined as a loose set of protocols in `hooks.py`.
+`HookManager` stores long-lived hook objects and exposes lifecycle methods such
+as `before_validate_metadata`, `resolve_artifact_locator`, and
+`before_record_write`. `Catalog` controls when those hook methods are called as
+part of an add operation.
+
+Catalog-scoped audit logging introduced a new requirement: hook dispatch should
+produce structured diagnostics for hook phases without moving hook phase
+metadata into `catalog.py` and without making `HookManager` depend directly on
+JSON Lines audit logging.
+
+The current add-operation implementation is also large. A broader future
+refactor should extract operation orchestration into an `OperationRunner`, but
+this ADR focuses only on the hook lifecycle observation boundary.
+
+## Requirements
+
+- Preserve existing public hook method signatures.
+- Preserve compatibility with plugin objects that satisfy hook protocols by
+  implementing one or more lifecycle methods.
+- Keep user-facing hook registration simple: users should pass hooks to
+  `Catalog.create`, `Catalog.open`, or `HookManager` as they do today.
+- Keep observer/callback lifetime operation-scoped so one catalog object can run
+  different operations with different diagnostics behavior.
+- Avoid global observer attach/detach requirements on the long-lived
+  `HookManager`.
+- Keep `HookManager` independent of audit storage details, catalog paths, user
+  ids, and JSON Lines.
+- Allow tests to target stable interfaces rather than concrete audit
+  implementation details.
+
+## Decision
+
+Adopt an operation-scoped hook dispatch model:
+
+- `HookManager` remains the long-lived registry of hook objects.
+- A new operation-scoped dispatcher, tentatively `HookDispatcher`, performs hook
+  invocation for one catalog operation.
+- Hook phase metadata is defined in `hooks.py`, close to `HOOK_METHOD_NAMES` and
+  the hook protocols.
+- The dispatcher emits hook lifecycle notifications through callbacks supplied
+  for that operation.
+- Audit logging is implemented as one callback adapter. The callback converts
+  hook lifecycle events into `AuditEvent` objects, but the dispatcher does not
+  know about audit sinks or JSONL.
+
+The core interface should look conceptually like this:
+
+```python
+@dataclass(frozen=True)
+class HookPhase:
+    name: str
+    label: str
+
+
+@dataclass(frozen=True)
+class HookLifecycleEvent:
+    phase: HookPhase
+    stage: Literal["started", "completed", "failed"]
+    context: OperationContext
+    hook_count: int
+    warnings_added: int = 0
+    error: BaseException | None = None
+
+
+HookLifecycleCallback = Callable[[HookLifecycleEvent], None]
+```
+
+`HookManager` should provide an operation-scoped dispatcher:
+
+```python
+dispatcher = catalog.hook_manager.dispatcher(notify=operation_hook_callback)
+dispatcher.before_validate_metadata(context)
+dispatcher.resolve_artifact_locator(context)
+```
+
+The existing `HookManager.before_validate_metadata(context)` style methods
+should remain available for callers that do not need operation-scoped
+observation. They can delegate to a dispatcher with no callback.
+
+## Rationale
+
+`Catalog` owns operation ordering, but not hook definitions. It should decide
+that validation precedes locator resolution and that commit follows record
+write. It should not need to know every formal hook phase name for audit
+purposes.
+
+`HookManager` owns hook dispatch facts. When its `before_record_write` behavior
+is invoked, it knows which lifecycle method is being dispatched, how many hooks
+implement that method, and whether dispatch started, completed, or failed. Those
+facts are exactly what observers need.
+
+Callbacks are operation-scoped rather than attached globally. A catalog object
+can perform many operations over its lifetime, and those operations may need
+different diagnostics policies. Passing callbacks to a dispatcher avoids
+long-lived observer identity, detach ordering, stale observers, and cross-
+operation leakage.
+
+The dispatcher should pass the phase as event data. Observers should not store a
+mutable "current phase" that `Catalog` sets before calling `HookManager`.
+Mutable observer phase state would create temporal coupling and could report the
+wrong phase if code forgets to update it or if nested dispatch is introduced.
+
+## Options Considered
+
+### Option 1: HookManager directly owns audit recording
+
+`HookManager` could accept an audit recorder and emit audit events around each
+hook method. This keeps hook phases out of `catalog.py`, but it couples hook
+dispatch to audit vocabulary. Future metrics or tracing would either reuse
+audit-specific interfaces or add another parallel mechanism.
+
+This option is simpler but less general.
+
+### Option 2: Operation-scoped lifecycle callbacks
+
+`HookManager` creates a dispatcher for a single operation. The dispatcher emits
+generic lifecycle events to callbacks. Audit is one callback adapter.
+
+This option is slightly more abstract, but it clearly separates hook dispatch
+from audit storage and solves callback lifetime problems.
+
+This ADR chooses Option 2.
+
+### Option 3: Global observer attachment on HookManager
+
+`HookManager` could support `attach(observer)` and `detach(observer)` and notify
+all attached observers. This follows the classic observer pattern, but it is a
+poor fit for operation-specific diagnostics because `HookManager` is long-lived.
+It would require careful detach behavior to avoid observers leaking between
+operations.
+
+This option is rejected.
+
+### Option 4: Catalog-managed mutable observer phase
+
+`Catalog` could set `observer.phase = "before_record_write"` before invoking a
+hook method. This makes `Catalog` own phase naming explicitly, but it relies on
+mutable side state and makes incorrect sequencing easy.
+
+This option is rejected.
+
+## Testing Guidance
+
+Tests should target the interfaces created by this decision:
+
+- A dispatcher invokes only hooks that implement the current phase.
+- A dispatcher emits `started`, `completed`, and `failed` lifecycle events with
+  the expected `HookPhase`, hook count, warning count, context, and exception.
+- A dispatcher with no callback preserves current hook behavior.
+- A callback failure policy is explicit. Audit callbacks should be best-effort
+  and should not fail hook dispatch.
+- Audit integration tests should assert conversion from `HookLifecycleEvent` to
+  `AuditEvent`, not duplicate dispatcher behavior.
+- Catalog operation tests should assert that operation flow receives hook
+  diagnostics through the callback interface, not by inspecting private phase
+  constants.
+
+Where an interface is internal but important, a small abstract base class or
+dataclass should be preferred if it makes the contract clearer than a loose
+callable. Protocols remain appropriate for plugin author extension points.
+
+## Consequences
+
+Positive consequences:
+
+- Hook phase metadata moves out of `catalog.py`.
+- Audit logging can observe hook dispatch without coupling `HookManager` to
+  audit sinks.
+- Per-operation callbacks avoid attach/detach lifecycle bugs.
+- The design creates a reusable path for metrics, tracing, or debug callbacks.
+- Tests can focus on stable dispatch and lifecycle event interfaces.
+
+Negative consequences:
+
+- The hook subsystem gains an additional internal concept: an operation-scoped
+  dispatcher.
+- Catalog code must create and pass a callback or dispatcher for observed
+  operations.
+- The implementation must preserve existing `HookManager` methods to avoid
+  unnecessary public API churn.
+
+## Deferred Questions
+
+- Should operation-specific hook selection also live on the dispatcher?
+- Should `OperationContext` eventually hold optional stage outputs such as a
+  validation report?
+- Should a future `OperationRunner` own dispatcher creation and audit callback
+  wiring once operation orchestration is extracted from `Catalog`?

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+Architecture decision records capture significant design choices for `ogcat`.
+They should be short enough to maintain, but concrete enough that future changes
+can be judged against the original context, options, and consequences.
+
+ADRs use this status vocabulary:
+
+- `Proposed`: a target design has been recorded, but implementation is pending.
+- `Accepted`: the design is implemented or actively treated as the project direction.
+- `Superseded`: a later ADR replaces the decision.
+
+```{toctree}
+:maxdepth: 1
+
+0001-operation-scoped-hook-lifecycle-observation
+```

--- a/docs/api/audit.rst
+++ b/docs/api/audit.rst
@@ -1,0 +1,5 @@
+Audit
+=====
+
+.. automodule:: ogcat.audit
+   :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -5,6 +5,7 @@ API reference
    :maxdepth: 1
 
    catalog
+   audit
    models
    search
    storage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,31 @@ Ingest a file into a catalog.
 ogcat add <file> --catalog <root> [--meta KEY=VALUE ...] [--operation copy|move]
 ```
 
+If an add operation fails after an operation id has been created, the error
+message includes ``operation_id: ...`` so it can be correlated with
+``ogcat logs --operation``.
+
+### ``ogcat logs``
+
+Inspect catalog-local audit events.
+
+```
+ogcat logs --catalog <root> [--user USER] [--operation OPERATION_ID] [--record RECORD_ID] [--level LEVEL] [--event-type TYPE] [--limit N] [--json]
+```
+
+Audit events are stored as JSON Lines under
+``<catalog-root>/.ogcat/logs/events.jsonl``. Use ``--json`` for full structured
+events, or omit it for a compact table with timestamp, level, event type,
+operation id, record id, and message.
+
+Examples:
+
+```bash
+ogcat logs --catalog <root> --level error
+ogcat logs --catalog <root> --user alice --json
+ogcat logs --catalog <root> --operation "$operation_id"
+```
+
 ### ``ogcat search``
 
 Search catalog records.

--- a/docs/concepts/transactions-and-logging.md
+++ b/docs/concepts/transactions-and-logging.md
@@ -16,6 +16,30 @@ The typical lifecycle is:
 If any step raises an exception, registered rollback actions run in reverse
 order to undo any partial writes.
 
+## Audit events
+
+Each catalog writes structured audit events to
+``<catalog-root>/.ogcat/logs/events.jsonl``. The log is append-only during
+normal operation and is intended for maintainers who need to answer which
+operation ran, which user ran it, which record was touched, and where a failure
+occurred.
+
+Add operations emit lifecycle events for operation start, validation, storage
+or record writes, commit, failure, and rollback. Events include an
+``operation_id``; CLI add failures include that id in the user-facing error
+message when available:
+
+```bash
+ogcat logs --catalog ./catalog --operation OPERATION_ID --json
+ogcat logs --catalog ./catalog --user alice --level error
+```
+
+Audit details intentionally avoid recording file contents, in-memory
+``OperationSource.payload`` values, or full user metadata payloads. Metadata key
+names and operation context are logged for diagnostics, and sensitive-looking
+keys such as tokens, passwords, credentials, API keys, and private keys are
+redacted when values are included in audit details.
+
 ## Rollback
 
 Rollback is best-effort.  Each rollback action is tried in turn; if one

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ searching records.
    architecture
    roadmap
    ideas
+   adr/index
    design-note-record-schemas
    design-note-artifact-locators
    design-note-hooks-plugins

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for ogcat."""
 
+from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
@@ -46,6 +47,8 @@ from ogcat.writers import (
 __all__ = [
     "ArtifactLocator",
     "ArtifactWriter",
+    "AuditEvent",
+    "AuditSink",
     "Catalog",
     "CatalogRecord",
     "CatalogRecordSet",
@@ -56,6 +59,7 @@ __all__ = [
     "FunctionArtifactWriter",
     "HookManager",
     "HookWarning",
+    "JsonlAuditSink",
     "LocalStorageAdapter",
     "MetadataFieldDescription",
     "MoveArtifactWriter",
@@ -79,6 +83,7 @@ __all__ = [
     "validate_record",
     "validate_schema",
     "validate_spec",
+    "read_audit_events",
     "memory_source",
     "memory_writer",
     "path_source",

--- a/src/ogcat/audit.py
+++ b/src/ogcat/audit.py
@@ -1,0 +1,378 @@
+"""Structured catalog audit events and JSON Lines storage."""
+
+from __future__ import annotations
+
+import json
+import os
+import traceback as traceback_module
+import warnings
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, cast
+from uuid import uuid4
+
+from ogcat.models import JsonValue, MetadataDict, normalize_metadata
+
+AUDIT_LOG_RELATIVE_PATH = Path(".ogcat") / "logs" / "events.jsonl"
+REDACTED = "[REDACTED]"
+SENSITIVE_KEY_PARTS = (
+    "password",
+    "passwd",
+    "token",
+    "secret",
+    "credential",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+)
+
+
+@dataclass(slots=True)
+class AuditEvent:
+    """One structured audit event emitted by a catalog operation.
+
+    Args:
+        event_id: Unique event identifier.
+        operation_id: Operation identifier shared with the active transaction.
+        timestamp_utc: UTC ISO 8601 timestamp.
+        level: Event severity, such as ``"info"``, ``"warning"``, or ``"error"``.
+        event_type: Stable lifecycle event type.
+        user_id: User associated with the operation.
+        catalog_id: Catalog name or other stable catalog identifier.
+        catalog_path: Filesystem path to the catalog root.
+        record_id: Catalog record id touched by the event, if known.
+        locator: Artifact locator summary, if known.
+        message: Human-readable event summary.
+        details: Redacted JSON-compatible event details.
+        exception_type: Exception class name for failures.
+        exception_message: Exception message for failures.
+        traceback: Optional truncated traceback text.
+    """
+
+    operation_id: str
+    level: str
+    event_type: str
+    message: str
+    event_id: str = field(default_factory=lambda: uuid4().hex)
+    timestamp_utc: str = field(default_factory=lambda: _utc_timestamp())
+    user_id: str | None = None
+    catalog_id: str | None = None
+    catalog_path: str | None = None
+    record_id: str | None = None
+    locator: MetadataDict | None = None
+    details: MetadataDict = field(default_factory=dict)
+    exception_type: str | None = None
+    exception_message: str | None = None
+    traceback: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize event fields into JSON-compatible values."""
+        self.level = self.level.lower()
+        self.details = redact_sensitive_values(self.details)
+        if self.locator is not None:
+            self.locator = redact_sensitive_values(self.locator)
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return the event as a JSON-compatible dictionary."""
+        payload: dict[str, JsonValue] = {
+            "event_id": self.event_id,
+            "operation_id": self.operation_id,
+            "timestamp_utc": self.timestamp_utc,
+            "level": self.level,
+            "event_type": self.event_type,
+            "user_id": self.user_id,
+            "catalog_id": self.catalog_id,
+            "catalog_path": self.catalog_path,
+            "record_id": self.record_id,
+            "locator": self.locator,
+            "message": self.message,
+            "details": self.details,
+            "exception_type": self.exception_type,
+            "exception_message": self.exception_message,
+            "traceback": self.traceback,
+        }
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> AuditEvent:
+        """Build an event from a dictionary read from JSON Lines."""
+        return cls(
+            event_id=str(data.get("event_id") or uuid4().hex),
+            operation_id=str(data.get("operation_id") or ""),
+            timestamp_utc=str(data.get("timestamp_utc") or _utc_timestamp()),
+            level=str(data.get("level") or "info"),
+            event_type=str(data.get("event_type") or "unknown"),
+            user_id=_optional_str(data.get("user_id")),
+            catalog_id=_optional_str(data.get("catalog_id")),
+            catalog_path=_optional_str(data.get("catalog_path")),
+            record_id=_optional_str(data.get("record_id")),
+            locator=_optional_metadata(data.get("locator"), field_name="locator"),
+            message=str(data.get("message") or ""),
+            details=_optional_metadata(data.get("details"), field_name="details") or {},
+            exception_type=_optional_str(data.get("exception_type")),
+            exception_message=_optional_str(data.get("exception_message")),
+            traceback=_optional_str(data.get("traceback")),
+        )
+
+    @classmethod
+    def from_exception(
+        cls,
+        *,
+        operation_id: str,
+        event_type: str,
+        message: str,
+        exception: BaseException,
+        user_id: str | None = None,
+        catalog_id: str | None = None,
+        catalog_path: str | None = None,
+        record_id: str | None = None,
+        locator: MetadataDict | None = None,
+        details: Mapping[str, object] | None = None,
+        traceback_limit: int = 8,
+    ) -> AuditEvent:
+        """Build an error event from an exception."""
+        traceback_text = "".join(
+            traceback_module.format_exception(
+                type(exception),
+                exception,
+                exception.__traceback__,
+                limit=traceback_limit,
+            )
+        ).strip()
+        return cls(
+            operation_id=operation_id,
+            level="error",
+            event_type=event_type,
+            user_id=user_id,
+            catalog_id=catalog_id,
+            catalog_path=catalog_path,
+            record_id=record_id,
+            locator=locator,
+            message=message,
+            details=redact_sensitive_values({} if details is None else details),
+            exception_type=type(exception).__name__,
+            exception_message=str(exception),
+            traceback=traceback_text,
+        )
+
+
+class AuditSink(Protocol):
+    """Sink for structured audit events."""
+
+    def emit(self, event: AuditEvent) -> None:
+        """Persist or forward one audit event."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class JsonlAuditSink:
+    """Append-only JSON Lines audit sink under a catalog root.
+
+    Args:
+        catalog_root: Catalog root directory.
+        relative_path: Log path relative to ``catalog_root``.
+    """
+
+    catalog_root: Path
+    relative_path: Path = AUDIT_LOG_RELATIVE_PATH
+
+    @property
+    def path(self) -> Path:
+        """Absolute path to the JSON Lines audit log."""
+        return self.catalog_root / self.relative_path
+
+    def emit(self, event: AuditEvent) -> None:
+        """Append one event as a JSON line."""
+        path = self.path
+        os.makedirs(path.parent, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.to_dict(), sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+
+    def read_events(
+        self,
+        *,
+        user_id: str | None = None,
+        operation_id: str | None = None,
+        record_id: str | None = None,
+        level: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        """Read events from the sink with optional filters."""
+        return read_audit_events(
+            self.path,
+            user_id=user_id,
+            operation_id=operation_id,
+            record_id=record_id,
+            level=level,
+            event_type=event_type,
+            limit=limit,
+        )
+
+
+def read_audit_events(
+    path: str | Path,
+    *,
+    user_id: str | None = None,
+    operation_id: str | None = None,
+    record_id: str | None = None,
+    level: str | None = None,
+    event_type: str | None = None,
+    limit: int | None = None,
+) -> list[AuditEvent]:
+    """Read matching audit events from a JSON Lines file.
+
+    Corrupt JSON lines and malformed event dictionaries are skipped with a
+    runtime warning so one bad line does not hide the rest of the audit log.
+    """
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative.")
+    log_path = Path(path)
+    if not log_path.exists():
+        return []
+    matches = [
+        event
+        for event in _iter_audit_events(log_path)
+        if _matches_filters(
+            event,
+            user_id=user_id,
+            operation_id=operation_id,
+            record_id=record_id,
+            level=level,
+            event_type=event_type,
+        )
+    ]
+    if limit is None:
+        return matches
+    if limit == 0:
+        return []
+    return matches[-limit:]
+
+
+def redact_sensitive_values(value: object) -> MetadataDict:
+    """Return a metadata dictionary with sensitive-looking keys redacted."""
+    normalized = normalize_metadata(value, field_name="audit")
+    return cast(MetadataDict, _redact_value(normalized, path_parts=()))
+
+
+def exception_operation_id(exception: BaseException) -> str | None:
+    """Return an operation id attached to an exception note, if present."""
+    for note in getattr(exception, "__notes__", ()):
+        if not isinstance(note, str):
+            continue
+        prefix = "ogcat operation_id: "
+        if note.startswith(prefix):
+            return note.removeprefix(prefix).strip() or None
+    return None
+
+
+def add_operation_note(exception: BaseException, operation_id: str) -> None:
+    """Attach an operation-id note to an exception if one is not already present."""
+    if exception_operation_id(exception) == operation_id:
+        return
+    exception.add_note(f"ogcat operation_id: {operation_id}")
+
+
+def _iter_audit_events(path: Path) -> Iterator[AuditEvent]:
+    """Yield well-formed audit events from a JSON Lines file."""
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                payload = json.loads(stripped)
+                if not isinstance(payload, dict):
+                    raise TypeError(f"expected JSON object, got {type(payload).__name__}")
+                yield AuditEvent.from_dict(payload)
+            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                warnings.warn(
+                    f"Skipping corrupt audit log line {path}:{line_number}: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
+
+def _matches_filters(
+    event: AuditEvent,
+    *,
+    user_id: str | None,
+    operation_id: str | None,
+    record_id: str | None,
+    level: str | None,
+    event_type: str | None,
+) -> bool:
+    """Return whether an event passes all supplied filters."""
+    return all(
+        (
+            user_id is None or event.user_id == user_id,
+            operation_id is None or event.operation_id == operation_id,
+            record_id is None or event.record_id == record_id,
+            level is None or event.level == level.lower(),
+            event_type is None or event.event_type == event_type,
+        )
+    )
+
+
+def _redact_value(value: JsonValue, *, path_parts: Iterable[str]) -> JsonValue:
+    """Recursively redact sensitive values below sensitive-looking keys."""
+    if _is_sensitive_path(path_parts):
+        return REDACTED
+    if isinstance(value, dict):
+        redacted: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            redacted[key] = _redact_value(item, path_parts=(*path_parts, key))
+        return redacted
+    if isinstance(value, list):
+        return [_redact_value(item, path_parts=path_parts) for item in value]
+    return value
+
+
+def _is_sensitive_path(path_parts: Iterable[str]) -> bool:
+    """Return whether a metadata path should be redacted."""
+    return any(_is_sensitive_key(part) for part in path_parts)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return whether one key looks sensitive."""
+    normalized = key.lower().replace("-", "_")
+    return any(part in normalized for part in SENSITIVE_KEY_PARTS)
+
+
+def _optional_str(value: object) -> str | None:
+    """Return an optional string from a JSON value."""
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_metadata(value: object, *, field_name: str) -> MetadataDict | None:
+    """Return an optional metadata dictionary from a JSON value."""
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a dictionary, got {type(value).__name__}")
+    return redact_sensitive_values(value)
+
+
+def _utc_timestamp() -> str:
+    """Return a UTC ISO 8601 timestamp."""
+    timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat()
+    return timestamp.replace("+00:00", "Z")
+
+
+__all__ = [
+    "AUDIT_LOG_RELATIVE_PATH",
+    "REDACTED",
+    "AuditEvent",
+    "AuditSink",
+    "JsonlAuditSink",
+    "add_operation_note",
+    "exception_operation_id",
+    "read_audit_events",
+    "redact_sensitive_values",
+]

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -58,6 +58,67 @@ HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
 
 
+@dataclass(frozen=True, slots=True)
+class _HookAuditPhase:
+    """Audit metadata for one hook dispatch phase."""
+
+    phase: str
+    method_name: str
+    label: str
+
+
+_BEFORE_VALIDATE_METADATA_HOOKS = _HookAuditPhase(
+    phase="before_validate_metadata",
+    method_name="before_validate_metadata",
+    label="before-validate metadata",
+)
+_AFTER_VALIDATE_METADATA_HOOKS = _HookAuditPhase(
+    phase="after_validate_metadata",
+    method_name="after_validate_metadata",
+    label="after-validate metadata",
+)
+_RESOLVE_ARTIFACT_LOCATOR_HOOKS = _HookAuditPhase(
+    phase="resolve_artifact_locator",
+    method_name="resolve_artifact_locator",
+    label="artifact locator resolution",
+)
+_EXTRACT_METADATA_HOOKS = _HookAuditPhase(
+    phase="extract_metadata",
+    method_name="extract_metadata",
+    label="metadata extraction",
+)
+_BEFORE_RECORD_WRITE_HOOKS = _HookAuditPhase(
+    phase="before_record_write",
+    method_name="before_record_write",
+    label="before-record-write",
+)
+_AFTER_RECORD_WRITE_HOOKS = _HookAuditPhase(
+    phase="after_record_write",
+    method_name="after_record_write",
+    label="after-record-write",
+)
+_BEFORE_COMMIT_HOOKS = _HookAuditPhase(
+    phase="before_commit",
+    method_name="before_commit",
+    label="before-commit",
+)
+_AFTER_COMMIT_HOOKS = _HookAuditPhase(
+    phase="after_commit",
+    method_name="after_commit",
+    label="after-commit",
+)
+_ON_ERROR_HOOKS = _HookAuditPhase(
+    phase="on_error",
+    method_name="on_error",
+    label="operation error",
+)
+_ON_ROLLBACK_HOOKS = _HookAuditPhase(
+    phase="on_rollback",
+    method_name="on_rollback",
+    label="operation rollback",
+)
+
+
 @dataclass(slots=True)
 class Catalog:
     """User-facing API bound to one catalog root.
@@ -1269,6 +1330,60 @@ class Catalog:
             )
         self._emit_audit(event)
 
+    def _run_hook_audit_phase(
+        self,
+        context: OperationContext,
+        phase: _HookAuditPhase,
+        callback: Callable[[], None],
+    ) -> None:
+        """Run one hook phase and emit structured audit events when hooks exist."""
+        hook_count = _hook_count(self.hook_manager, phase.method_name)
+        if hook_count == 0:
+            callback()
+            return
+
+        base_details = {
+            "phase": phase.phase,
+            "hook_method": phase.method_name,
+            "hook_count": hook_count,
+        }
+        self._emit_operation_audit(
+            context,
+            event_type="hook",
+            message=f"{phase.label} hooks started.",
+            details={**base_details, "hook_phase": "started"},
+        )
+        warning_count_before = len(context.warnings)
+        try:
+            callback()
+        except Exception as exc:
+            self._emit_operation_audit(
+                context,
+                event_type="hook",
+                level="error",
+                message=f"{phase.label} hooks failed.",
+                details={**base_details, "hook_phase": "failed"},
+                exception=exc,
+            )
+            raise
+
+        warnings_added = len(context.warnings) - warning_count_before
+        self._emit_operation_audit(
+            context,
+            event_type="hook",
+            level="warning" if warnings_added else "info",
+            message=(
+                f"{phase.label} hooks completed with warnings."
+                if warnings_added
+                else f"{phase.label} hooks completed."
+            ),
+            details={
+                **base_details,
+                "hook_phase": "completed",
+                "warnings_added": warnings_added,
+            },
+        )
+
     def _run_add_operation(
         self,
         *,
@@ -1307,7 +1422,7 @@ class Catalog:
             original_filename=original_filename,
             suffixes=[] if suffixes is None else list(suffixes),
         )
-        audit_phase = "operation-started"
+        current_phase = "operation-started"
         self._emit_operation_audit(
             hook_context,
             event_type="operation-started",
@@ -1315,9 +1430,13 @@ class Catalog:
             details={"caller_owned_transaction": not commit},
         )
         try:
-            audit_phase = "before_validate_metadata"
-            self.hook_manager.before_validate_metadata(hook_context)
-            audit_phase = "validation"
+            current_phase = _BEFORE_VALIDATE_METADATA_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _BEFORE_VALIDATE_METADATA_HOOKS,
+                lambda: self.hook_manager.before_validate_metadata(hook_context),
+            )
+            current_phase = "validation"
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
                 schema_name=self._schema_name(schema_record_type),
@@ -1327,7 +1446,12 @@ class Catalog:
                 metadata=hook_context.user_metadata,
                 record_type=schema_record_type,
             )
-            self.hook_manager.after_validate_metadata(hook_context, validation_report)
+            current_phase = _AFTER_VALIDATE_METADATA_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _AFTER_VALIDATE_METADATA_HOOKS,
+                lambda: self.hook_manager.after_validate_metadata(hook_context, validation_report),
+            )
             self._emit_operation_audit(
                 hook_context,
                 event_type="validation",
@@ -1336,12 +1460,17 @@ class Catalog:
                 details=_validation_audit_details(validation_report),
             )
             validation_report.raise_for_errors()
-            audit_phase = "locator-resolution"
+            current_phase = "locator-factory"
             hook_context.planned_locators = [locator_factory(hook_context)]
-            self.hook_manager.resolve_artifact_locator(hook_context)
+            current_phase = _RESOLVE_ARTIFACT_LOCATOR_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _RESOLVE_ARTIFACT_LOCATOR_HOOKS,
+                lambda: self.hook_manager.resolve_artifact_locator(hook_context),
+            )
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
-            audit_phase = "storage-plan"
+            current_phase = "storage-plan"
             hook_context.storage_plan = (
                 storage_plan_factory(hook_context, canonical_locator)
                 if storage_plan_factory is not None
@@ -1385,7 +1514,7 @@ class Catalog:
                     locator=canonical_locator,
                 )
             else:
-                audit_phase = "artifact-write"
+                current_phase = "artifact-write"
                 artifact_writer.write(hook_context, hook_context.source, canonical_locator)
                 self._emit_operation_audit(
                     hook_context,
@@ -1398,17 +1527,26 @@ class Catalog:
                     },
                     locator=canonical_locator,
                 )
-            audit_phase = "metadata-extraction"
+            current_phase = "metadata-extraction"
             _add_classification_metadata(hook_context, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
-            self.hook_manager.extract_metadata(hook_context)
+            current_phase = _EXTRACT_METADATA_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _EXTRACT_METADATA_HOOKS,
+                lambda: self.hook_manager.extract_metadata(hook_context),
+            )
             hook_context.derived_metadata = normalize_metadata(
                 hook_context.derived_metadata,
                 field_name="derived_metadata",
             )
-            audit_phase = "before_record_write"
-            self.hook_manager.before_record_write(hook_context)
+            current_phase = _BEFORE_RECORD_WRITE_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _BEFORE_RECORD_WRITE_HOOKS,
+                lambda: self.hook_manager.before_record_write(hook_context),
+            )
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
                 schema_name=self._schema_name(schema_record_type),
@@ -1429,7 +1567,7 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
             )
-            audit_phase = "record-write"
+            current_phase = "record-write"
             persisted = transaction.insert_staged_record(record)
             hook_context.record_id = _require_record_id(persisted)
             self._emit_operation_audit(
@@ -1439,12 +1577,20 @@ class Catalog:
                 details={"write_phase": "record-write", "transaction_state": transaction.state.value},
                 locator=canonical_locator,
             )
-            audit_phase = "after_record_write"
-            self.hook_manager.after_record_write(hook_context)
+            current_phase = _AFTER_RECORD_WRITE_HOOKS.phase
+            self._run_hook_audit_phase(
+                hook_context,
+                _AFTER_RECORD_WRITE_HOOKS,
+                lambda: self.hook_manager.after_record_write(hook_context),
+            )
             if commit:
-                audit_phase = "before_commit"
-                self.hook_manager.before_commit(hook_context)
-                audit_phase = "commit"
+                current_phase = _BEFORE_COMMIT_HOOKS.phase
+                self._run_hook_audit_phase(
+                    hook_context,
+                    _BEFORE_COMMIT_HOOKS,
+                    lambda: self.hook_manager.before_commit(hook_context),
+                )
+                current_phase = "commit"
                 transaction.commit()
                 self._emit_operation_audit(
                     hook_context,
@@ -1455,18 +1601,26 @@ class Catalog:
                 )
                 # After-commit hooks are best-effort: failures warn, but cannot
                 # turn an already-persisted record into an apparent API failure.
-                audit_phase = "after_commit"
-                self.hook_manager.after_commit(hook_context)
+                current_phase = _AFTER_COMMIT_HOOKS.phase
+                self._run_hook_audit_phase(
+                    hook_context,
+                    _AFTER_COMMIT_HOOKS,
+                    lambda: self.hook_manager.after_commit(hook_context),
+                )
             return persisted
         except Exception as exc:
             add_operation_note(exc, hook_context.operation_id)
-            self.hook_manager.on_error(hook_context, exc)
+            self._run_hook_audit_phase(
+                hook_context,
+                _ON_ERROR_HOOKS,
+                lambda error=exc: self.hook_manager.on_error(hook_context, error),
+            )
             self._emit_operation_audit(
                 hook_context,
                 event_type="failure",
                 message=f"{operation_type} operation failed.",
                 details={
-                    "phase": audit_phase,
+                    "phase": current_phase,
                     "transaction_state": transaction.state.value,
                     "caller_owned_transaction": not commit,
                 },
@@ -1482,7 +1636,11 @@ class Catalog:
                     details={"rollback_phase": "started", "transaction_state": transaction.state.value},
                 )
                 transaction.rollback(original_exception=exc)
-                self.hook_manager.on_rollback(hook_context, exc)
+                self._run_hook_audit_phase(
+                    hook_context,
+                    _ON_ROLLBACK_HOOKS,
+                    lambda error=exc: self.hook_manager.on_rollback(hook_context, error),
+                )
                 if transaction.rollback_errors:
                     rollback_details: dict[str, object] = {
                         "rollback_phase": "failed",
@@ -2034,6 +2192,11 @@ def _operation_audit_details(context: OperationContext) -> dict[str, object]:
         "suffixes": list(context.suffixes),
         "hook_warning_count": len(context.warnings),
     }
+
+
+def _hook_count(hook_manager: HookManager, method_name: str) -> int:
+    """Return the number of registered hooks with a callable lifecycle method."""
+    return sum(1 for hook in hook_manager.hooks if callable(getattr(hook, method_name, None)))
 
 
 def _audit_locator(locator: ArtifactLocator | None) -> MetadataDict | None:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import getpass
 import importlib.util
+import os
+import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
@@ -11,6 +14,12 @@ from pathlib import Path
 from typing import Any, Literal, cast, overload
 from uuid import uuid4
 
+from ogcat.audit import (
+    AuditEvent,
+    AuditSink,
+    JsonlAuditSink,
+    add_operation_note,
+)
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import (
@@ -36,7 +45,7 @@ from ogcat.storage import (
     plan_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
-from ogcat.transactions import OperationState, UnitOfWork
+from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
 from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 
@@ -59,12 +68,16 @@ class Catalog:
         spec: Catalog specification loaded from or written to ``catalog.json``.
         repository: Record storage backend.
         hook_manager: Dispatcher for lifecycle hooks.
+        audit_sink: Sink for structured operation audit events.
+        audit_user_id: User id recorded on audit events.
     """
 
     root: Path
     spec: CatalogSpec
     repository: CatalogRepository
     hook_manager: HookManager = field(default_factory=HookManager)
+    audit_sink: AuditSink | None = None
+    audit_user_id: str | None = None
 
     @classmethod
     def create(
@@ -74,6 +87,8 @@ class Catalog:
         *,
         plugins: PluginInput = None,
         hooks: HookInput = None,
+        audit_sink: AuditSink | None = None,
+        audit_user_id: str | None = None,
     ) -> Catalog:
         """Create a catalog directory and write its specification.
 
@@ -84,6 +99,9 @@ class Catalog:
                 used to build a hook manager.
             hooks: Optional hook manager, or iterable of hook objects. Pass
                 either ``plugins`` or ``hooks``.
+            audit_sink: Optional audit sink. Defaults to a catalog-local JSONL
+                sink under ``.ogcat/logs/events.jsonl``.
+            audit_user_id: Optional user id to record on audit events.
 
         Returns:
             Open catalog instance bound to ``root``.
@@ -103,6 +121,8 @@ class Catalog:
             spec=spec,
             repository=repository,
             hook_manager=hook_manager,
+            audit_sink=_coerce_audit_sink(root_path, audit_sink),
+            audit_user_id=_resolve_audit_user_id(audit_user_id),
         )
 
     @classmethod
@@ -112,6 +132,8 @@ class Catalog:
         *,
         plugins: PluginInput = None,
         hooks: HookInput = None,
+        audit_sink: AuditSink | None = None,
+        audit_user_id: str | None = None,
     ) -> Catalog:
         """Open an existing catalog from disk.
 
@@ -121,6 +143,9 @@ class Catalog:
                 used to build a hook manager.
             hooks: Optional hook manager, or iterable of hook objects. Pass
                 either ``plugins`` or ``hooks``.
+            audit_sink: Optional audit sink. Defaults to a catalog-local JSONL
+                sink under ``.ogcat/logs/events.jsonl``.
+            audit_user_id: Optional user id to record on audit events.
 
         Returns:
             Open catalog instance bound to ``root``.
@@ -139,6 +164,8 @@ class Catalog:
             spec=spec,
             repository=repository,
             hook_manager=hook_manager,
+            audit_sink=_coerce_audit_sink(root_path, audit_sink),
+            audit_user_id=_resolve_audit_user_id(audit_user_id),
         )
 
     def add_file(
@@ -572,6 +599,48 @@ class Catalog:
         """
         with UnitOfWork(self.repository) as transaction:
             yield transaction
+
+    def audit_events(
+        self,
+        *,
+        user_id: str | None = None,
+        operation_id: str | None = None,
+        record_id: str | None = None,
+        level: str | None = None,
+        event_type: str | None = None,
+        limit: int | None = None,
+    ) -> list[AuditEvent]:
+        """Return catalog-local audit events matching optional filters.
+
+        Args:
+            user_id: Optional user id filter.
+            operation_id: Optional operation id filter.
+            record_id: Optional record id filter.
+            level: Optional event severity filter.
+            event_type: Optional lifecycle event type filter.
+            limit: Optional number of most recent matching events to return.
+
+        Returns:
+            Matching audit events in log order.
+        """
+        sink = self.audit_sink
+        if isinstance(sink, JsonlAuditSink):
+            return sink.read_events(
+                user_id=user_id,
+                operation_id=operation_id,
+                record_id=record_id,
+                level=level,
+                event_type=event_type,
+                limit=limit,
+            )
+        return JsonlAuditSink(self.root).read_events(
+            user_id=user_id,
+            operation_id=operation_id,
+            record_id=record_id,
+            level=level,
+            event_type=event_type,
+            limit=limit,
+        )
 
     def add_artifacts(
         self,
@@ -1142,6 +1211,64 @@ class Catalog:
             ),
         )
 
+    def _emit_audit(self, event: AuditEvent) -> None:
+        """Emit an audit event without failing the catalog operation."""
+        if self.audit_sink is None:
+            return
+        try:
+            self.audit_sink.emit(event)
+        except Exception as exc:
+            warnings.warn(
+                f"audit logging failed: {type(exc).__name__}: {exc}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    def _emit_operation_audit(
+        self,
+        context: OperationContext,
+        *,
+        event_type: str,
+        level: str = "info",
+        message: str,
+        details: Mapping[str, object] | None = None,
+        exception: BaseException | None = None,
+        locator: ArtifactLocator | None = None,
+    ) -> None:
+        """Emit one audit event for an operation context."""
+        raw_event_details = _operation_audit_details(context)
+        if details is not None:
+            raw_event_details.update(details)
+        event_details = normalize_metadata(raw_event_details, field_name="audit.details")
+        locator_details = _audit_locator(locator or _first_planned_locator(context))
+        if exception is None:
+            event = AuditEvent(
+                operation_id=context.operation_id,
+                level=level,
+                event_type=event_type,
+                user_id=self.audit_user_id,
+                catalog_id=self.spec.catalog_name,
+                catalog_path=str(self.root),
+                record_id=context.record_id,
+                locator=locator_details,
+                message=message,
+                details=event_details,
+            )
+        else:
+            event = AuditEvent.from_exception(
+                operation_id=context.operation_id,
+                event_type=event_type,
+                user_id=self.audit_user_id,
+                catalog_id=self.spec.catalog_name,
+                catalog_path=str(self.root),
+                record_id=context.record_id,
+                locator=locator_details,
+                message=message,
+                details=event_details,
+                exception=exception,
+            )
+        self._emit_audit(event)
+
     def _run_add_operation(
         self,
         *,
@@ -1180,8 +1307,17 @@ class Catalog:
             original_filename=original_filename,
             suffixes=[] if suffixes is None else list(suffixes),
         )
+        audit_phase = "operation-started"
+        self._emit_operation_audit(
+            hook_context,
+            event_type="operation-started",
+            message=f"Started {operation_type} operation.",
+            details={"caller_owned_transaction": not commit},
+        )
         try:
+            audit_phase = "before_validate_metadata"
             self.hook_manager.before_validate_metadata(hook_context)
+            audit_phase = "validation"
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
                 schema_name=self._schema_name(schema_record_type),
@@ -1192,11 +1328,20 @@ class Catalog:
                 record_type=schema_record_type,
             )
             self.hook_manager.after_validate_metadata(hook_context, validation_report)
+            self._emit_operation_audit(
+                hook_context,
+                event_type="validation",
+                level=_validation_audit_level(validation_report),
+                message=_validation_audit_message(validation_report),
+                details=_validation_audit_details(validation_report),
+            )
             validation_report.raise_for_errors()
+            audit_phase = "locator-resolution"
             hook_context.planned_locators = [locator_factory(hook_context)]
             self.hook_manager.resolve_artifact_locator(hook_context)
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
+            audit_phase = "storage-plan"
             hook_context.storage_plan = (
                 storage_plan_factory(hook_context, canonical_locator)
                 if storage_plan_factory is not None
@@ -1214,6 +1359,16 @@ class Catalog:
             storage_plan = hook_context.storage_plan
             if storage_plan is None:
                 raise RuntimeError("Add operation did not produce a storage plan.")
+            self._emit_operation_audit(
+                hook_context,
+                event_type="write",
+                message="Storage plan prepared.",
+                details={
+                    "write_phase": "storage-plan",
+                    "storage_plan": _storage_plan_audit_details(storage_plan),
+                },
+                locator=canonical_locator,
+            )
             if naming_metadata is not None:
                 naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
             if artifact_writer is None:
@@ -1222,8 +1377,28 @@ class Catalog:
                         f"Storage plan with write mode {storage_plan.write_mode!r} "
                         "requires an artifact_writer."
                     )
+                self._emit_operation_audit(
+                    hook_context,
+                    event_type="write",
+                    message="Artifact write skipped for reference operation.",
+                    details={"write_phase": "artifact-write", "write_mode": storage_plan.write_mode},
+                    locator=canonical_locator,
+                )
             else:
+                audit_phase = "artifact-write"
                 artifact_writer.write(hook_context, hook_context.source, canonical_locator)
+                self._emit_operation_audit(
+                    hook_context,
+                    event_type="write",
+                    message="Artifact write completed.",
+                    details={
+                        "write_phase": "artifact-write",
+                        "writer_type": type(artifact_writer).__name__,
+                        "write_mode": storage_plan.write_mode,
+                    },
+                    locator=canonical_locator,
+                )
+            audit_phase = "metadata-extraction"
             _add_classification_metadata(hook_context, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
@@ -1232,6 +1407,7 @@ class Catalog:
                 hook_context.derived_metadata,
                 field_name="derived_metadata",
             )
+            audit_phase = "before_record_write"
             self.hook_manager.before_record_write(hook_context)
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
@@ -1253,22 +1429,84 @@ class Catalog:
                 naming_metadata=naming_metadata,
                 time_added=time_added,
             )
+            audit_phase = "record-write"
             persisted = transaction.insert_staged_record(record)
+            hook_context.record_id = _require_record_id(persisted)
+            self._emit_operation_audit(
+                hook_context,
+                event_type="write",
+                message="Record staged.",
+                details={"write_phase": "record-write", "transaction_state": transaction.state.value},
+                locator=canonical_locator,
+            )
+            audit_phase = "after_record_write"
             self.hook_manager.after_record_write(hook_context)
             if commit:
+                audit_phase = "before_commit"
                 self.hook_manager.before_commit(hook_context)
+                audit_phase = "commit"
                 transaction.commit()
+                self._emit_operation_audit(
+                    hook_context,
+                    event_type="commit",
+                    message="Commit succeeded.",
+                    details={"transaction_state": transaction.state.value},
+                    locator=canonical_locator,
+                )
                 # After-commit hooks are best-effort: failures warn, but cannot
                 # turn an already-persisted record into an apparent API failure.
+                audit_phase = "after_commit"
                 self.hook_manager.after_commit(hook_context)
             return persisted
         except Exception as exc:
+            add_operation_note(exc, hook_context.operation_id)
             self.hook_manager.on_error(hook_context, exc)
+            self._emit_operation_audit(
+                hook_context,
+                event_type="failure",
+                message=f"{operation_type} operation failed.",
+                details={
+                    "phase": audit_phase,
+                    "transaction_state": transaction.state.value,
+                    "caller_owned_transaction": not commit,
+                },
+                exception=exc,
+            )
             # Caller-supplied transactions stay caller-owned. Internal
             # transactions commit=True and roll back here before re-raising.
             if commit and transaction.state is not OperationState.COMMITTED:
+                self._emit_operation_audit(
+                    hook_context,
+                    event_type="rollback",
+                    message="Rollback started.",
+                    details={"rollback_phase": "started", "transaction_state": transaction.state.value},
+                )
                 transaction.rollback(original_exception=exc)
                 self.hook_manager.on_rollback(hook_context, exc)
+                if transaction.rollback_errors:
+                    rollback_details: dict[str, object] = {
+                        "rollback_phase": "failed",
+                        "transaction_state": transaction.state.value,
+                        "rollback_errors": _rollback_errors_audit_details(transaction.rollback_errors),
+                    }
+                    self._emit_operation_audit(
+                        hook_context,
+                        event_type="rollback",
+                        level="error",
+                        message="Rollback completed with failures.",
+                        details=rollback_details,
+                        exception=transaction.rollback_errors[0].exception,
+                    )
+                else:
+                    self._emit_operation_audit(
+                        hook_context,
+                        event_type="rollback",
+                        message="Rollback completed.",
+                        details={
+                            "rollback_phase": "completed",
+                            "transaction_state": transaction.state.value,
+                        },
+                    )
             raise
 
     def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
@@ -1419,6 +1657,27 @@ def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     if spec.db_backend != "tinydb":
         raise ValueError(f"Unsupported db_backend: {spec.db_backend}")
     return TinyDbCatalogRepository(root / spec.db_path)
+
+
+def _coerce_audit_sink(root: Path, audit_sink: AuditSink | None) -> AuditSink:
+    """Return an audit sink for a catalog root."""
+    if audit_sink is not None:
+        return audit_sink
+    return JsonlAuditSink(root)
+
+
+def _resolve_audit_user_id(audit_user_id: str | None) -> str | None:
+    """Resolve the audit user id from explicit input, environment, or OS user."""
+    if audit_user_id is not None:
+        return str(audit_user_id)
+    for env_name in ("OGCAT_USER_ID", "OGCAT_USER"):
+        env_value = os.environ.get(env_name)
+        if env_value:
+            return env_value
+    try:
+        return getpass.getuser()
+    except OSError:
+        return None
 
 
 def _coerce_hook_manager(
@@ -1751,6 +2010,110 @@ def _validate_artifact_batch_item(item: object, index: int) -> dict[str, object]
         raise ValueError(f"artifact batch item {index} must not supply {forbidden}")
 
     return item
+
+
+def _operation_audit_details(context: OperationContext) -> dict[str, object]:
+    """Return sanitized operation context details for audit events."""
+    source = context.source
+    return {
+        "operation_type": context.operation_type,
+        "record_type": context.record_type,
+        "storage_mode": context.storage_mode,
+        "record_id": context.record_id,
+        "metadata_keys": sorted(context.user_metadata),
+        "derived_metadata_keys": sorted(context.derived_metadata),
+        "source": {
+            "kind": source.kind,
+            "path": None if source.path is None else str(source.path),
+            "descriptor": source.descriptor,
+            "metadata_keys": sorted(source.metadata),
+            "payload_present": source.payload is not None,
+        },
+        "original_path": None if context.original_path is None else str(context.original_path),
+        "original_filename": context.original_filename,
+        "suffixes": list(context.suffixes),
+        "hook_warning_count": len(context.warnings),
+    }
+
+
+def _audit_locator(locator: ArtifactLocator | None) -> MetadataDict | None:
+    """Return a JSON-compatible locator summary for audit events."""
+    if locator is None:
+        return None
+    return normalize_metadata(locator.to_dict(), field_name="locator")
+
+
+def _first_planned_locator(context: OperationContext) -> ArtifactLocator | None:
+    """Return the first planned locator when one exists."""
+    if not context.planned_locators:
+        return None
+    return context.planned_locators[0]
+
+
+def _validation_audit_level(report: ValidationReport) -> str:
+    """Return the audit level for a validation report."""
+    if report.errors:
+        return "error"
+    if report.warnings:
+        return "warning"
+    return "info"
+
+
+def _validation_audit_message(report: ValidationReport) -> str:
+    """Return a concise validation audit message."""
+    if report.errors:
+        return "Metadata validation failed."
+    if report.warnings:
+        return "Metadata validation completed with warnings."
+    return "Metadata validation succeeded."
+
+
+def _validation_audit_details(report: ValidationReport) -> dict[str, object]:
+    """Return validation issue summaries for audit events."""
+    return {
+        "validation": {
+            "error_count": len(report.errors),
+            "warning_count": len(report.warnings),
+            "issues": [
+                {
+                    "path": issue.path,
+                    "message": issue.message,
+                    "severity": issue.severity,
+                    "code": issue.code,
+                    "hint": issue.hint,
+                }
+                for issue in report.issues
+            ],
+        }
+    }
+
+
+def _storage_plan_audit_details(plan: StoragePlan) -> dict[str, object]:
+    """Return storage plan details that are safe for audit logging."""
+    return {
+        "target_kind": plan.target_kind,
+        "write_mode": plan.write_mode,
+        "checksum": plan.checksum,
+        "ogcat_owned": plan.ogcat_owned,
+        "profile": plan.profile,
+        "adapter": plan.adapter,
+        "time_added": plan.time_added,
+        "storage_relative_path": plan.storage_relative_path,
+        "resolved_directory": plan.resolved_directory,
+        "resolved_filename": plan.resolved_filename,
+    }
+
+
+def _rollback_errors_audit_details(rollback_errors: list[RollbackFailure]) -> list[dict[str, str]]:
+    """Return rollback failure summaries for audit events."""
+    return [
+        {
+            "description": failure.description,
+            "exception_type": type(failure.exception).__name__,
+            "exception_message": str(failure.exception),
+        }
+        for failure in rollback_errors
+    ]
 
 
 def _require_record_id(record: CatalogRecord) -> str:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -14,6 +14,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from ogcat.audit import exception_operation_id
 from ogcat.catalog import Catalog
 from ogcat.models import CatalogRecord
 from ogcat.record_set import CatalogRecordSet
@@ -36,6 +37,15 @@ def _fail(message: str, *, code: int = 1) -> NoReturn:
     """Print a consistent error message and exit."""
     error_console.print(f"Error: {message}")
     raise typer.Exit(code=code)
+
+
+def _format_exception_message(exc: Exception) -> str:
+    """Return a CLI error message with operation id context when available."""
+    message = str(exc)
+    operation_id = exception_operation_id(exc)
+    if operation_id is None:
+        return message
+    return f"{message} (operation_id: {operation_id})"
 
 
 def _resolve_catalog_path(catalog: Path | None) -> Path:
@@ -339,9 +349,79 @@ def add_command(
             operation=operation,
             record_type=record_type,
         )
-    except ValueError as exc:
-        _fail(str(exc))
+    except Exception as exc:
+        _fail(_format_exception_message(exc))
     console.print(f"Added {record.id}: {record.stored_abspath}")
+
+
+@app.command()
+def logs(
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    user_id: Annotated[
+        str | None,
+        typer.Option("--user", help="Show events for this user id."),
+    ] = None,
+    operation_id: Annotated[
+        str | None,
+        typer.Option("--operation", help="Show events for this operation id."),
+    ] = None,
+    record_id: Annotated[
+        str | None,
+        typer.Option("--record", help="Show events for this record id."),
+    ] = None,
+    level: Annotated[
+        str | None,
+        typer.Option("--level", help="Show events at this level."),
+    ] = None,
+    event_type: Annotated[
+        str | None,
+        typer.Option("--event-type", help="Show events with this event type."),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", min=0, help="Show only the most recent matching events."),
+    ] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print matching audit events as JSON."),
+    ] = False,
+) -> None:
+    """Show catalog audit events."""
+    active_catalog = _open_catalog_or_fail(catalog)
+    events = active_catalog.audit_events(
+        user_id=user_id,
+        operation_id=operation_id,
+        record_id=record_id,
+        level=level,
+        event_type=event_type,
+        limit=limit,
+    )
+
+    if json_mode:
+        _print_json([event.to_dict() for event in events])
+        return
+
+    if not events:
+        console.print("No audit events matched.")
+        return
+
+    table = Table(title="ogcat audit events")
+    table.add_column("timestamp", overflow="fold")
+    table.add_column("level")
+    table.add_column("event")
+    table.add_column("operation")
+    table.add_column("record")
+    table.add_column("message", overflow="fold")
+    for event in events:
+        table.add_row(
+            event.timestamp_utc,
+            event.level,
+            event.event_type,
+            event.operation_id,
+            event.record_id or "",
+            event.message,
+        )
+    console.print(table)
 
 
 @app.command(

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -198,6 +198,7 @@ class OperationContext:
         operation_type: Catalog operation name, such as ``"add_file"``.
         record_type: Record type being created.
         user_metadata: User-supplied metadata, mutable by hooks before validation.
+        record_id: Persisted record id, set after a record write succeeds.
         derived_metadata: Derived metadata collected during the operation.
         planned_locators: Locators planned or supplied for the operation.
         register_rollback: Low-level rollback registrar. Hook authors should
@@ -215,6 +216,7 @@ class OperationContext:
     operation_type: str
     record_type: str
     user_metadata: MetadataDict
+    record_id: str | None = None
     derived_metadata: MetadataDict = field(default_factory=dict)
     planned_locators: list[ArtifactLocator] = field(default_factory=list)
     register_rollback: RollbackRegistrar | None = None

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,171 @@
+"""Structured audit logging tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import ArtifactLocator, Catalog, CatalogSpec
+from ogcat.audit import (
+    AUDIT_LOG_RELATIVE_PATH,
+    AuditEvent,
+    JsonlAuditSink,
+    exception_operation_id,
+    redact_sensitive_values,
+)
+from ogcat.hooks import OperationContext, OperationSource
+
+
+def _source_file(tmp_path: Path, name: str = "source.nc") -> Path:
+    """Create a small source file for add tests."""
+    source = tmp_path / name
+    source.write_text("dummy", encoding="utf-8")
+    return source
+
+
+def test_successful_add_writes_structured_audit_events(tmp_path: Path) -> None:
+    """Successful add operations should write the expected lifecycle events."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        audit_user_id="alice",
+    )
+
+    record = catalog.add_file(_source_file(tmp_path))
+
+    events = catalog.audit_events()
+    event_types = [event.event_type for event in events]
+    assert event_types[:2] == ["operation-started", "validation"]
+    assert "write" in event_types
+    assert event_types[-1] == "commit"
+    assert "failure" not in event_types
+    assert "rollback" not in event_types
+    assert {event.operation_id for event in events} == {events[0].operation_id}
+    assert {event.user_id for event in events} == {"alice"}
+    assert {event.catalog_path for event in events} == {str(catalog.root)}
+    assert any(event.record_id == record.id and event.event_type == "commit" for event in events)
+    assert (catalog.root / AUDIT_LOG_RELATIVE_PATH).exists()
+
+
+def test_failed_add_writes_failure_and_rollback_events(tmp_path: Path) -> None:
+    """A failed add should log the failure, rollback, and operation id."""
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("simulated audit failure path")
+
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        hooks=[FailingHook()],
+        audit_user_id="alice",
+    )
+    source = _source_file(tmp_path, "failure.nc")
+
+    with pytest.raises(RuntimeError, match="simulated audit failure path") as exc_info:
+        catalog.add_file(source)
+
+    operation_id = exception_operation_id(exc_info.value)
+    assert operation_id is not None
+    events = catalog.audit_events(operation_id=operation_id)
+    event_types = [event.event_type for event in events]
+    assert "failure" in event_types
+    assert event_types.count("rollback") == 2
+    failure = next(event for event in events if event.event_type == "failure")
+    assert failure.exception_type == "RuntimeError"
+    assert failure.details["phase"] == "before_record_write"
+    rollback_events = [event for event in events if event.event_type == "rollback"]
+    assert rollback_events[-1].message == "Rollback completed."
+    assert catalog.repository.all() == []
+    assert source.exists()
+    assert list((catalog.root / catalog.spec.files_root).rglob("failure.nc")) == []
+
+
+def test_audit_events_filter_by_user_operation_and_record(tmp_path: Path) -> None:
+    """Audit event filters should narrow results by user, operation, and record."""
+    root = tmp_path / "catalog"
+    alice_catalog = Catalog.create(root, CatalogSpec(catalog_name="artifacts"), audit_user_id="alice")
+    alice_record = alice_catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/alice.zarr"),
+    )
+    bob_catalog = Catalog.open(root, audit_user_id="bob")
+    bob_record = bob_catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/bob.zarr"),
+    )
+    alice_operation = next(
+        event.operation_id
+        for event in alice_catalog.audit_events(record_id=alice_record.id)
+        if event.event_type == "commit"
+    )
+    bob_operation = next(
+        event.operation_id
+        for event in bob_catalog.audit_events(record_id=bob_record.id)
+        if event.event_type == "commit"
+    )
+
+    assert {event.user_id for event in bob_catalog.audit_events(user_id="alice")} == {"alice"}
+    assert {event.operation_id for event in bob_catalog.audit_events(operation_id=alice_operation)} == {
+        alice_operation
+    }
+    assert {event.record_id for event in bob_catalog.audit_events(record_id=bob_record.id)} == {bob_record.id}
+    assert bob_catalog.audit_events(operation_id=alice_operation)
+    assert bob_catalog.audit_events(operation_id=bob_operation)
+
+
+def test_sensitive_audit_details_are_redacted() -> None:
+    """Sensitive-looking keys should have their values redacted recursively."""
+    event = AuditEvent(
+        operation_id="op-1",
+        level="info",
+        event_type="operation-started",
+        message="started",
+        details={
+            "api_key": "abc123",
+            "nested": {"password": "pw", "safe": "kept"},
+            "items": [{"secret_token": "token-value"}],
+        },
+    )
+
+    assert event.details["api_key"] == "[REDACTED]"
+    assert event.details["nested"] == {"password": "[REDACTED]", "safe": "kept"}
+    assert event.details["items"] == [{"secret_token": "[REDACTED]"}]
+    assert redact_sensitive_values({"private_key": "key"})["private_key"] == "[REDACTED]"
+
+
+def test_corrupt_audit_log_lines_are_skipped(tmp_path: Path) -> None:
+    """A corrupt JSONL line should warn without hiding valid audit events."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_file(_source_file(tmp_path))
+    log_path = JsonlAuditSink(catalog.root).path
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("{not-json}\n")
+
+    with pytest.warns(RuntimeWarning, match="Skipping corrupt audit log line"):
+        events = catalog.audit_events()
+
+    assert [event.event_type for event in events]
+    assert all(event.event_type != "unknown" for event in events)
+
+
+def test_audit_logs_do_not_record_operation_source_payloads(tmp_path: Path) -> None:
+    """OperationSource payload contents should not be written to audit logs."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    payload = {"contents": "DO-NOT-LOG-PAYLOAD"}
+
+    catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/payload.zarr"),
+        source=OperationSource(
+            kind="memory",
+            descriptor="payload source",
+            metadata={"api_key": "DO-NOT-LOG-KEY"},
+            payload=payload,
+        ),
+    )
+
+    raw_log = JsonlAuditSink(catalog.root).path.read_text(encoding="utf-8")
+    assert "DO-NOT-LOG-PAYLOAD" not in raw_log
+    assert "DO-NOT-LOG-KEY" not in raw_log

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -48,6 +48,38 @@ def test_successful_add_writes_structured_audit_events(tmp_path: Path) -> None:
     assert (catalog.root / AUDIT_LOG_RELATIVE_PATH).exists()
 
 
+def test_registered_hook_phases_emit_formal_audit_events(tmp_path: Path) -> None:
+    """Hook audit events should describe the method and phase consistently."""
+
+    class AuditedHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            context.user_metadata["hooked"] = True
+
+        def before_commit(self, context: OperationContext) -> None:
+            context.add_warning("commit hook warning", hook_name="AuditedHook")
+
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        hooks=[AuditedHook()],
+    )
+
+    catalog.add_file(_source_file(tmp_path))
+
+    hook_events = [event for event in catalog.audit_events(event_type="hook")]
+    hook_methods_and_phases = [
+        (event.details["hook_method"], event.details["hook_phase"], event.level) for event in hook_events
+    ]
+    assert hook_methods_and_phases == [
+        ("before_validate_metadata", "started", "info"),
+        ("before_validate_metadata", "completed", "info"),
+        ("before_commit", "started", "info"),
+        ("before_commit", "completed", "warning"),
+    ]
+    assert all(event.details["hook_count"] == 1 for event in hook_events)
+    assert hook_events[-1].details["warnings_added"] == 1
+
+
 def test_failed_add_writes_failure_and_rollback_events(tmp_path: Path) -> None:
     """A failed add should log the failure, rollback, and operation id."""
 
@@ -75,6 +107,11 @@ def test_failed_add_writes_failure_and_rollback_events(tmp_path: Path) -> None:
     failure = next(event for event in events if event.event_type == "failure")
     assert failure.exception_type == "RuntimeError"
     assert failure.details["phase"] == "before_record_write"
+    hook_failure = next(
+        event for event in events if event.event_type == "hook" and event.details["hook_phase"] == "failed"
+    )
+    assert hook_failure.details["hook_method"] == "before_record_write"
+    assert hook_failure.exception_type == "RuntimeError"
     rollback_events = [event for event in events if event.event_type == "rollback"]
     assert rollback_events[-1].message == "Rollback completed."
     assert catalog.repository.all() == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,6 +743,59 @@ def test_add_accepts_json_object_metadata(tmp_path: Path) -> None:
     assert record.user_metadata == {"species": "CO2", "month": 1}
 
 
+def test_logs_json_filters_by_user(tmp_path: Path) -> None:
+    """The logs command should expose filtered structured audit events."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="fluxes"),
+        audit_user_id="cli-user",
+    )
+    source = tmp_path / "source.nc"
+    source.write_text("dummy", encoding="utf-8")
+    record = catalog.add_file(source, metadata={"species": "CO2"})
+
+    result = runner.invoke(
+        app,
+        ["logs", "--catalog", str(catalog.root), "--user", "cli-user", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(strip_ansi(result.stdout))
+    assert {event["user_id"] for event in payload} == {"cli-user"}
+    assert "operation-started" in {event["event_type"] for event in payload}
+    assert any(
+        event["event_type"] == "commit" and event["record_id"] == _record_id(record) for event in payload
+    )
+
+
+def test_add_failure_error_includes_operation_id(tmp_path: Path) -> None:
+    """CLI add failures should expose the operation id for audit correlation."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="fluxes",
+            default_schema=RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="species",
+                        description="Gas species.",
+                        required=True,
+                    )
+                ]
+            ),
+        ),
+    )
+    source = tmp_path / "source.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    result = runner.invoke(app, ["add", str(source), "--catalog", str(catalog.root)])
+
+    assert result.exit_code == 1
+    stderr = strip_ansi(result.stderr)
+    assert "Missing required metadata for schema default: species" in stderr
+    assert "operation_id:" in stderr
+
+
 def test_show_missing_record_returns_helpful_error(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
 


### PR DESCRIPTION
## Summary
- Add a catalog-local JSONL audit log with structured `AuditEvent` records, redaction, tolerant reads, and filtering helpers.
- Wire add-operation lifecycle auditing into validation, write, commit, rollback, and failure paths, and surface `operation_id` in user-facing add errors where available.
- Add `ogcat logs` plus docs and ADRs for the new logging and hook-lifecycle direction.

## Testing
- Added unit tests for successful add logging, failure and rollback logging, filtering, redaction, and corrupt-line tolerance.
- Added CLI coverage for log filtering and operation-id error reporting.
- Full test suite, type checking, formatting, and docs build all passed.