### PR TITLE
Add operation-scoped hook dispatchers and lifecycle audit events

### DIFF
--- a/docs/adr/0001-operation-scoped-hook-lifecycle-observation.md
+++ b/docs/adr/0001-operation-scoped-hook-lifecycle-observation.md
@@ -1,6 +1,6 @@
 # ADR 0001: Operation-Scoped Hook Lifecycle Observation
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-05-14
 - **Related issues**: [openghg/ogcat#75](https://github.com/openghg/ogcat/issues/75)
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -23,7 +23,9 @@ from ogcat.audit import (
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import (
+    HOOK_PHASES,
     ArtifactWriter,
+    HookLifecycleEvent,
     HookManager,
     OperationContext,
     OperationSource,
@@ -56,67 +58,6 @@ PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
-
-
-@dataclass(frozen=True, slots=True)
-class _HookAuditPhase:
-    """Audit metadata for one hook dispatch phase."""
-
-    phase: str
-    method_name: str
-    label: str
-
-
-_BEFORE_VALIDATE_METADATA_HOOKS = _HookAuditPhase(
-    phase="before_validate_metadata",
-    method_name="before_validate_metadata",
-    label="before-validate metadata",
-)
-_AFTER_VALIDATE_METADATA_HOOKS = _HookAuditPhase(
-    phase="after_validate_metadata",
-    method_name="after_validate_metadata",
-    label="after-validate metadata",
-)
-_RESOLVE_ARTIFACT_LOCATOR_HOOKS = _HookAuditPhase(
-    phase="resolve_artifact_locator",
-    method_name="resolve_artifact_locator",
-    label="artifact locator resolution",
-)
-_EXTRACT_METADATA_HOOKS = _HookAuditPhase(
-    phase="extract_metadata",
-    method_name="extract_metadata",
-    label="metadata extraction",
-)
-_BEFORE_RECORD_WRITE_HOOKS = _HookAuditPhase(
-    phase="before_record_write",
-    method_name="before_record_write",
-    label="before-record-write",
-)
-_AFTER_RECORD_WRITE_HOOKS = _HookAuditPhase(
-    phase="after_record_write",
-    method_name="after_record_write",
-    label="after-record-write",
-)
-_BEFORE_COMMIT_HOOKS = _HookAuditPhase(
-    phase="before_commit",
-    method_name="before_commit",
-    label="before-commit",
-)
-_AFTER_COMMIT_HOOKS = _HookAuditPhase(
-    phase="after_commit",
-    method_name="after_commit",
-    label="after-commit",
-)
-_ON_ERROR_HOOKS = _HookAuditPhase(
-    phase="on_error",
-    method_name="on_error",
-    label="operation error",
-)
-_ON_ROLLBACK_HOOKS = _HookAuditPhase(
-    phase="on_rollback",
-    method_name="on_rollback",
-    label="operation rollback",
-)
 
 
 @dataclass(slots=True)
@@ -401,7 +342,8 @@ class Catalog:
             suffixes=[] if source_path is None else list(source_path.suffixes),
         )
 
-        self.hook_manager.before_validate_metadata(context)
+        hook_dispatcher = self.hook_manager.dispatcher()
+        hook_dispatcher.before_validate_metadata(context)
         context.user_metadata = _normalize_metadata_for_schema(
             context.user_metadata,
             schema_name=schema_name,
@@ -411,7 +353,7 @@ class Catalog:
             metadata=context.user_metadata,
             record_type=record_type,
         )
-        self.hook_manager.after_validate_metadata(context, validation_report)
+        hook_dispatcher.after_validate_metadata(context, validation_report)
         validation_report.raise_for_errors()
 
         if locator is None:
@@ -434,7 +376,7 @@ class Catalog:
             resolved_directory = _directory_from_locator(locator)
             resolved_filename = _filename_from_locator(locator)
         context.planned_locators = [planned_locator]
-        self.hook_manager.resolve_artifact_locator(context)
+        hook_dispatcher.resolve_artifact_locator(context)
         canonical_locator = _artifact_locator_from_context(context)
         if canonical_locator != planned_locator:
             storage_relative_path = canonical_locator.relative_path
@@ -1330,58 +1272,46 @@ class Catalog:
             )
         self._emit_audit(event)
 
-    def _run_hook_audit_phase(
-        self,
-        context: OperationContext,
-        phase: _HookAuditPhase,
-        callback: Callable[[], None],
-    ) -> None:
-        """Run one hook phase and emit structured audit events when hooks exist."""
-        hook_count = _hook_count(self.hook_manager, phase.method_name)
-        if hook_count == 0:
-            callback()
-            return
-
-        base_details = {
-            "phase": phase.phase,
-            "hook_method": phase.method_name,
-            "hook_count": hook_count,
+    def _emit_hook_lifecycle_audit(self, event: HookLifecycleEvent) -> None:
+        """Convert a hook lifecycle event into a structured audit event."""
+        details: dict[str, object] = {
+            "phase": event.phase.name,
+            "hook_method": event.phase.name,
+            "hook_count": event.hook_count,
+            "hook_phase": event.stage,
         }
-        self._emit_operation_audit(
-            context,
-            event_type="hook",
-            message=f"{phase.label} hooks started.",
-            details={**base_details, "hook_phase": "started"},
-        )
-        warning_count_before = len(context.warnings)
-        try:
-            callback()
-        except Exception as exc:
+        if event.stage == "completed":
+            details["warnings_added"] = event.warnings_added
+
+        if event.stage == "started":
             self._emit_operation_audit(
-                context,
+                event.context,
+                event_type="hook",
+                message=f"{event.phase.label} hooks started.",
+                details=details,
+            )
+            return
+        if event.stage == "failed":
+            self._emit_operation_audit(
+                event.context,
                 event_type="hook",
                 level="error",
-                message=f"{phase.label} hooks failed.",
-                details={**base_details, "hook_phase": "failed"},
-                exception=exc,
+                message=f"{event.phase.label} hooks failed.",
+                details=details,
+                exception=event.error,
             )
-            raise
+            return
 
-        warnings_added = len(context.warnings) - warning_count_before
         self._emit_operation_audit(
-            context,
+            event.context,
             event_type="hook",
-            level="warning" if warnings_added else "info",
+            level="warning" if event.warnings_added else "info",
             message=(
-                f"{phase.label} hooks completed with warnings."
-                if warnings_added
-                else f"{phase.label} hooks completed."
+                f"{event.phase.label} hooks completed with warnings."
+                if event.warnings_added
+                else f"{event.phase.label} hooks completed."
             ),
-            details={
-                **base_details,
-                "hook_phase": "completed",
-                "warnings_added": warnings_added,
-            },
+            details=details,
         )
 
     def _run_add_operation(
@@ -1422,6 +1352,7 @@ class Catalog:
             original_filename=original_filename,
             suffixes=[] if suffixes is None else list(suffixes),
         )
+        hook_dispatcher = self.hook_manager.dispatcher(notify=self._emit_hook_lifecycle_audit)
         current_phase = "operation-started"
         self._emit_operation_audit(
             hook_context,
@@ -1430,12 +1361,8 @@ class Catalog:
             details={"caller_owned_transaction": not commit},
         )
         try:
-            current_phase = _BEFORE_VALIDATE_METADATA_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _BEFORE_VALIDATE_METADATA_HOOKS,
-                lambda: self.hook_manager.before_validate_metadata(hook_context),
-            )
+            current_phase = HOOK_PHASES["before_validate_metadata"].name
+            hook_dispatcher.before_validate_metadata(hook_context)
             current_phase = "validation"
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
@@ -1446,12 +1373,8 @@ class Catalog:
                 metadata=hook_context.user_metadata,
                 record_type=schema_record_type,
             )
-            current_phase = _AFTER_VALIDATE_METADATA_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _AFTER_VALIDATE_METADATA_HOOKS,
-                lambda: self.hook_manager.after_validate_metadata(hook_context, validation_report),
-            )
+            current_phase = HOOK_PHASES["after_validate_metadata"].name
+            hook_dispatcher.after_validate_metadata(hook_context, validation_report)
             self._emit_operation_audit(
                 hook_context,
                 event_type="validation",
@@ -1462,12 +1385,8 @@ class Catalog:
             validation_report.raise_for_errors()
             current_phase = "locator-factory"
             hook_context.planned_locators = [locator_factory(hook_context)]
-            current_phase = _RESOLVE_ARTIFACT_LOCATOR_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _RESOLVE_ARTIFACT_LOCATOR_HOOKS,
-                lambda: self.hook_manager.resolve_artifact_locator(hook_context),
-            )
+            current_phase = HOOK_PHASES["resolve_artifact_locator"].name
+            hook_dispatcher.resolve_artifact_locator(hook_context)
             canonical_locator = _artifact_locator_from_context(hook_context)
             hook_context.planned_locators[0] = canonical_locator
             current_phase = "storage-plan"
@@ -1531,22 +1450,14 @@ class Catalog:
             _add_classification_metadata(hook_context, canonical_locator)
             if derived_metadata_collector is not None:
                 derived_metadata_collector(hook_context, canonical_locator)
-            current_phase = _EXTRACT_METADATA_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _EXTRACT_METADATA_HOOKS,
-                lambda: self.hook_manager.extract_metadata(hook_context),
-            )
+            current_phase = HOOK_PHASES["extract_metadata"].name
+            hook_dispatcher.extract_metadata(hook_context)
             hook_context.derived_metadata = normalize_metadata(
                 hook_context.derived_metadata,
                 field_name="derived_metadata",
             )
-            current_phase = _BEFORE_RECORD_WRITE_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _BEFORE_RECORD_WRITE_HOOKS,
-                lambda: self.hook_manager.before_record_write(hook_context),
-            )
+            current_phase = HOOK_PHASES["before_record_write"].name
+            hook_dispatcher.before_record_write(hook_context)
             hook_context.user_metadata = _normalize_metadata_for_schema(
                 hook_context.user_metadata,
                 schema_name=self._schema_name(schema_record_type),
@@ -1577,19 +1488,11 @@ class Catalog:
                 details={"write_phase": "record-write", "transaction_state": transaction.state.value},
                 locator=canonical_locator,
             )
-            current_phase = _AFTER_RECORD_WRITE_HOOKS.phase
-            self._run_hook_audit_phase(
-                hook_context,
-                _AFTER_RECORD_WRITE_HOOKS,
-                lambda: self.hook_manager.after_record_write(hook_context),
-            )
+            current_phase = HOOK_PHASES["after_record_write"].name
+            hook_dispatcher.after_record_write(hook_context)
             if commit:
-                current_phase = _BEFORE_COMMIT_HOOKS.phase
-                self._run_hook_audit_phase(
-                    hook_context,
-                    _BEFORE_COMMIT_HOOKS,
-                    lambda: self.hook_manager.before_commit(hook_context),
-                )
+                current_phase = HOOK_PHASES["before_commit"].name
+                hook_dispatcher.before_commit(hook_context)
                 current_phase = "commit"
                 transaction.commit()
                 self._emit_operation_audit(
@@ -1601,20 +1504,12 @@ class Catalog:
                 )
                 # After-commit hooks are best-effort: failures warn, but cannot
                 # turn an already-persisted record into an apparent API failure.
-                current_phase = _AFTER_COMMIT_HOOKS.phase
-                self._run_hook_audit_phase(
-                    hook_context,
-                    _AFTER_COMMIT_HOOKS,
-                    lambda: self.hook_manager.after_commit(hook_context),
-                )
+                current_phase = HOOK_PHASES["after_commit"].name
+                hook_dispatcher.after_commit(hook_context)
             return persisted
         except Exception as exc:
             add_operation_note(exc, hook_context.operation_id)
-            self._run_hook_audit_phase(
-                hook_context,
-                _ON_ERROR_HOOKS,
-                lambda error=exc: self.hook_manager.on_error(hook_context, error),
-            )
+            hook_dispatcher.on_error(hook_context, exc)
             self._emit_operation_audit(
                 hook_context,
                 event_type="failure",
@@ -1636,11 +1531,7 @@ class Catalog:
                     details={"rollback_phase": "started", "transaction_state": transaction.state.value},
                 )
                 transaction.rollback(original_exception=exc)
-                self._run_hook_audit_phase(
-                    hook_context,
-                    _ON_ROLLBACK_HOOKS,
-                    lambda error=exc: self.hook_manager.on_rollback(hook_context, error),
-                )
+                hook_dispatcher.on_rollback(hook_context, exc)
                 if transaction.rollback_errors:
                     rollback_details: dict[str, object] = {
                         "rollback_phase": "failed",
@@ -2192,11 +2083,6 @@ def _operation_audit_details(context: OperationContext) -> dict[str, object]:
         "suffixes": list(context.suffixes),
         "hook_warning_count": len(context.warnings),
     }
-
-
-def _hook_count(hook_manager: HookManager, method_name: str) -> int:
-    """Return the number of registered hooks with a callable lifecycle method."""
-    return sum(1 for hook in hook_manager.hooks if callable(getattr(hook, method_name, None)))
 
 
 def _audit_locator(locator: ArtifactLocator | None) -> MetadataDict | None:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -69,7 +69,7 @@ class Catalog:
             managed files.
         spec: Catalog specification loaded from or written to ``catalog.json``.
         repository: Record storage backend.
-        hook_manager: Dispatcher for lifecycle hooks.
+        hook_manager: Long-lived hook registry.
         audit_sink: Sink for structured operation audit events.
         audit_user_id: User id recorded on audit events.
     """

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -10,15 +10,16 @@ derived metadata, rollback registrar, and accumulated hook warnings.
 The design intentionally keeps hook classes lightweight. Plugin authors do not
 subclass a base class; they implement one or more protocol methods, usually with
 ``context: OperationContext`` and ``-> None`` or ``-> MetadataDict | None`` type
-hints. ``HookManager`` dispatches protocols in deterministic registration order,
-merges returned derived metadata, records non-fatal after-commit failures as
-warnings, and preserves the original exception when error or rollback hooks
+hints. ``HookManager`` stores the long-lived hook registry. Operation-scoped
+``HookDispatcher`` instances dispatch protocols in deterministic registration
+order, merge returned derived metadata, record non-fatal after-commit failures
+as warnings, and preserve the original exception when error or rollback hooks
 fail.
 
-``HOOK_METHOD_NAMES`` is the validation source of truth for ad hoc hook object
-inputs. When adding a lifecycle protocol to this module, add its method name to
-that tuple so ``Catalog.open()`` and ``Catalog.create()`` accept hooks that only
-implement the new stage.
+``_HOOK_PHASE_SEQUENCE`` defines formal hook phases, and ``HOOK_PHASES`` is the
+public mapping used during dispatch and validation. ``HOOK_METHOD_NAMES`` is
+derived from that source of truth for compatibility with existing validation
+callers.
 
 Artifact writers use the same context model. Any object satisfying
 :class:`ArtifactWriter` can materialise an :class:`ogcat.models.ArtifactLocator`
@@ -56,6 +57,7 @@ class HookPhase:
     label: str
 
 
+# Source of truth for lifecycle hook phase registration.
 _HOOK_PHASE_SEQUENCE = (
     HookPhase("before_validate_metadata", "before-validate metadata"),
     HookPhase("after_validate_metadata", "after-validate metadata"),
@@ -404,6 +406,8 @@ class ErrorHook(Protocol):
 class HookDispatcher:
     """Operation-scoped dispatcher for registered catalog hooks.
 
+    The dispatcher snapshots hooks for one operation.
+
     Args:
         hooks: Hook objects available to this operation.
         notify: Optional lifecycle callback for this operation.
@@ -576,7 +580,7 @@ class HookManager:
     """Long-lived registry for catalog hooks."""
 
     def __init__(self, hooks: Iterable[object] = ()) -> None:
-        self._hooks = list(hooks)
+        self._hooks = validate_hook_objects(hooks, label="hooks")
 
     @property
     def hooks(self) -> tuple[object, ...]:
@@ -585,8 +589,9 @@ class HookManager:
 
     def register(self, hook: object) -> object:
         """Register a hook object and return it for decorator-style usage."""
-        self._hooks.append(hook)
-        return hook
+        validated = validate_hook_objects([hook], label="hooks")
+        self._hooks.append(validated[0])
+        return validated[0]
 
     def dispatcher(self, notify: HookLifecycleCallback | None = None) -> HookDispatcher:
         """Return an operation-scoped hook dispatcher."""

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -28,28 +28,72 @@ from an :class:`OperationSource` before the catalog record is committed.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from types import MappingProxyType
+from typing import Literal, Protocol, cast, runtime_checkable
 
 from ogcat.models import ArtifactLocator, MetadataDict
 from ogcat.storage import StoragePlan
 from ogcat.transactions import RollbackAction
 from ogcat.validation import ValidationReport
 
-HOOK_METHOD_NAMES = (
-    "before_validate_metadata",
-    "after_validate_metadata",
-    "resolve_artifact_locator",
-    "before_record_write",
-    "after_record_write",
-    "extract_metadata",
-    "before_commit",
-    "after_commit",
-    "on_error",
-    "on_rollback",
+HookLifecycleStage = Literal["started", "completed", "failed"]
+_HookMethod = Callable[..., object]
+
+
+@dataclass(frozen=True, slots=True)
+class HookPhase:
+    """Formal metadata for one hook dispatch phase.
+
+    Args:
+        name: Hook method name used to select participating hooks.
+        label: Human-readable phase label for diagnostics.
+    """
+
+    name: str
+    label: str
+
+
+_HOOK_PHASE_SEQUENCE = (
+    HookPhase("before_validate_metadata", "before-validate metadata"),
+    HookPhase("after_validate_metadata", "after-validate metadata"),
+    HookPhase("resolve_artifact_locator", "artifact locator resolution"),
+    HookPhase("before_record_write", "before-record-write"),
+    HookPhase("after_record_write", "after-record-write"),
+    HookPhase("extract_metadata", "metadata extraction"),
+    HookPhase("before_commit", "before-commit"),
+    HookPhase("after_commit", "after-commit"),
+    HookPhase("on_error", "operation error"),
+    HookPhase("on_rollback", "operation rollback"),
 )
+HOOK_PHASES: Mapping[str, HookPhase] = MappingProxyType({phase.name: phase for phase in _HOOK_PHASE_SEQUENCE})
+HOOK_METHOD_NAMES = tuple(HOOK_PHASES)
+
+
+@dataclass(frozen=True, slots=True)
+class HookLifecycleEvent:
+    """Lifecycle notification emitted around one hook dispatch phase.
+
+    Args:
+        phase: Formal hook phase metadata.
+        stage: Dispatch stage.
+        context: Operation context supplied to the hook phase.
+        hook_count: Number of hooks participating in this phase.
+        warnings_added: Number of context warnings added during dispatch.
+        error: Exception raised by the phase, if dispatch failed.
+    """
+
+    phase: HookPhase
+    stage: HookLifecycleStage
+    context: OperationContext
+    hook_count: int
+    warnings_added: int = 0
+    error: BaseException | None = None
+
+
+HookLifecycleCallback = Callable[[HookLifecycleEvent], None]
 
 
 def coerce_hook_iterable(value: object, *, label: str) -> list[object]:
@@ -357,8 +401,179 @@ class ErrorHook(Protocol):
         ...
 
 
+class HookDispatcher:
+    """Operation-scoped dispatcher for registered catalog hooks.
+
+    Args:
+        hooks: Hook objects available to this operation.
+        notify: Optional lifecycle callback for this operation.
+    """
+
+    def __init__(self, hooks: Iterable[object], notify: HookLifecycleCallback | None = None) -> None:
+        self._hooks = tuple(hooks)
+        self._notify = notify
+
+    def before_validate_metadata(self, context: OperationContext) -> None:
+        """Dispatch ``before_validate_metadata`` hooks."""
+        self._dispatch_context_method(HOOK_PHASES["before_validate_metadata"], context)
+
+    def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+        """Dispatch ``after_validate_metadata`` hooks."""
+
+        def invoke(_hook: object, method: _HookMethod) -> None:
+            method(context, report)
+
+        self._dispatch(HOOK_PHASES["after_validate_metadata"], context, invoke)
+
+    def resolve_artifact_locator(self, context: OperationContext) -> None:
+        """Dispatch ``resolve_artifact_locator`` hooks."""
+        self._dispatch_context_method(HOOK_PHASES["resolve_artifact_locator"], context)
+
+    def before_record_write(self, context: OperationContext) -> None:
+        """Dispatch ``before_record_write`` hooks."""
+        self._dispatch_context_method(HOOK_PHASES["before_record_write"], context)
+
+    def after_record_write(self, context: OperationContext) -> None:
+        """Dispatch ``after_record_write`` hooks."""
+        self._dispatch_context_method(HOOK_PHASES["after_record_write"], context)
+
+    def extract_metadata(self, context: OperationContext) -> None:
+        """Dispatch metadata extraction hooks and merge returned metadata."""
+
+        def invoke(_hook: object, method: _HookMethod) -> None:
+            extracted = method(context)
+            if extracted is not None:
+                context.derived_metadata.update(cast(MetadataDict, extracted))
+
+        self._dispatch(HOOK_PHASES["extract_metadata"], context, invoke)
+
+    def before_commit(self, context: OperationContext) -> None:
+        """Dispatch ``before_commit`` hooks."""
+        self._dispatch_context_method(HOOK_PHASES["before_commit"], context)
+
+    def after_commit(self, context: OperationContext) -> None:
+        """Dispatch ``after_commit`` hooks without failing committed work."""
+
+        def invoke(hook: object, method: _HookMethod) -> None:
+            try:
+                method(context)
+            except Exception as exc:
+                warning = HookWarning(
+                    hook_name=type(hook).__name__,
+                    message=f"after_commit hook failed: {type(exc).__name__}: {exc}",
+                    code="hook.after_commit_failed",
+                )
+                context.add_warning(warning)
+                warnings.warn(
+                    f"{warning.hook_name}: {warning.message}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
+        self._dispatch(HOOK_PHASES["after_commit"], context, invoke)
+
+    def on_error(self, context: OperationContext, error: BaseException) -> None:
+        """Dispatch error hooks, preserving the original operation failure."""
+
+        def invoke(_hook: object, method: _HookMethod) -> None:
+            try:
+                method(context, error)
+            except Exception as exc:
+                error.add_note(f"error hook failed: {type(exc).__name__}: {exc}")
+
+        self._dispatch(HOOK_PHASES["on_error"], context, invoke)
+
+    def on_rollback(self, context: OperationContext, error: BaseException) -> None:
+        """Dispatch rollback hooks, preserving the original operation failure."""
+
+        def invoke(_hook: object, method: _HookMethod) -> None:
+            try:
+                method(context, error)
+            except Exception as exc:
+                error.add_note(f"rollback hook failed: {type(exc).__name__}: {exc}")
+
+        self._dispatch(HOOK_PHASES["on_rollback"], context, invoke)
+
+    def _dispatch(
+        self,
+        phase: HookPhase,
+        context: OperationContext,
+        invoke: Callable[[object, _HookMethod], None],
+    ) -> None:
+        """Dispatch one phase and emit lifecycle events."""
+        matching_hooks = self._matching_hooks(phase)
+        hook_count = len(matching_hooks)
+        if hook_count == 0:
+            return
+
+        self._notify_event(
+            HookLifecycleEvent(
+                phase=phase,
+                stage="started",
+                context=context,
+                hook_count=hook_count,
+            )
+        )
+        warning_count_before = len(context.warnings)
+        try:
+            for hook, method in matching_hooks:
+                invoke(hook, method)
+        except Exception as exc:
+            self._notify_event(
+                HookLifecycleEvent(
+                    phase=phase,
+                    stage="failed",
+                    context=context,
+                    hook_count=hook_count,
+                    warnings_added=len(context.warnings) - warning_count_before,
+                    error=exc,
+                )
+            )
+            raise
+
+        self._notify_event(
+            HookLifecycleEvent(
+                phase=phase,
+                stage="completed",
+                context=context,
+                hook_count=hook_count,
+                warnings_added=len(context.warnings) - warning_count_before,
+            )
+        )
+
+    def _dispatch_context_method(self, phase: HookPhase, context: OperationContext) -> None:
+        """Dispatch a phase whose hook methods only accept a context."""
+
+        def invoke(_hook: object, method: _HookMethod) -> None:
+            method(context)
+
+        self._dispatch(phase, context, invoke)
+
+    def _matching_hooks(self, phase: HookPhase) -> tuple[tuple[object, _HookMethod], ...]:
+        """Return registered hooks that implement a lifecycle phase."""
+        hooks: list[tuple[object, _HookMethod]] = []
+        for hook in self._hooks:
+            method = getattr(hook, phase.name, None)
+            if callable(method):
+                hooks.append((hook, method))
+        return tuple(hooks)
+
+    def _notify_event(self, event: HookLifecycleEvent) -> None:
+        """Notify one lifecycle event without failing hook dispatch."""
+        if self._notify is None:
+            return
+        try:
+            self._notify(event)
+        except Exception as exc:
+            warnings.warn(
+                f"hook lifecycle callback failed: {type(exc).__name__}: {exc}",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+
 class HookManager:
-    """Deterministic dispatcher for registered catalog hooks."""
+    """Long-lived registry for catalog hooks."""
 
     def __init__(self, hooks: Iterable[object] = ()) -> None:
         self._hooks = list(hooks)
@@ -373,86 +588,49 @@ class HookManager:
         self._hooks.append(hook)
         return hook
 
+    def dispatcher(self, notify: HookLifecycleCallback | None = None) -> HookDispatcher:
+        """Return an operation-scoped hook dispatcher."""
+        return HookDispatcher(self._hooks, notify=notify)
+
     def before_validate_metadata(self, context: OperationContext) -> None:
         """Dispatch ``before_validate_metadata`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, BeforeValidateMetadataHook):
-                hook.before_validate_metadata(context)
+        self.dispatcher().before_validate_metadata(context)
 
     def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
         """Dispatch ``after_validate_metadata`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, AfterValidateMetadataHook):
-                hook.after_validate_metadata(context, report)
+        self.dispatcher().after_validate_metadata(context, report)
 
     def resolve_artifact_locator(self, context: OperationContext) -> None:
         """Dispatch ``resolve_artifact_locator`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, ResolveArtifactLocatorHook):
-                hook.resolve_artifact_locator(context)
+        self.dispatcher().resolve_artifact_locator(context)
 
     def before_record_write(self, context: OperationContext) -> None:
         """Dispatch ``before_record_write`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, BeforeRecordWriteHook):
-                hook.before_record_write(context)
+        self.dispatcher().before_record_write(context)
 
     def after_record_write(self, context: OperationContext) -> None:
         """Dispatch ``after_record_write`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, AfterRecordWriteHook):
-                hook.after_record_write(context)
+        self.dispatcher().after_record_write(context)
 
     def extract_metadata(self, context: OperationContext) -> None:
         """Dispatch metadata extraction hooks and merge returned metadata."""
-        for hook in self._hooks:
-            if isinstance(hook, ExtractMetadataHook):
-                extracted = hook.extract_metadata(context)
-                if extracted is not None:
-                    context.derived_metadata.update(extracted)
+        self.dispatcher().extract_metadata(context)
 
     def before_commit(self, context: OperationContext) -> None:
         """Dispatch ``before_commit`` hooks."""
-        for hook in self._hooks:
-            if isinstance(hook, BeforeCommitHook):
-                hook.before_commit(context)
+        self.dispatcher().before_commit(context)
 
     def after_commit(self, context: OperationContext) -> None:
         """Dispatch ``after_commit`` hooks without failing committed work."""
-        for hook in self._hooks:
-            if isinstance(hook, AfterCommitHook):
-                try:
-                    hook.after_commit(context)
-                except Exception as exc:
-                    warning = HookWarning(
-                        hook_name=type(hook).__name__,
-                        message=f"after_commit hook failed: {type(exc).__name__}: {exc}",
-                        code="hook.after_commit_failed",
-                    )
-                    context.add_warning(warning)
-                    warnings.warn(
-                        f"{warning.hook_name}: {warning.message}",
-                        RuntimeWarning,
-                        stacklevel=2,
-                    )
+        self.dispatcher().after_commit(context)
 
     def on_error(self, context: OperationContext, error: BaseException) -> None:
         """Dispatch error hooks, preserving the original operation failure."""
-        for hook in self._hooks:
-            if isinstance(hook, ErrorHook):
-                try:
-                    hook.on_error(context, error)
-                except Exception as exc:
-                    error.add_note(f"error hook failed: {type(exc).__name__}: {exc}")
+        self.dispatcher().on_error(context, error)
 
     def on_rollback(self, context: OperationContext, error: BaseException) -> None:
         """Dispatch rollback hooks, preserving the original operation failure."""
-        for hook in self._hooks:
-            if isinstance(hook, RollbackHook):
-                try:
-                    hook.on_rollback(context, error)
-                except Exception as exc:
-                    error.add_note(f"rollback hook failed: {type(exc).__name__}: {exc}")
+        self.dispatcher().on_rollback(context, error)
 
 
 __all__ = [
@@ -466,7 +644,13 @@ __all__ = [
     "ErrorHook",
     "ExtractMetadataHook",
     "HOOK_METHOD_NAMES",
+    "HOOK_PHASES",
+    "HookDispatcher",
+    "HookLifecycleCallback",
+    "HookLifecycleEvent",
+    "HookLifecycleStage",
     "HookManager",
+    "HookPhase",
     "HookWarning",
     "OperationContext",
     "OperationSource",

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -77,6 +77,12 @@ def test_registered_hook_phases_emit_formal_audit_events(tmp_path: Path) -> None
         ("before_commit", "completed", "warning"),
     ]
     assert all(event.details["hook_count"] == 1 for event in hook_events)
+    assert [event.details["phase"] for event in hook_events] == [
+        "before_validate_metadata",
+        "before_validate_metadata",
+        "before_commit",
+        "before_commit",
+    ]
     assert hook_events[-1].details["warnings_added"] == 1
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -16,10 +16,21 @@ from ogcat import (
     PluginRegistry,
     RecordSchema,
 )
-from ogcat.hooks import OperationContext, OperationSource
+from ogcat.hooks import HookLifecycleEvent, OperationContext, OperationSource
 from ogcat.models import JsonValue
 from ogcat.transactions import OperationState
 from ogcat.validation import ValidationReport
+
+
+def _hook_context(tmp_path: Path) -> OperationContext:
+    """Build a minimal operation context for dispatcher unit tests."""
+    return OperationContext(
+        catalog_root=tmp_path,
+        operation_id="operation-1",
+        operation_type="add_file",
+        record_type="managed_artifact",
+        user_metadata={},
+    )
 
 
 def test_direct_registration_invokes_hook(tmp_path: Path) -> None:
@@ -180,6 +191,130 @@ def test_hooks_run_in_registration_order(tmp_path: Path) -> None:
         "first:before_commit",
         "second:before_commit",
     ]
+
+
+def test_hook_dispatcher_invokes_matching_hooks_and_emits_lifecycle_events(tmp_path: Path) -> None:
+    """A dispatcher should emit events around hooks that implement the selected phase."""
+    calls: list[str] = []
+    events: list[HookLifecycleEvent] = []
+
+    class FirstHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append("first")
+
+    class OtherPhaseHook:
+        def before_commit(self, context: OperationContext) -> None:
+            calls.append("other")
+
+    class SecondHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append("second")
+
+    dispatcher = HookManager([FirstHook(), OtherPhaseHook(), SecondHook()]).dispatcher(notify=events.append)
+
+    dispatcher.before_validate_metadata(_hook_context(tmp_path))
+
+    assert calls == ["first", "second"]
+    assert [
+        (event.phase.name, event.phase.label, event.stage, event.hook_count, event.warnings_added)
+        for event in events
+    ] == [
+        ("before_validate_metadata", "before-validate metadata", "started", 2, 0),
+        ("before_validate_metadata", "before-validate metadata", "completed", 2, 0),
+    ]
+
+
+def test_hook_dispatcher_emits_no_events_when_phase_has_no_hooks(tmp_path: Path) -> None:
+    """A dispatcher should stay silent when no registered hook matches a phase."""
+    events: list[HookLifecycleEvent] = []
+
+    class Hook:
+        def before_commit(self, context: OperationContext) -> None:
+            context.user_metadata["called"] = True
+
+    dispatcher = HookManager([Hook()]).dispatcher(notify=events.append)
+    context = _hook_context(tmp_path)
+
+    dispatcher.resolve_artifact_locator(context)
+
+    assert events == []
+    assert context.user_metadata == {}
+
+
+def test_hook_dispatcher_without_callback_preserves_hook_behavior(tmp_path: Path) -> None:
+    """A dispatcher without a callback should still run hooks normally."""
+
+    class ExtractorHook:
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            return {"checksum": "abc123"}
+
+    context = _hook_context(tmp_path)
+
+    HookManager([ExtractorHook()]).dispatcher().extract_metadata(context)
+
+    assert context.derived_metadata == {"checksum": "abc123"}
+
+
+def test_hook_dispatcher_failed_event_preserves_hook_exception(tmp_path: Path) -> None:
+    """A failing hook should emit a failed event with the original exception."""
+    events: list[HookLifecycleEvent] = []
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("record hook failed")
+
+    dispatcher = HookManager([FailingHook()]).dispatcher(notify=events.append)
+
+    with pytest.raises(RuntimeError, match="record hook failed") as exc_info:
+        dispatcher.before_record_write(_hook_context(tmp_path))
+
+    assert [(event.phase.name, event.stage, event.hook_count) for event in events] == [
+        ("before_record_write", "started", 1),
+        ("before_record_write", "failed", 1),
+    ]
+    assert events[-1].error is exc_info.value
+
+
+def test_hook_dispatcher_callback_failure_does_not_skip_hooks(tmp_path: Path) -> None:
+    """A callback failure should warn without preventing hook dispatch."""
+    calls: list[str] = []
+    stages: list[str] = []
+
+    class Hook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append("hook")
+
+    def notify(event: HookLifecycleEvent) -> None:
+        stages.append(event.stage)
+        if event.stage == "started":
+            raise RuntimeError("observer failed")
+
+    dispatcher = HookManager([Hook()]).dispatcher(notify=notify)
+
+    with pytest.warns(RuntimeWarning, match="hook lifecycle callback failed"):
+        dispatcher.before_validate_metadata(_hook_context(tmp_path))
+
+    assert calls == ["hook"]
+    assert stages == ["started", "completed"]
+
+
+def test_hook_dispatcher_after_commit_failure_completes_with_warning(tmp_path: Path) -> None:
+    """After-commit hook failures should become warnings and completed events."""
+    events: list[HookLifecycleEvent] = []
+
+    class FailingAfterCommitHook:
+        def after_commit(self, context: OperationContext) -> None:
+            raise RuntimeError("external service failed")
+
+    context = _hook_context(tmp_path)
+    dispatcher = HookManager([FailingAfterCommitHook()]).dispatcher(notify=events.append)
+
+    with pytest.warns(RuntimeWarning, match="after_commit hook failed"):
+        dispatcher.after_commit(context)
+
+    assert [event.stage for event in events] == ["started", "completed"]
+    assert events[-1].warnings_added == 1
+    assert context.warnings[0].code == "hook.after_commit_failed"
 
 
 def test_before_validate_hook_can_mutate_metadata_for_validation_and_naming(tmp_path: Path) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -130,13 +130,28 @@ def test_open_rejects_invalid_plugin_inputs_immediately(tmp_path: Path) -> None:
         Catalog.open(created.root, plugins="not plugins")  # type: ignore[arg-type]
 
 
-def test_open_rejects_non_hook_objects_in_hook_manager_immediately(tmp_path: Path) -> None:
-    """Hook managers should reject entries with no supported hook methods."""
+def test_empty_hook_manager_is_allowed() -> None:
+    """Empty hook managers should remain valid registries."""
+    manager = HookManager()
 
-    created = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    assert manager.hooks == ()
+
+
+def test_hook_manager_constructor_rejects_non_hook_objects() -> None:
+    """Hook managers should reject constructor entries with no supported hook methods."""
 
     with pytest.raises(TypeError, match="hooks item 0 must provide at least one callable hook method"):
-        Catalog.open(created.root, hooks=HookManager([object()]))
+        HookManager([object()])
+
+
+def test_hook_manager_register_rejects_non_hook_objects() -> None:
+    """Hook managers should reject registered objects with no supported hook methods."""
+    manager = HookManager()
+
+    with pytest.raises(TypeError, match="hooks item 0 must provide at least one callable hook method"):
+        manager.register(object())
+
+    assert manager.hooks == ()
 
 
 def test_create_rejects_both_plugins_and_hooks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Introduce `HookDispatcher` and formal hook lifecycle event types in `ogcat.hooks` while keeping `HookManager` as the long-lived hook registry.
- Move hook phase metadata out of `catalog.py` and route add-operation hook execution through an operation-scoped dispatcher.
- Preserve existing hook protocols and audit hook events, with the audit layer now observing dispatcher lifecycle callbacks.
- Mark ADR-0001 as accepted.

Closes #75 

## Testing
- Added dispatcher-level regression tests for hook ordering, lifecycle event emission, warning counts, failed dispatch, no-callback behavior, and callback failure handling.
- Updated audit tests to verify hook lifecycle events still produce the expected audit details.
- Validation passed: ruff, pyright, focused hook/audit tests, and the full test suite (`315 passed, 1 skipped`).