### PR TITLE
Extract add-operation lifecycle into OperationRunner

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ The main pieces are:
 - `CatalogRecord`: the stored record model
 - naming helpers: template rendering for managed storage paths
 - extractors: optional post-ingest metadata extraction
+- operation runners: internal coordinators for validated catalog operation lifecycles
 - CLI: a thin wrapper around the catalog API
 
 The catalog root is self-describing:
@@ -74,6 +75,24 @@ step fails. It is not a true database transaction and should not be described as
 Each unit of work exposes an `operation_id` so future audit logging or hooks can correlate staged
 record writes, storage activity, and cleanup. Stronger backends can map the same conceptual API to
 native transaction support later.
+
+## Operation Runners
+
+`Catalog` remains the public API and setup layer: it validates user inputs, selects schemas, opens
+transactions, and prepares operation-specific request objects. Internal operation runners own the
+ordered lifecycle after that setup.
+
+The current concrete runner is `AddOperationRunner`. It implements the add lifecycle for
+`add_file()` and `add_artifact()`: validation, hook dispatch, locator resolution, storage planning,
+artifact writing or reference skipping, derived metadata collection, record staging, commit, audit,
+and rollback. `OperationRunner` is the generic internal command interface with a single `run()`
+method, so future operation families can be represented without overloading add-specific names.
+
+Shared catalog services such as hook management, audit emission, validation, and record building are
+passed through `OperationServices`. Operation-specific data lives in request dataclasses such as
+`AddOperationRequest`. This keeps the public catalog surface narrow while making the internal
+contract explicit enough for future runners, such as an artifact update runner, to reuse the same
+services without sharing add-only request fields.
 
 ## Why Templates and Metadata Live in `catalog.json`
 

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -140,6 +140,13 @@ is intentionally being used as an artifact writer.
 hook, writer, and commit lifecycle independently; if a later item fails, earlier successful items
 remain committed.
 
+Internally, `Catalog` prepares an `AddOperationRequest` and delegates the ordered lifecycle to an
+`AddOperationRunner`. The runner is not public API, but the boundary matters for plugin behavior:
+hooks and artifact writers see the same `OperationContext`, hook ordering, rollback behavior, and
+audit events whether the operation started from `add_file()` or `add_artifact()`. The generic
+`OperationRunner` interface is intentionally broader than add operations so future operation
+families can use the same command boundary without changing the public hook API.
+
 The same wrapper pattern works for path-backed transforms:
 
 ```python

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -31,17 +31,21 @@ from ogcat.hooks import (
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.naming import build_naming_context, render_storage_location
+from ogcat.operation_helpers import (
+    adapter_name,
+    artifact_locator_from_context,
+    directory_from_locator,
+    directory_from_relative_path,
+    filename_from_locator,
+    naming_metadata_from_storage_plan,
+    normalize_metadata_for_schema,
+    storage_plan_with_locator,
+)
 from ogcat.operation_runner import (
+    AddOperationRequest,
+    AddOperationRunner,
     OperationRunner,
-    _adapter_name,
-    _AddOperationRequest,
-    _artifact_locator_from_context,
-    _directory_from_locator,
-    _directory_from_relative_path,
-    _filename_from_locator,
-    _naming_metadata_from_storage_plan,
-    _OperationRunnerDependencies,
-    _storage_plan_with_locator,
+    OperationServices,
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
@@ -252,10 +256,10 @@ class Catalog:
                 target_kind="file",
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
-                adapter=_adapter_name(locator),
+                adapter=adapter_name(locator),
                 storage_relative_path=locator.relative_path,
-                resolved_directory=_directory_from_relative_path(locator.relative_path),
-                resolved_filename=_filename_from_locator(locator),
+                resolved_directory=directory_from_relative_path(locator.relative_path),
+                resolved_filename=filename_from_locator(locator),
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
@@ -353,7 +357,7 @@ class Catalog:
 
         hook_dispatcher = self.hook_manager.dispatcher()
         hook_dispatcher.before_validate_metadata(context)
-        context.user_metadata = _normalize_metadata_for_schema(
+        context.user_metadata = normalize_metadata_for_schema(
             context.user_metadata,
             schema_name=schema_name,
         )
@@ -382,21 +386,21 @@ class Catalog:
         else:
             planned_locator = locator
             storage_relative_path = locator.relative_path
-            resolved_directory = _directory_from_locator(locator)
-            resolved_filename = _filename_from_locator(locator)
+            resolved_directory = directory_from_locator(locator)
+            resolved_filename = filename_from_locator(locator)
         context.planned_locators = [planned_locator]
         hook_dispatcher.resolve_artifact_locator(context)
-        canonical_locator = _artifact_locator_from_context(context)
+        canonical_locator = artifact_locator_from_context(context)
         if canonical_locator != planned_locator:
             storage_relative_path = canonical_locator.relative_path
-            resolved_directory = _directory_from_locator(canonical_locator)
-            resolved_filename = _filename_from_locator(canonical_locator)
+            resolved_directory = directory_from_locator(canonical_locator)
+            resolved_filename = filename_from_locator(canonical_locator)
         plan = plan_storage(
             canonical_locator,
             target_kind=target_kind,
             write_mode=resolved_write_mode,
             ogcat_owned=ogcat_owned,
-            adapter=_adapter_name(canonical_locator),
+            adapter=adapter_name(canonical_locator),
             time_added=timestamp,
             storage_relative_path=storage_relative_path,
             resolved_directory=resolved_directory,
@@ -467,7 +471,7 @@ class Catalog:
             if time_added is None:
                 time_added = storage_plan.time_added
             if naming_metadata is None:
-                naming_metadata = _naming_metadata_from_storage_plan(storage_plan)
+                naming_metadata = naming_metadata_from_storage_plan(storage_plan)
         assert locator is not None
         metadata_input = {} if metadata is None else metadata
         derived_metadata = (
@@ -1216,7 +1220,7 @@ class Catalog:
             storage_plan_factory=(
                 None
                 if storage_plan is None
-                else lambda context, canonical_locator: _storage_plan_with_locator(
+                else lambda context, canonical_locator: storage_plan_with_locator(
                     storage_plan,
                     canonical_locator,
                 )
@@ -1347,16 +1351,7 @@ class Catalog:
         derived_metadata_collector: DerivedMetadataCollector | None = None,
     ) -> CatalogRecord:
         """Run the shared add operation lifecycle for file and record-only adds."""
-        dependencies = _OperationRunnerDependencies(
-            catalog_root=self.root,
-            hook_manager=self.hook_manager,
-            schema_name=self._schema_name,
-            metadata_validation_report=self._metadata_validation_report,
-            build_artifact_record=self._build_artifact_record,
-            emit_operation_audit=self._emit_operation_audit,
-            emit_hook_lifecycle_audit=self._emit_hook_lifecycle_audit,
-        )
-        request = _AddOperationRequest(
+        request = AddOperationRequest(
             transaction=transaction,
             commit=commit,
             operation_type=operation_type,
@@ -1377,7 +1372,23 @@ class Catalog:
             artifact_writer=artifact_writer,
             derived_metadata_collector=derived_metadata_collector,
         )
-        return OperationRunner(dependencies=dependencies, request=request).run()
+        return self._build_add_operation_runner(request).run()
+
+    def _build_add_operation_runner(self, request: AddOperationRequest) -> OperationRunner:
+        """Build the runner used for one internal add operation."""
+        return AddOperationRunner(dependencies=self._operation_runner_dependencies(), request=request)
+
+    def _operation_runner_dependencies(self) -> OperationServices:
+        """Build catalog-owned dependencies for an internal operation runner."""
+        return OperationServices(
+            catalog_root=self.root,
+            hook_manager=self.hook_manager,
+            schema_name=self._schema_name,
+            metadata_validation_report=self._metadata_validation_report,
+            build_artifact_record=self._build_artifact_record,
+            emit_operation_audit=self._emit_operation_audit,
+            emit_hook_lifecycle_audit=self._emit_hook_lifecycle_audit,
+        )
 
     def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
         """Select the schema that applies to a record."""
@@ -1423,7 +1434,7 @@ class Catalog:
                 updates=normalized_input,
                 mode=update_mode,
             )
-            updated_metadata = _normalize_metadata_for_schema(
+            updated_metadata = normalize_metadata_for_schema(
                 updated_metadata,
                 schema_name=schema_name,
             )
@@ -1666,16 +1677,7 @@ def _coerce_metadata_input(
     schema_name: str,
 ) -> MetadataDict:
     """Copy user metadata after preserving existing non-dictionary errors."""
-    return _normalize_metadata_for_schema(metadata, schema_name=schema_name)
-
-
-def _normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> MetadataDict:
-    """Normalize user metadata with the existing schema-aware error prefix."""
-    return normalize_metadata(
-        metadata,
-        field_name="metadata",
-        label=f"Metadata for schema {schema_name}",
-    )
+    return normalize_metadata_for_schema(metadata, schema_name=schema_name)
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -25,6 +25,7 @@ from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import (
     HOOK_PHASES,
     ArtifactWriter,
+    HookDispatcher,
     HookLifecycleEvent,
     HookManager,
     OperationContext,
@@ -58,6 +59,17 @@ PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
+_PhaseSetter = Callable[[str], None]
+
+
+@dataclass(slots=True)
+class _AddOperationPlan:
+    """Validated add-operation storage plan and its mutable hook context."""
+
+    context: OperationContext
+    locator: ArtifactLocator
+    storage_plan: StoragePlan
+    validation_report: ValidationReport
 
 
 @dataclass(slots=True)
@@ -1338,7 +1350,116 @@ class Catalog:
         derived_metadata_collector: DerivedMetadataCollector | None = None,
     ) -> CatalogRecord:
         """Run the shared add operation lifecycle for file and record-only adds."""
-        hook_context = OperationContext(
+        hook_context = self._build_add_operation_context(
+            transaction=transaction,
+            operation_type=operation_type,
+            record_type=record_type,
+            metadata=metadata,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=suffixes,
+            derived_metadata=derived_metadata,
+            source=source,
+        )
+        hook_dispatcher = self.hook_manager.dispatcher(notify=self._emit_hook_lifecycle_audit)
+        current_phase = "operation-started"
+
+        def set_phase(phase: str) -> None:
+            """Track the currently running add-operation phase for failure audit."""
+            nonlocal current_phase
+            current_phase = phase
+
+        self._emit_operation_audit(
+            hook_context,
+            event_type="operation-started",
+            message=f"Started {operation_type} operation.",
+            details={"caller_owned_transaction": not commit},
+        )
+        try:
+            validation_report = self._validate_add_operation_metadata(
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                schema=schema,
+                schema_record_type=schema_record_type,
+                set_phase=set_phase,
+            )
+            canonical_locator = self._resolve_add_operation_locator(
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                locator_factory=locator_factory,
+                set_phase=set_phase,
+            )
+            add_plan = self._plan_add_operation_storage(
+                context=hook_context,
+                locator=canonical_locator,
+                validation_report=validation_report,
+                storage_plan_factory=storage_plan_factory,
+                artifact_writer=artifact_writer,
+                naming_metadata=naming_metadata,
+                set_phase=set_phase,
+            )
+            self._write_add_operation_artifact(
+                add_plan=add_plan,
+                artifact_writer=artifact_writer,
+                set_phase=set_phase,
+            )
+            self._collect_add_operation_metadata(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                derived_metadata_collector=derived_metadata_collector,
+                set_phase=set_phase,
+            )
+            persisted = self._stage_add_operation_record(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                transaction=transaction,
+                record_type=record_type,
+                schema_record_type=schema_record_type,
+                storage_mode=storage_mode,
+                original_path=original_path,
+                original_filename=original_filename,
+                suffixes=suffixes,
+                naming_metadata=naming_metadata,
+                time_added=time_added,
+                set_phase=set_phase,
+            )
+            self._commit_add_operation_if_owned(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                transaction=transaction,
+                commit=commit,
+                set_phase=set_phase,
+            )
+            return persisted
+        except Exception as exc:
+            self._handle_add_operation_error(
+                error=exc,
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                transaction=transaction,
+                commit=commit,
+                operation_type=operation_type,
+                current_phase=current_phase,
+            )
+            raise
+
+    def _build_add_operation_context(
+        self,
+        *,
+        transaction: UnitOfWork,
+        operation_type: str,
+        record_type: str,
+        metadata: MetadataDict,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        derived_metadata: MetadataDict,
+        source: OperationSource,
+    ) -> OperationContext:
+        """Build the mutable context shared by add-operation hooks and writers."""
+        return OperationContext(
             catalog_root=self.root,
             operation_id=transaction.operation_id,
             operation_type=operation_type,
@@ -1352,211 +1473,308 @@ class Catalog:
             original_filename=original_filename,
             suffixes=[] if suffixes is None else list(suffixes),
         )
-        hook_dispatcher = self.hook_manager.dispatcher(notify=self._emit_hook_lifecycle_audit)
-        current_phase = "operation-started"
-        self._emit_operation_audit(
-            hook_context,
-            event_type="operation-started",
-            message=f"Started {operation_type} operation.",
-            details={"caller_owned_transaction": not commit},
+
+    def _validate_add_operation_metadata(
+        self,
+        *,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        schema: RecordSchema,
+        schema_record_type: str | None,
+        set_phase: _PhaseSetter,
+    ) -> ValidationReport:
+        """Run validation hooks and return the add-operation validation report."""
+        set_phase(HOOK_PHASES["before_validate_metadata"].name)
+        hook_dispatcher.before_validate_metadata(context)
+        set_phase("validation")
+        context.user_metadata = _normalize_metadata_for_schema(
+            context.user_metadata,
+            schema_name=self._schema_name(schema_record_type),
         )
-        try:
-            current_phase = HOOK_PHASES["before_validate_metadata"].name
-            hook_dispatcher.before_validate_metadata(hook_context)
-            current_phase = "validation"
-            hook_context.user_metadata = _normalize_metadata_for_schema(
-                hook_context.user_metadata,
-                schema_name=self._schema_name(schema_record_type),
+        validation_report = self._metadata_validation_report(
+            schema=schema,
+            metadata=context.user_metadata,
+            record_type=schema_record_type,
+        )
+        set_phase(HOOK_PHASES["after_validate_metadata"].name)
+        hook_dispatcher.after_validate_metadata(context, validation_report)
+        self._emit_operation_audit(
+            context,
+            event_type="validation",
+            level=_validation_audit_level(validation_report),
+            message=_validation_audit_message(validation_report),
+            details=_validation_audit_details(validation_report),
+        )
+        validation_report.raise_for_errors()
+        return validation_report
+
+    def _resolve_add_operation_locator(
+        self,
+        *,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        locator_factory: ArtifactLocatorFactory,
+        set_phase: _PhaseSetter,
+    ) -> ArtifactLocator:
+        """Resolve the canonical artifact locator for an add operation."""
+        set_phase("locator-factory")
+        context.planned_locators = [locator_factory(context)]
+        set_phase(HOOK_PHASES["resolve_artifact_locator"].name)
+        hook_dispatcher.resolve_artifact_locator(context)
+        canonical_locator = _artifact_locator_from_context(context)
+        context.planned_locators[0] = canonical_locator
+        return canonical_locator
+
+    def _plan_add_operation_storage(
+        self,
+        *,
+        context: OperationContext,
+        locator: ArtifactLocator,
+        validation_report: ValidationReport,
+        storage_plan_factory: StoragePlanFactory | None,
+        artifact_writer: ArtifactWriter | None,
+        naming_metadata: MetadataDict | None,
+        set_phase: _PhaseSetter,
+    ) -> _AddOperationPlan:
+        """Build and audit the storage plan for an add operation."""
+        set_phase("storage-plan")
+        context.storage_plan = (
+            storage_plan_factory(context, locator)
+            if storage_plan_factory is not None
+            else plan_storage(
+                locator,
+                target_kind=_target_kind_from_writer(artifact_writer),
+                write_mode=_write_mode_from_writer(artifact_writer),
+                ogcat_owned=artifact_writer is not None,
+                adapter=_adapter_name(locator),
+                storage_relative_path=locator.relative_path,
+                resolved_directory=_directory_from_locator(locator),
+                resolved_filename=_filename_from_locator(locator),
             )
-            validation_report = self._metadata_validation_report(
-                schema=schema,
-                metadata=hook_context.user_metadata,
-                record_type=schema_record_type,
-            )
-            current_phase = HOOK_PHASES["after_validate_metadata"].name
-            hook_dispatcher.after_validate_metadata(hook_context, validation_report)
-            self._emit_operation_audit(
-                hook_context,
-                event_type="validation",
-                level=_validation_audit_level(validation_report),
-                message=_validation_audit_message(validation_report),
-                details=_validation_audit_details(validation_report),
-            )
-            validation_report.raise_for_errors()
-            current_phase = "locator-factory"
-            hook_context.planned_locators = [locator_factory(hook_context)]
-            current_phase = HOOK_PHASES["resolve_artifact_locator"].name
-            hook_dispatcher.resolve_artifact_locator(hook_context)
-            canonical_locator = _artifact_locator_from_context(hook_context)
-            hook_context.planned_locators[0] = canonical_locator
-            current_phase = "storage-plan"
-            hook_context.storage_plan = (
-                storage_plan_factory(hook_context, canonical_locator)
-                if storage_plan_factory is not None
-                else plan_storage(
-                    canonical_locator,
-                    target_kind=_target_kind_from_writer(artifact_writer),
-                    write_mode=_write_mode_from_writer(artifact_writer),
-                    ogcat_owned=artifact_writer is not None,
-                    adapter=_adapter_name(canonical_locator),
-                    storage_relative_path=canonical_locator.relative_path,
-                    resolved_directory=_directory_from_locator(canonical_locator),
-                    resolved_filename=_filename_from_locator(canonical_locator),
+        )
+        storage_plan = context.storage_plan
+        if storage_plan is None:
+            raise RuntimeError("Add operation did not produce a storage plan.")
+        self._emit_operation_audit(
+            context,
+            event_type="write",
+            message="Storage plan prepared.",
+            details={
+                "write_phase": "storage-plan",
+                "storage_plan": _storage_plan_audit_details(storage_plan),
+            },
+            locator=locator,
+        )
+        if naming_metadata is not None:
+            naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
+        return _AddOperationPlan(
+            context=context,
+            locator=locator,
+            storage_plan=storage_plan,
+            validation_report=validation_report,
+        )
+
+    def _write_add_operation_artifact(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        artifact_writer: ArtifactWriter | None,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Materialise or skip the artifact write for an add operation."""
+        if artifact_writer is None:
+            if add_plan.storage_plan.write_mode != "reference":
+                raise ValueError(
+                    f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
+                    "requires an artifact_writer."
                 )
-            )
-            storage_plan = hook_context.storage_plan
-            if storage_plan is None:
-                raise RuntimeError("Add operation did not produce a storage plan.")
             self._emit_operation_audit(
-                hook_context,
+                add_plan.context,
                 event_type="write",
-                message="Storage plan prepared.",
+                message="Artifact write skipped for reference operation.",
                 details={
-                    "write_phase": "storage-plan",
-                    "storage_plan": _storage_plan_audit_details(storage_plan),
+                    "write_phase": "artifact-write",
+                    "write_mode": add_plan.storage_plan.write_mode,
                 },
-                locator=canonical_locator,
+                locator=add_plan.locator,
             )
-            if naming_metadata is not None:
-                naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
-            if artifact_writer is None:
-                if storage_plan.write_mode != "reference":
-                    raise ValueError(
-                        f"Storage plan with write mode {storage_plan.write_mode!r} "
-                        "requires an artifact_writer."
-                    )
+            return
+
+        set_phase("artifact-write")
+        artifact_writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
+        self._emit_operation_audit(
+            add_plan.context,
+            event_type="write",
+            message="Artifact write completed.",
+            details={
+                "write_phase": "artifact-write",
+                "writer_type": type(artifact_writer).__name__,
+                "write_mode": add_plan.storage_plan.write_mode,
+            },
+            locator=add_plan.locator,
+        )
+
+    def _collect_add_operation_metadata(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        derived_metadata_collector: DerivedMetadataCollector | None,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Collect derived metadata before record staging."""
+        set_phase("metadata-extraction")
+        _add_classification_metadata(add_plan.context, add_plan.locator)
+        if derived_metadata_collector is not None:
+            derived_metadata_collector(add_plan.context, add_plan.locator)
+        set_phase(HOOK_PHASES["extract_metadata"].name)
+        hook_dispatcher.extract_metadata(add_plan.context)
+        add_plan.context.derived_metadata = normalize_metadata(
+            add_plan.context.derived_metadata,
+            field_name="derived_metadata",
+        )
+
+    def _stage_add_operation_record(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        transaction: UnitOfWork,
+        record_type: str,
+        schema_record_type: str | None,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        naming_metadata: MetadataDict | None,
+        time_added: str | None,
+        set_phase: _PhaseSetter,
+    ) -> CatalogRecord:
+        """Stage the catalog record and run record-write hooks."""
+        set_phase(HOOK_PHASES["before_record_write"].name)
+        hook_dispatcher.before_record_write(add_plan.context)
+        add_plan.context.user_metadata = _normalize_metadata_for_schema(
+            add_plan.context.user_metadata,
+            schema_name=self._schema_name(schema_record_type),
+        )
+        add_plan.context.derived_metadata = normalize_metadata(
+            add_plan.context.derived_metadata,
+            field_name="derived_metadata",
+        )
+        record = self._build_artifact_record(
+            record_type=record_type,
+            locator=add_plan.locator,
+            metadata=add_plan.context.user_metadata,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=suffixes,
+            derived_metadata=_metadata_with_hook_warnings(add_plan.context),
+            naming_metadata=naming_metadata,
+            time_added=time_added,
+        )
+        set_phase("record-write")
+        persisted = transaction.insert_staged_record(record)
+        add_plan.context.record_id = _require_record_id(persisted)
+        self._emit_operation_audit(
+            add_plan.context,
+            event_type="write",
+            message="Record staged.",
+            details={"write_phase": "record-write", "transaction_state": transaction.state.value},
+            locator=add_plan.locator,
+        )
+        set_phase(HOOK_PHASES["after_record_write"].name)
+        hook_dispatcher.after_record_write(add_plan.context)
+        return persisted
+
+    def _commit_add_operation_if_owned(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        transaction: UnitOfWork,
+        commit: bool,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Commit internal add-operation transactions and run commit hooks."""
+        if not commit:
+            return
+        set_phase(HOOK_PHASES["before_commit"].name)
+        hook_dispatcher.before_commit(add_plan.context)
+        set_phase("commit")
+        transaction.commit()
+        self._emit_operation_audit(
+            add_plan.context,
+            event_type="commit",
+            message="Commit succeeded.",
+            details={"transaction_state": transaction.state.value},
+            locator=add_plan.locator,
+        )
+        # After-commit hooks are best-effort: failures warn, but cannot turn an
+        # already-persisted record into an apparent API failure.
+        set_phase(HOOK_PHASES["after_commit"].name)
+        hook_dispatcher.after_commit(add_plan.context)
+
+    def _handle_add_operation_error(
+        self,
+        *,
+        error: Exception,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        transaction: UnitOfWork,
+        commit: bool,
+        operation_type: str,
+        current_phase: str,
+    ) -> None:
+        """Audit and roll back a failed add operation."""
+        add_operation_note(error, context.operation_id)
+        hook_dispatcher.on_error(context, error)
+        self._emit_operation_audit(
+            context,
+            event_type="failure",
+            message=f"{operation_type} operation failed.",
+            details={
+                "phase": current_phase,
+                "transaction_state": transaction.state.value,
+                "caller_owned_transaction": not commit,
+            },
+            exception=error,
+        )
+        # Caller-supplied transactions stay caller-owned. Internal transactions
+        # commit=True and roll back here before re-raising.
+        if commit and transaction.state is not OperationState.COMMITTED:
+            self._emit_operation_audit(
+                context,
+                event_type="rollback",
+                message="Rollback started.",
+                details={"rollback_phase": "started", "transaction_state": transaction.state.value},
+            )
+            transaction.rollback(original_exception=error)
+            hook_dispatcher.on_rollback(context, error)
+            if transaction.rollback_errors:
+                rollback_details: dict[str, object] = {
+                    "rollback_phase": "failed",
+                    "transaction_state": transaction.state.value,
+                    "rollback_errors": _rollback_errors_audit_details(transaction.rollback_errors),
+                }
                 self._emit_operation_audit(
-                    hook_context,
-                    event_type="write",
-                    message="Artifact write skipped for reference operation.",
-                    details={"write_phase": "artifact-write", "write_mode": storage_plan.write_mode},
-                    locator=canonical_locator,
+                    context,
+                    event_type="rollback",
+                    level="error",
+                    message="Rollback completed with failures.",
+                    details=rollback_details,
+                    exception=transaction.rollback_errors[0].exception,
                 )
             else:
-                current_phase = "artifact-write"
-                artifact_writer.write(hook_context, hook_context.source, canonical_locator)
                 self._emit_operation_audit(
-                    hook_context,
-                    event_type="write",
-                    message="Artifact write completed.",
-                    details={
-                        "write_phase": "artifact-write",
-                        "writer_type": type(artifact_writer).__name__,
-                        "write_mode": storage_plan.write_mode,
-                    },
-                    locator=canonical_locator,
-                )
-            current_phase = "metadata-extraction"
-            _add_classification_metadata(hook_context, canonical_locator)
-            if derived_metadata_collector is not None:
-                derived_metadata_collector(hook_context, canonical_locator)
-            current_phase = HOOK_PHASES["extract_metadata"].name
-            hook_dispatcher.extract_metadata(hook_context)
-            hook_context.derived_metadata = normalize_metadata(
-                hook_context.derived_metadata,
-                field_name="derived_metadata",
-            )
-            current_phase = HOOK_PHASES["before_record_write"].name
-            hook_dispatcher.before_record_write(hook_context)
-            hook_context.user_metadata = _normalize_metadata_for_schema(
-                hook_context.user_metadata,
-                schema_name=self._schema_name(schema_record_type),
-            )
-            hook_context.derived_metadata = normalize_metadata(
-                hook_context.derived_metadata,
-                field_name="derived_metadata",
-            )
-            record = self._build_artifact_record(
-                record_type=record_type,
-                locator=canonical_locator,
-                metadata=hook_context.user_metadata,
-                storage_mode=storage_mode,
-                original_path=original_path,
-                original_filename=original_filename,
-                suffixes=suffixes,
-                derived_metadata=_metadata_with_hook_warnings(hook_context),
-                naming_metadata=naming_metadata,
-                time_added=time_added,
-            )
-            current_phase = "record-write"
-            persisted = transaction.insert_staged_record(record)
-            hook_context.record_id = _require_record_id(persisted)
-            self._emit_operation_audit(
-                hook_context,
-                event_type="write",
-                message="Record staged.",
-                details={"write_phase": "record-write", "transaction_state": transaction.state.value},
-                locator=canonical_locator,
-            )
-            current_phase = HOOK_PHASES["after_record_write"].name
-            hook_dispatcher.after_record_write(hook_context)
-            if commit:
-                current_phase = HOOK_PHASES["before_commit"].name
-                hook_dispatcher.before_commit(hook_context)
-                current_phase = "commit"
-                transaction.commit()
-                self._emit_operation_audit(
-                    hook_context,
-                    event_type="commit",
-                    message="Commit succeeded.",
-                    details={"transaction_state": transaction.state.value},
-                    locator=canonical_locator,
-                )
-                # After-commit hooks are best-effort: failures warn, but cannot
-                # turn an already-persisted record into an apparent API failure.
-                current_phase = HOOK_PHASES["after_commit"].name
-                hook_dispatcher.after_commit(hook_context)
-            return persisted
-        except Exception as exc:
-            add_operation_note(exc, hook_context.operation_id)
-            hook_dispatcher.on_error(hook_context, exc)
-            self._emit_operation_audit(
-                hook_context,
-                event_type="failure",
-                message=f"{operation_type} operation failed.",
-                details={
-                    "phase": current_phase,
-                    "transaction_state": transaction.state.value,
-                    "caller_owned_transaction": not commit,
-                },
-                exception=exc,
-            )
-            # Caller-supplied transactions stay caller-owned. Internal
-            # transactions commit=True and roll back here before re-raising.
-            if commit and transaction.state is not OperationState.COMMITTED:
-                self._emit_operation_audit(
-                    hook_context,
+                    context,
                     event_type="rollback",
-                    message="Rollback started.",
-                    details={"rollback_phase": "started", "transaction_state": transaction.state.value},
-                )
-                transaction.rollback(original_exception=exc)
-                hook_dispatcher.on_rollback(hook_context, exc)
-                if transaction.rollback_errors:
-                    rollback_details: dict[str, object] = {
-                        "rollback_phase": "failed",
+                    message="Rollback completed.",
+                    details={
+                        "rollback_phase": "completed",
                         "transaction_state": transaction.state.value,
-                        "rollback_errors": _rollback_errors_audit_details(transaction.rollback_errors),
-                    }
-                    self._emit_operation_audit(
-                        hook_context,
-                        event_type="rollback",
-                        level="error",
-                        message="Rollback completed with failures.",
-                        details=rollback_details,
-                        exception=transaction.rollback_errors[0].exception,
-                    )
-                else:
-                    self._emit_operation_audit(
-                        hook_context,
-                        event_type="rollback",
-                        message="Rollback completed.",
-                        details={
-                            "rollback_phase": "completed",
-                            "transaction_state": transaction.state.value,
-                        },
-                    )
-            raise
+                    },
+                )
 
     def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
         """Select the schema that applies to a record."""

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -18,14 +18,10 @@ from ogcat.audit import (
     AuditEvent,
     AuditSink,
     JsonlAuditSink,
-    add_operation_note,
 )
-from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import (
-    HOOK_PHASES,
     ArtifactWriter,
-    HookDispatcher,
     HookLifecycleEvent,
     HookManager,
     OperationContext,
@@ -35,6 +31,18 @@ from ogcat.hooks import (
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.naming import build_naming_context, render_storage_location
+from ogcat.operation_runner import (
+    OperationRunner,
+    _adapter_name,
+    _AddOperationRequest,
+    _artifact_locator_from_context,
+    _directory_from_locator,
+    _directory_from_relative_path,
+    _filename_from_locator,
+    _naming_metadata_from_storage_plan,
+    _OperationRunnerDependencies,
+    _storage_plan_with_locator,
+)
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
 from ogcat.repository import CatalogRepository
@@ -48,7 +56,7 @@ from ogcat.storage import (
     plan_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
-from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
+from ogcat.transactions import UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
 from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 
@@ -59,17 +67,6 @@ PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
-_PhaseSetter = Callable[[str], None]
-
-
-@dataclass(slots=True)
-class _AddOperationPlan:
-    """Validated add-operation storage plan and its mutable hook context."""
-
-    context: OperationContext
-    locator: ArtifactLocator
-    storage_plan: StoragePlan
-    validation_report: ValidationReport
 
 
 @dataclass(slots=True)
@@ -1350,431 +1347,37 @@ class Catalog:
         derived_metadata_collector: DerivedMetadataCollector | None = None,
     ) -> CatalogRecord:
         """Run the shared add operation lifecycle for file and record-only adds."""
-        hook_context = self._build_add_operation_context(
+        dependencies = _OperationRunnerDependencies(
+            catalog_root=self.root,
+            hook_manager=self.hook_manager,
+            schema_name=self._schema_name,
+            metadata_validation_report=self._metadata_validation_report,
+            build_artifact_record=self._build_artifact_record,
+            emit_operation_audit=self._emit_operation_audit,
+            emit_hook_lifecycle_audit=self._emit_hook_lifecycle_audit,
+        )
+        request = _AddOperationRequest(
             transaction=transaction,
+            commit=commit,
             operation_type=operation_type,
             record_type=record_type,
+            schema=schema,
+            schema_record_type=schema_record_type,
             metadata=metadata,
             storage_mode=storage_mode,
             original_path=original_path,
             original_filename=original_filename,
             suffixes=suffixes,
             derived_metadata=derived_metadata,
-            source=source,
-        )
-        hook_dispatcher = self.hook_manager.dispatcher(notify=self._emit_hook_lifecycle_audit)
-        current_phase = "operation-started"
-
-        def set_phase(phase: str) -> None:
-            """Track the currently running add-operation phase for failure audit."""
-            nonlocal current_phase
-            current_phase = phase
-
-        self._emit_operation_audit(
-            hook_context,
-            event_type="operation-started",
-            message=f"Started {operation_type} operation.",
-            details={"caller_owned_transaction": not commit},
-        )
-        try:
-            validation_report = self._validate_add_operation_metadata(
-                context=hook_context,
-                hook_dispatcher=hook_dispatcher,
-                schema=schema,
-                schema_record_type=schema_record_type,
-                set_phase=set_phase,
-            )
-            canonical_locator = self._resolve_add_operation_locator(
-                context=hook_context,
-                hook_dispatcher=hook_dispatcher,
-                locator_factory=locator_factory,
-                set_phase=set_phase,
-            )
-            add_plan = self._plan_add_operation_storage(
-                context=hook_context,
-                locator=canonical_locator,
-                validation_report=validation_report,
-                storage_plan_factory=storage_plan_factory,
-                artifact_writer=artifact_writer,
-                naming_metadata=naming_metadata,
-                set_phase=set_phase,
-            )
-            self._write_add_operation_artifact(
-                add_plan=add_plan,
-                artifact_writer=artifact_writer,
-                set_phase=set_phase,
-            )
-            self._collect_add_operation_metadata(
-                add_plan=add_plan,
-                hook_dispatcher=hook_dispatcher,
-                derived_metadata_collector=derived_metadata_collector,
-                set_phase=set_phase,
-            )
-            persisted = self._stage_add_operation_record(
-                add_plan=add_plan,
-                hook_dispatcher=hook_dispatcher,
-                transaction=transaction,
-                record_type=record_type,
-                schema_record_type=schema_record_type,
-                storage_mode=storage_mode,
-                original_path=original_path,
-                original_filename=original_filename,
-                suffixes=suffixes,
-                naming_metadata=naming_metadata,
-                time_added=time_added,
-                set_phase=set_phase,
-            )
-            self._commit_add_operation_if_owned(
-                add_plan=add_plan,
-                hook_dispatcher=hook_dispatcher,
-                transaction=transaction,
-                commit=commit,
-                set_phase=set_phase,
-            )
-            return persisted
-        except Exception as exc:
-            self._handle_add_operation_error(
-                error=exc,
-                context=hook_context,
-                hook_dispatcher=hook_dispatcher,
-                transaction=transaction,
-                commit=commit,
-                operation_type=operation_type,
-                current_phase=current_phase,
-            )
-            raise
-
-    def _build_add_operation_context(
-        self,
-        *,
-        transaction: UnitOfWork,
-        operation_type: str,
-        record_type: str,
-        metadata: MetadataDict,
-        storage_mode: str | None,
-        original_path: str | Path | None,
-        original_filename: str | None,
-        suffixes: list[str] | None,
-        derived_metadata: MetadataDict,
-        source: OperationSource,
-    ) -> OperationContext:
-        """Build the mutable context shared by add-operation hooks and writers."""
-        return OperationContext(
-            catalog_root=self.root,
-            operation_id=transaction.operation_id,
-            operation_type=operation_type,
-            record_type=record_type,
-            user_metadata=metadata,
-            derived_metadata=derived_metadata,
-            register_rollback=transaction.register_rollback,
-            source=source,
-            storage_mode=storage_mode,
-            original_path=original_path,
-            original_filename=original_filename,
-            suffixes=[] if suffixes is None else list(suffixes),
-        )
-
-    def _validate_add_operation_metadata(
-        self,
-        *,
-        context: OperationContext,
-        hook_dispatcher: HookDispatcher,
-        schema: RecordSchema,
-        schema_record_type: str | None,
-        set_phase: _PhaseSetter,
-    ) -> ValidationReport:
-        """Run validation hooks and return the add-operation validation report."""
-        set_phase(HOOK_PHASES["before_validate_metadata"].name)
-        hook_dispatcher.before_validate_metadata(context)
-        set_phase("validation")
-        context.user_metadata = _normalize_metadata_for_schema(
-            context.user_metadata,
-            schema_name=self._schema_name(schema_record_type),
-        )
-        validation_report = self._metadata_validation_report(
-            schema=schema,
-            metadata=context.user_metadata,
-            record_type=schema_record_type,
-        )
-        set_phase(HOOK_PHASES["after_validate_metadata"].name)
-        hook_dispatcher.after_validate_metadata(context, validation_report)
-        self._emit_operation_audit(
-            context,
-            event_type="validation",
-            level=_validation_audit_level(validation_report),
-            message=_validation_audit_message(validation_report),
-            details=_validation_audit_details(validation_report),
-        )
-        validation_report.raise_for_errors()
-        return validation_report
-
-    def _resolve_add_operation_locator(
-        self,
-        *,
-        context: OperationContext,
-        hook_dispatcher: HookDispatcher,
-        locator_factory: ArtifactLocatorFactory,
-        set_phase: _PhaseSetter,
-    ) -> ArtifactLocator:
-        """Resolve the canonical artifact locator for an add operation."""
-        set_phase("locator-factory")
-        context.planned_locators = [locator_factory(context)]
-        set_phase(HOOK_PHASES["resolve_artifact_locator"].name)
-        hook_dispatcher.resolve_artifact_locator(context)
-        canonical_locator = _artifact_locator_from_context(context)
-        context.planned_locators[0] = canonical_locator
-        return canonical_locator
-
-    def _plan_add_operation_storage(
-        self,
-        *,
-        context: OperationContext,
-        locator: ArtifactLocator,
-        validation_report: ValidationReport,
-        storage_plan_factory: StoragePlanFactory | None,
-        artifact_writer: ArtifactWriter | None,
-        naming_metadata: MetadataDict | None,
-        set_phase: _PhaseSetter,
-    ) -> _AddOperationPlan:
-        """Build and audit the storage plan for an add operation."""
-        set_phase("storage-plan")
-        context.storage_plan = (
-            storage_plan_factory(context, locator)
-            if storage_plan_factory is not None
-            else plan_storage(
-                locator,
-                target_kind=_target_kind_from_writer(artifact_writer),
-                write_mode=_write_mode_from_writer(artifact_writer),
-                ogcat_owned=artifact_writer is not None,
-                adapter=_adapter_name(locator),
-                storage_relative_path=locator.relative_path,
-                resolved_directory=_directory_from_locator(locator),
-                resolved_filename=_filename_from_locator(locator),
-            )
-        )
-        storage_plan = context.storage_plan
-        if storage_plan is None:
-            raise RuntimeError("Add operation did not produce a storage plan.")
-        self._emit_operation_audit(
-            context,
-            event_type="write",
-            message="Storage plan prepared.",
-            details={
-                "write_phase": "storage-plan",
-                "storage_plan": _storage_plan_audit_details(storage_plan),
-            },
-            locator=locator,
-        )
-        if naming_metadata is not None:
-            naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
-        return _AddOperationPlan(
-            context=context,
-            locator=locator,
-            storage_plan=storage_plan,
-            validation_report=validation_report,
-        )
-
-    def _write_add_operation_artifact(
-        self,
-        *,
-        add_plan: _AddOperationPlan,
-        artifact_writer: ArtifactWriter | None,
-        set_phase: _PhaseSetter,
-    ) -> None:
-        """Materialise or skip the artifact write for an add operation."""
-        if artifact_writer is None:
-            if add_plan.storage_plan.write_mode != "reference":
-                raise ValueError(
-                    f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
-                    "requires an artifact_writer."
-                )
-            self._emit_operation_audit(
-                add_plan.context,
-                event_type="write",
-                message="Artifact write skipped for reference operation.",
-                details={
-                    "write_phase": "artifact-write",
-                    "write_mode": add_plan.storage_plan.write_mode,
-                },
-                locator=add_plan.locator,
-            )
-            return
-
-        set_phase("artifact-write")
-        artifact_writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
-        self._emit_operation_audit(
-            add_plan.context,
-            event_type="write",
-            message="Artifact write completed.",
-            details={
-                "write_phase": "artifact-write",
-                "writer_type": type(artifact_writer).__name__,
-                "write_mode": add_plan.storage_plan.write_mode,
-            },
-            locator=add_plan.locator,
-        )
-
-    def _collect_add_operation_metadata(
-        self,
-        *,
-        add_plan: _AddOperationPlan,
-        hook_dispatcher: HookDispatcher,
-        derived_metadata_collector: DerivedMetadataCollector | None,
-        set_phase: _PhaseSetter,
-    ) -> None:
-        """Collect derived metadata before record staging."""
-        set_phase("metadata-extraction")
-        _add_classification_metadata(add_plan.context, add_plan.locator)
-        if derived_metadata_collector is not None:
-            derived_metadata_collector(add_plan.context, add_plan.locator)
-        set_phase(HOOK_PHASES["extract_metadata"].name)
-        hook_dispatcher.extract_metadata(add_plan.context)
-        add_plan.context.derived_metadata = normalize_metadata(
-            add_plan.context.derived_metadata,
-            field_name="derived_metadata",
-        )
-
-    def _stage_add_operation_record(
-        self,
-        *,
-        add_plan: _AddOperationPlan,
-        hook_dispatcher: HookDispatcher,
-        transaction: UnitOfWork,
-        record_type: str,
-        schema_record_type: str | None,
-        storage_mode: str | None,
-        original_path: str | Path | None,
-        original_filename: str | None,
-        suffixes: list[str] | None,
-        naming_metadata: MetadataDict | None,
-        time_added: str | None,
-        set_phase: _PhaseSetter,
-    ) -> CatalogRecord:
-        """Stage the catalog record and run record-write hooks."""
-        set_phase(HOOK_PHASES["before_record_write"].name)
-        hook_dispatcher.before_record_write(add_plan.context)
-        add_plan.context.user_metadata = _normalize_metadata_for_schema(
-            add_plan.context.user_metadata,
-            schema_name=self._schema_name(schema_record_type),
-        )
-        add_plan.context.derived_metadata = normalize_metadata(
-            add_plan.context.derived_metadata,
-            field_name="derived_metadata",
-        )
-        record = self._build_artifact_record(
-            record_type=record_type,
-            locator=add_plan.locator,
-            metadata=add_plan.context.user_metadata,
-            storage_mode=storage_mode,
-            original_path=original_path,
-            original_filename=original_filename,
-            suffixes=suffixes,
-            derived_metadata=_metadata_with_hook_warnings(add_plan.context),
             naming_metadata=naming_metadata,
             time_added=time_added,
+            source=source,
+            locator_factory=locator_factory,
+            storage_plan_factory=storage_plan_factory,
+            artifact_writer=artifact_writer,
+            derived_metadata_collector=derived_metadata_collector,
         )
-        set_phase("record-write")
-        persisted = transaction.insert_staged_record(record)
-        add_plan.context.record_id = _require_record_id(persisted)
-        self._emit_operation_audit(
-            add_plan.context,
-            event_type="write",
-            message="Record staged.",
-            details={"write_phase": "record-write", "transaction_state": transaction.state.value},
-            locator=add_plan.locator,
-        )
-        set_phase(HOOK_PHASES["after_record_write"].name)
-        hook_dispatcher.after_record_write(add_plan.context)
-        return persisted
-
-    def _commit_add_operation_if_owned(
-        self,
-        *,
-        add_plan: _AddOperationPlan,
-        hook_dispatcher: HookDispatcher,
-        transaction: UnitOfWork,
-        commit: bool,
-        set_phase: _PhaseSetter,
-    ) -> None:
-        """Commit internal add-operation transactions and run commit hooks."""
-        if not commit:
-            return
-        set_phase(HOOK_PHASES["before_commit"].name)
-        hook_dispatcher.before_commit(add_plan.context)
-        set_phase("commit")
-        transaction.commit()
-        self._emit_operation_audit(
-            add_plan.context,
-            event_type="commit",
-            message="Commit succeeded.",
-            details={"transaction_state": transaction.state.value},
-            locator=add_plan.locator,
-        )
-        # After-commit hooks are best-effort: failures warn, but cannot turn an
-        # already-persisted record into an apparent API failure.
-        set_phase(HOOK_PHASES["after_commit"].name)
-        hook_dispatcher.after_commit(add_plan.context)
-
-    def _handle_add_operation_error(
-        self,
-        *,
-        error: Exception,
-        context: OperationContext,
-        hook_dispatcher: HookDispatcher,
-        transaction: UnitOfWork,
-        commit: bool,
-        operation_type: str,
-        current_phase: str,
-    ) -> None:
-        """Audit and roll back a failed add operation."""
-        add_operation_note(error, context.operation_id)
-        hook_dispatcher.on_error(context, error)
-        self._emit_operation_audit(
-            context,
-            event_type="failure",
-            message=f"{operation_type} operation failed.",
-            details={
-                "phase": current_phase,
-                "transaction_state": transaction.state.value,
-                "caller_owned_transaction": not commit,
-            },
-            exception=error,
-        )
-        # Caller-supplied transactions stay caller-owned. Internal transactions
-        # commit=True and roll back here before re-raising.
-        if commit and transaction.state is not OperationState.COMMITTED:
-            self._emit_operation_audit(
-                context,
-                event_type="rollback",
-                message="Rollback started.",
-                details={"rollback_phase": "started", "transaction_state": transaction.state.value},
-            )
-            transaction.rollback(original_exception=error)
-            hook_dispatcher.on_rollback(context, error)
-            if transaction.rollback_errors:
-                rollback_details: dict[str, object] = {
-                    "rollback_phase": "failed",
-                    "transaction_state": transaction.state.value,
-                    "rollback_errors": _rollback_errors_audit_details(transaction.rollback_errors),
-                }
-                self._emit_operation_audit(
-                    context,
-                    event_type="rollback",
-                    level="error",
-                    message="Rollback completed with failures.",
-                    details=rollback_details,
-                    exception=transaction.rollback_errors[0].exception,
-                )
-            else:
-                self._emit_operation_audit(
-                    context,
-                    event_type="rollback",
-                    message="Rollback completed.",
-                    details={
-                        "rollback_phase": "completed",
-                        "transaction_state": transaction.state.value,
-                    },
-                )
+        return OperationRunner(dependencies=dependencies, request=request).run()
 
     def _select_schema(self, record_type: str | None, *, require_known: bool) -> RecordSchema:
         """Select the schema that applies to a record."""
@@ -2025,88 +1628,6 @@ def _reference_locator_and_path(
     return ArtifactLocator.from_path(path), path
 
 
-def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
-    """Return derived metadata with non-fatal hook warnings included."""
-    metadata = normalize_metadata(context.derived_metadata, field_name="derived_metadata")
-    if context.warnings:
-        warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
-        metadata["hook_warnings"] = warnings_metadata
-    return normalize_metadata(metadata, field_name="derived_metadata")
-
-
-def _add_classification_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
-    """Add cheap artifact classification metadata without overwriting caller values."""
-    classification = classify_artifact(
-        locator,
-        original_path=context.original_path,
-        original_filename=context.original_filename,
-        suffixes=context.suffixes,
-    )
-    existing = context.derived_metadata.get(CLASSIFICATION_METADATA_KEY)
-    if isinstance(existing, Mapping):
-        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = {
-            **classification,
-            **existing,
-        }
-    elif existing is None:
-        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
-
-
-def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
-    """Return a storage plan adjusted to a hook-resolved canonical locator."""
-    if plan.locator == locator:
-        return plan
-    return replace(
-        plan,
-        locator=locator,
-        adapter=_adapter_name(locator),
-        storage_relative_path=locator.relative_path,
-        resolved_directory=_directory_from_locator(locator),
-        resolved_filename=_filename_from_locator(locator),
-    )
-
-
-def _naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
-    """Build record naming metadata from storage planning outputs."""
-    metadata: MetadataDict = {}
-    if plan.storage_relative_path is not None:
-        metadata["storage_relative_path"] = plan.storage_relative_path
-    if plan.resolved_directory is not None:
-        metadata["resolved_directory"] = plan.resolved_directory
-    if plan.resolved_filename is not None:
-        metadata["resolved_filename"] = plan.resolved_filename
-    return metadata
-
-
-def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
-    """Infer a storage target kind from a writer when it declares one."""
-    if artifact_writer is None:
-        return "file"
-    target_kind = getattr(artifact_writer, "target_kind", "file")
-    if target_kind in {"file", "directory"}:
-        return cast(TargetKind, target_kind)
-    return "file"
-
-
-def _write_mode_from_writer(artifact_writer: ArtifactWriter | None) -> WriteMode:
-    """Infer a storage write mode from a writer when it declares one."""
-    if artifact_writer is None:
-        return "reference"
-    write_mode = getattr(artifact_writer, "write_mode", "write")
-    if write_mode in {"copy", "move", "write", "reference"}:
-        return cast(WriteMode, write_mode)
-    return "write"
-
-
-def _adapter_name(locator: ArtifactLocator) -> str | None:
-    """Return the storage adapter name implied by a locator."""
-    if locator.kind == "path":
-        return "local"
-    if locator.kind == "urlpath":
-        return "fsspec"
-    return None
-
-
 def _urlpath_exists_if_supported(urlpath: str) -> bool:
     """Return whether a URL path exists when fsspec is installed.
 
@@ -2155,35 +1676,6 @@ def _normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> Met
         field_name="metadata",
         label=f"Metadata for schema {schema_name}",
     )
-
-
-def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
-    """Return the canonical locator after locator-resolution hooks run."""
-    if not context.planned_locators:
-        raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
-    return context.planned_locators[0]
-
-
-def _filename_from_locator(locator: ArtifactLocator) -> str:
-    """Return the final filename-like component from a locator."""
-    if locator.kind == "path":
-        return Path(locator.value).name
-    return locator.value.rstrip("/").rsplit("/", 1)[-1]
-
-
-def _directory_from_locator(locator: ArtifactLocator) -> str:
-    """Return the directory-like component from a locator."""
-    if locator.kind == "path":
-        return Path(locator.value).parent.as_posix()
-    return locator.value.rstrip("/").rsplit("/", 1)[0]
-
-
-def _directory_from_relative_path(relative_path: str | None) -> str | None:
-    """Return the directory component from a storage-relative path."""
-    if relative_path is None:
-        return None
-    directory = Path(relative_path).parent.as_posix()
-    return "" if directory == "." else directory
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:
@@ -2315,76 +1807,3 @@ def _first_planned_locator(context: OperationContext) -> ArtifactLocator | None:
     if not context.planned_locators:
         return None
     return context.planned_locators[0]
-
-
-def _validation_audit_level(report: ValidationReport) -> str:
-    """Return the audit level for a validation report."""
-    if report.errors:
-        return "error"
-    if report.warnings:
-        return "warning"
-    return "info"
-
-
-def _validation_audit_message(report: ValidationReport) -> str:
-    """Return a concise validation audit message."""
-    if report.errors:
-        return "Metadata validation failed."
-    if report.warnings:
-        return "Metadata validation completed with warnings."
-    return "Metadata validation succeeded."
-
-
-def _validation_audit_details(report: ValidationReport) -> dict[str, object]:
-    """Return validation issue summaries for audit events."""
-    return {
-        "validation": {
-            "error_count": len(report.errors),
-            "warning_count": len(report.warnings),
-            "issues": [
-                {
-                    "path": issue.path,
-                    "message": issue.message,
-                    "severity": issue.severity,
-                    "code": issue.code,
-                    "hint": issue.hint,
-                }
-                for issue in report.issues
-            ],
-        }
-    }
-
-
-def _storage_plan_audit_details(plan: StoragePlan) -> dict[str, object]:
-    """Return storage plan details that are safe for audit logging."""
-    return {
-        "target_kind": plan.target_kind,
-        "write_mode": plan.write_mode,
-        "checksum": plan.checksum,
-        "ogcat_owned": plan.ogcat_owned,
-        "profile": plan.profile,
-        "adapter": plan.adapter,
-        "time_added": plan.time_added,
-        "storage_relative_path": plan.storage_relative_path,
-        "resolved_directory": plan.resolved_directory,
-        "resolved_filename": plan.resolved_filename,
-    }
-
-
-def _rollback_errors_audit_details(rollback_errors: list[RollbackFailure]) -> list[dict[str, str]]:
-    """Return rollback failure summaries for audit events."""
-    return [
-        {
-            "description": failure.description,
-            "exception_type": type(failure.exception).__name__,
-            "exception_message": str(failure.exception),
-        }
-        for failure in rollback_errors
-    ]
-
-
-def _require_record_id(record: CatalogRecord) -> str:
-    """Return a persisted record id."""
-    if record.id is None:
-        raise RuntimeError("Repository returned a persisted record without an id.")
-    return record.id

--- a/src/ogcat/operation_helpers.py
+++ b/src/ogcat/operation_helpers.py
@@ -1,0 +1,90 @@
+"""Shared helpers for internal catalog operation planning.
+
+These helpers are not public API, but they are intentionally shared across
+internal modules. ``Catalog`` uses them while preparing add-operation inputs,
+and operation runners use them while executing the lifecycle. Keeping them here
+avoids importing private names from a concrete runner implementation and keeps
+schema-aware normalization behavior in one place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from ogcat.hooks import OperationContext
+from ogcat.models import ArtifactLocator, MetadataDict, normalize_metadata
+from ogcat.storage import StoragePlan
+
+
+def normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> MetadataDict:
+    """Normalize user metadata with the existing schema-aware error prefix."""
+    return normalize_metadata(
+        metadata,
+        field_name="metadata",
+        label=f"Metadata for schema {schema_name}",
+    )
+
+
+def artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
+    """Return the canonical locator after locator-resolution hooks run."""
+    if not context.planned_locators:
+        raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
+    return context.planned_locators[0]
+
+
+def storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
+    """Return a storage plan adjusted to a hook-resolved canonical locator."""
+    if plan.locator == locator:
+        return plan
+    return replace(
+        plan,
+        locator=locator,
+        adapter=adapter_name(locator),
+        storage_relative_path=locator.relative_path,
+        resolved_directory=directory_from_locator(locator),
+        resolved_filename=filename_from_locator(locator),
+    )
+
+
+def naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
+    """Build record naming metadata from storage planning outputs."""
+    metadata: MetadataDict = {}
+    if plan.storage_relative_path is not None:
+        metadata["storage_relative_path"] = plan.storage_relative_path
+    if plan.resolved_directory is not None:
+        metadata["resolved_directory"] = plan.resolved_directory
+    if plan.resolved_filename is not None:
+        metadata["resolved_filename"] = plan.resolved_filename
+    return metadata
+
+
+def adapter_name(locator: ArtifactLocator) -> str | None:
+    """Return the storage adapter name implied by a locator."""
+    if locator.kind == "path":
+        return "local"
+    if locator.kind == "urlpath":
+        return "fsspec"
+    return None
+
+
+def filename_from_locator(locator: ArtifactLocator) -> str:
+    """Return the final filename-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).name
+    return locator.value.rstrip("/").rsplit("/", 1)[-1]
+
+
+def directory_from_locator(locator: ArtifactLocator) -> str:
+    """Return the directory-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).parent.as_posix()
+    return locator.value.rstrip("/").rsplit("/", 1)[0]
+
+
+def directory_from_relative_path(relative_path: str | None) -> str | None:
+    """Return the directory component from a storage-relative path."""
+    if relative_path is None:
+        return None
+    directory = Path(relative_path).parent.as_posix()
+    return "" if directory == "." else directory

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -1,0 +1,700 @@
+"""Internal coordinator for catalog add operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from ogcat.audit import add_operation_note
+from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
+from ogcat.hooks import (
+    HOOK_PHASES,
+    ArtifactWriter,
+    HookDispatcher,
+    HookLifecycleCallback,
+    HookManager,
+    OperationContext,
+    OperationSource,
+)
+from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
+from ogcat.spec import RecordSchema
+from ogcat.storage import StoragePlan, TargetKind, WriteMode, plan_storage
+from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
+from ogcat.validation import ValidationReport
+
+ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
+StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
+DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
+_PhaseSetter = Callable[[str], None]
+
+
+class _OperationAuditEmitter(Protocol):
+    """Callable used by the runner to emit catalog operation audit events."""
+
+    def __call__(
+        self,
+        context: OperationContext,
+        *,
+        event_type: str,
+        level: str = "info",
+        message: str,
+        details: Mapping[str, object] | None = None,
+        exception: BaseException | None = None,
+        locator: ArtifactLocator | None = None,
+    ) -> None:
+        """Emit one operation audit event."""
+        ...
+
+
+class _MetadataValidationReporter(Protocol):
+    """Callable used by the runner to validate operation metadata."""
+
+    def __call__(
+        self,
+        *,
+        schema: RecordSchema,
+        metadata: object,
+        record_type: str | None,
+    ) -> ValidationReport:
+        """Return a validation report for the supplied metadata."""
+        ...
+
+
+class _ArtifactRecordBuilder(Protocol):
+    """Callable used by the runner to build a catalog record."""
+
+    def __call__(
+        self,
+        *,
+        record_type: str,
+        locator: ArtifactLocator,
+        record_id: str | None = None,
+        metadata: MetadataDict | None = None,
+        storage_mode: str | None = None,
+        original_path: str | Path | None = None,
+        original_filename: str | None = None,
+        suffixes: list[str] | None = None,
+        derived_metadata: Mapping[Any, Any] | None = None,
+        naming_metadata: Mapping[Any, Any] | None = None,
+        time_added: str | None = None,
+    ) -> CatalogRecord:
+        """Build an artifact record without persisting it."""
+        ...
+
+
+@dataclass(slots=True)
+class _OperationRunnerDependencies:
+    """Catalog-owned collaborators used by an add operation runner."""
+
+    catalog_root: Path
+    hook_manager: HookManager
+    schema_name: Callable[[str | None], str]
+    metadata_validation_report: _MetadataValidationReporter
+    build_artifact_record: _ArtifactRecordBuilder
+    emit_operation_audit: _OperationAuditEmitter
+    emit_hook_lifecycle_audit: HookLifecycleCallback
+
+
+@dataclass(slots=True)
+class _AddOperationRequest:
+    """Inputs required to run one catalog add operation."""
+
+    transaction: UnitOfWork
+    commit: bool
+    operation_type: str
+    record_type: str
+    schema: RecordSchema
+    schema_record_type: str | None
+    metadata: MetadataDict
+    storage_mode: str | None
+    original_path: str | Path | None
+    original_filename: str | None
+    suffixes: list[str] | None
+    derived_metadata: MetadataDict
+    naming_metadata: MetadataDict | None
+    time_added: str | None
+    source: OperationSource
+    locator_factory: ArtifactLocatorFactory
+    storage_plan_factory: StoragePlanFactory | None = None
+    artifact_writer: ArtifactWriter | None = None
+    derived_metadata_collector: DerivedMetadataCollector | None = None
+
+
+@dataclass(slots=True)
+class _AddOperationPlan:
+    """Validated add-operation storage plan and its mutable hook context."""
+
+    context: OperationContext
+    locator: ArtifactLocator
+    storage_plan: StoragePlan
+    validation_report: ValidationReport
+
+
+@dataclass(slots=True)
+class OperationRunner:
+    """Internal coordinator for one add-operation lifecycle."""
+
+    dependencies: _OperationRunnerDependencies
+    request: _AddOperationRequest
+
+    def run(self) -> CatalogRecord:
+        """Run the add operation and return the persisted or staged record."""
+        hook_context = self._build_context()
+        hook_dispatcher = self.dependencies.hook_manager.dispatcher(
+            notify=self.dependencies.emit_hook_lifecycle_audit
+        )
+        current_phase = "operation-started"
+
+        def set_phase(phase: str) -> None:
+            """Track the currently running add-operation phase for failure audit."""
+            nonlocal current_phase
+            current_phase = phase
+
+        self.dependencies.emit_operation_audit(
+            hook_context,
+            event_type="operation-started",
+            message=f"Started {self.request.operation_type} operation.",
+            details={"caller_owned_transaction": not self.request.commit},
+        )
+        try:
+            validation_report = self._validate_metadata(
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                set_phase=set_phase,
+            )
+            canonical_locator = self._resolve_locator(
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                set_phase=set_phase,
+            )
+            add_plan = self._plan_storage(
+                context=hook_context,
+                locator=canonical_locator,
+                validation_report=validation_report,
+                set_phase=set_phase,
+            )
+            self._write_artifact(add_plan=add_plan, set_phase=set_phase)
+            self._collect_metadata(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                set_phase=set_phase,
+            )
+            persisted = self._stage_record(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                set_phase=set_phase,
+            )
+            self._commit_if_owned(
+                add_plan=add_plan,
+                hook_dispatcher=hook_dispatcher,
+                set_phase=set_phase,
+            )
+            return persisted
+        except Exception as exc:
+            self._handle_error(
+                error=exc,
+                context=hook_context,
+                hook_dispatcher=hook_dispatcher,
+                current_phase=current_phase,
+            )
+            raise
+
+    def _build_context(self) -> OperationContext:
+        """Build the mutable context shared by add-operation hooks and writers."""
+        return OperationContext(
+            catalog_root=self.dependencies.catalog_root,
+            operation_id=self.request.transaction.operation_id,
+            operation_type=self.request.operation_type,
+            record_type=self.request.record_type,
+            user_metadata=self.request.metadata,
+            derived_metadata=self.request.derived_metadata,
+            register_rollback=self.request.transaction.register_rollback,
+            source=self.request.source,
+            storage_mode=self.request.storage_mode,
+            original_path=self.request.original_path,
+            original_filename=self.request.original_filename,
+            suffixes=[] if self.request.suffixes is None else list(self.request.suffixes),
+        )
+
+    def _validate_metadata(
+        self,
+        *,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        set_phase: _PhaseSetter,
+    ) -> ValidationReport:
+        """Run validation hooks and return the add-operation validation report."""
+        set_phase(HOOK_PHASES["before_validate_metadata"].name)
+        hook_dispatcher.before_validate_metadata(context)
+        set_phase("validation")
+        context.user_metadata = _normalize_metadata_for_schema(
+            context.user_metadata,
+            schema_name=self.dependencies.schema_name(self.request.schema_record_type),
+        )
+        validation_report = self.dependencies.metadata_validation_report(
+            schema=self.request.schema,
+            metadata=context.user_metadata,
+            record_type=self.request.schema_record_type,
+        )
+        set_phase(HOOK_PHASES["after_validate_metadata"].name)
+        hook_dispatcher.after_validate_metadata(context, validation_report)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="validation",
+            level=_validation_audit_level(validation_report),
+            message=_validation_audit_message(validation_report),
+            details=_validation_audit_details(validation_report),
+        )
+        validation_report.raise_for_errors()
+        return validation_report
+
+    def _resolve_locator(
+        self,
+        *,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        set_phase: _PhaseSetter,
+    ) -> ArtifactLocator:
+        """Resolve the canonical artifact locator for an add operation."""
+        set_phase("locator-factory")
+        context.planned_locators = [self.request.locator_factory(context)]
+        set_phase(HOOK_PHASES["resolve_artifact_locator"].name)
+        hook_dispatcher.resolve_artifact_locator(context)
+        canonical_locator = _artifact_locator_from_context(context)
+        context.planned_locators[0] = canonical_locator
+        return canonical_locator
+
+    def _plan_storage(
+        self,
+        *,
+        context: OperationContext,
+        locator: ArtifactLocator,
+        validation_report: ValidationReport,
+        set_phase: _PhaseSetter,
+    ) -> _AddOperationPlan:
+        """Build and audit the storage plan for an add operation."""
+        set_phase("storage-plan")
+        context.storage_plan = (
+            self.request.storage_plan_factory(context, locator)
+            if self.request.storage_plan_factory is not None
+            else plan_storage(
+                locator,
+                target_kind=_target_kind_from_writer(self.request.artifact_writer),
+                write_mode=_write_mode_from_writer(self.request.artifact_writer),
+                ogcat_owned=self.request.artifact_writer is not None,
+                adapter=_adapter_name(locator),
+                storage_relative_path=locator.relative_path,
+                resolved_directory=_directory_from_locator(locator),
+                resolved_filename=_filename_from_locator(locator),
+            )
+        )
+        storage_plan = context.storage_plan
+        if storage_plan is None:
+            raise RuntimeError("Add operation did not produce a storage plan.")
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="write",
+            message="Storage plan prepared.",
+            details={
+                "write_phase": "storage-plan",
+                "storage_plan": _storage_plan_audit_details(storage_plan),
+            },
+            locator=locator,
+        )
+        if self.request.naming_metadata is not None:
+            self.request.naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
+        return _AddOperationPlan(
+            context=context,
+            locator=locator,
+            storage_plan=storage_plan,
+            validation_report=validation_report,
+        )
+
+    def _write_artifact(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Materialise or skip the artifact write for an add operation."""
+        if self.request.artifact_writer is None:
+            if add_plan.storage_plan.write_mode != "reference":
+                raise ValueError(
+                    f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
+                    "requires an artifact_writer."
+                )
+            self.dependencies.emit_operation_audit(
+                add_plan.context,
+                event_type="write",
+                message="Artifact write skipped for reference operation.",
+                details={
+                    "write_phase": "artifact-write",
+                    "write_mode": add_plan.storage_plan.write_mode,
+                },
+                locator=add_plan.locator,
+            )
+            return
+
+        set_phase("artifact-write")
+        self.request.artifact_writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
+        self.dependencies.emit_operation_audit(
+            add_plan.context,
+            event_type="write",
+            message="Artifact write completed.",
+            details={
+                "write_phase": "artifact-write",
+                "writer_type": type(self.request.artifact_writer).__name__,
+                "write_mode": add_plan.storage_plan.write_mode,
+            },
+            locator=add_plan.locator,
+        )
+
+    def _collect_metadata(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Collect derived metadata before record staging."""
+        set_phase("metadata-extraction")
+        _add_classification_metadata(add_plan.context, add_plan.locator)
+        if self.request.derived_metadata_collector is not None:
+            self.request.derived_metadata_collector(add_plan.context, add_plan.locator)
+        set_phase(HOOK_PHASES["extract_metadata"].name)
+        hook_dispatcher.extract_metadata(add_plan.context)
+        add_plan.context.derived_metadata = normalize_metadata(
+            add_plan.context.derived_metadata,
+            field_name="derived_metadata",
+        )
+
+    def _stage_record(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        set_phase: _PhaseSetter,
+    ) -> CatalogRecord:
+        """Stage the catalog record and run record-write hooks."""
+        set_phase(HOOK_PHASES["before_record_write"].name)
+        hook_dispatcher.before_record_write(add_plan.context)
+        add_plan.context.user_metadata = _normalize_metadata_for_schema(
+            add_plan.context.user_metadata,
+            schema_name=self.dependencies.schema_name(self.request.schema_record_type),
+        )
+        add_plan.context.derived_metadata = normalize_metadata(
+            add_plan.context.derived_metadata,
+            field_name="derived_metadata",
+        )
+        record = self.dependencies.build_artifact_record(
+            record_type=self.request.record_type,
+            locator=add_plan.locator,
+            metadata=add_plan.context.user_metadata,
+            storage_mode=self.request.storage_mode,
+            original_path=self.request.original_path,
+            original_filename=self.request.original_filename,
+            suffixes=self.request.suffixes,
+            derived_metadata=_metadata_with_hook_warnings(add_plan.context),
+            naming_metadata=self.request.naming_metadata,
+            time_added=self.request.time_added,
+        )
+        set_phase("record-write")
+        persisted = self.request.transaction.insert_staged_record(record)
+        add_plan.context.record_id = _require_record_id(persisted)
+        self.dependencies.emit_operation_audit(
+            add_plan.context,
+            event_type="write",
+            message="Record staged.",
+            details={
+                "write_phase": "record-write",
+                "transaction_state": self.request.transaction.state.value,
+            },
+            locator=add_plan.locator,
+        )
+        set_phase(HOOK_PHASES["after_record_write"].name)
+        hook_dispatcher.after_record_write(add_plan.context)
+        return persisted
+
+    def _commit_if_owned(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        hook_dispatcher: HookDispatcher,
+        set_phase: _PhaseSetter,
+    ) -> None:
+        """Commit internal add-operation transactions and run commit hooks."""
+        if not self.request.commit:
+            return
+        set_phase(HOOK_PHASES["before_commit"].name)
+        hook_dispatcher.before_commit(add_plan.context)
+        set_phase("commit")
+        self.request.transaction.commit()
+        self.dependencies.emit_operation_audit(
+            add_plan.context,
+            event_type="commit",
+            message="Commit succeeded.",
+            details={"transaction_state": self.request.transaction.state.value},
+            locator=add_plan.locator,
+        )
+        # After-commit hooks are best-effort: failures warn, but cannot turn an
+        # already-persisted record into an apparent API failure.
+        set_phase(HOOK_PHASES["after_commit"].name)
+        hook_dispatcher.after_commit(add_plan.context)
+
+    def _handle_error(
+        self,
+        *,
+        error: Exception,
+        context: OperationContext,
+        hook_dispatcher: HookDispatcher,
+        current_phase: str,
+    ) -> None:
+        """Audit and roll back a failed add operation."""
+        add_operation_note(error, context.operation_id)
+        hook_dispatcher.on_error(context, error)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="failure",
+            message=f"{self.request.operation_type} operation failed.",
+            details={
+                "phase": current_phase,
+                "transaction_state": self.request.transaction.state.value,
+                "caller_owned_transaction": not self.request.commit,
+            },
+            exception=error,
+        )
+        # Caller-supplied transactions stay caller-owned. Internal transactions
+        # commit=True and roll back here before re-raising.
+        if self.request.commit and self.request.transaction.state is not OperationState.COMMITTED:
+            self.dependencies.emit_operation_audit(
+                context,
+                event_type="rollback",
+                message="Rollback started.",
+                details={
+                    "rollback_phase": "started",
+                    "transaction_state": self.request.transaction.state.value,
+                },
+            )
+            self.request.transaction.rollback(original_exception=error)
+            hook_dispatcher.on_rollback(context, error)
+            if self.request.transaction.rollback_errors:
+                rollback_details: dict[str, object] = {
+                    "rollback_phase": "failed",
+                    "transaction_state": self.request.transaction.state.value,
+                    "rollback_errors": _rollback_errors_audit_details(
+                        self.request.transaction.rollback_errors
+                    ),
+                }
+                self.dependencies.emit_operation_audit(
+                    context,
+                    event_type="rollback",
+                    level="error",
+                    message="Rollback completed with failures.",
+                    details=rollback_details,
+                    exception=self.request.transaction.rollback_errors[0].exception,
+                )
+            else:
+                self.dependencies.emit_operation_audit(
+                    context,
+                    event_type="rollback",
+                    message="Rollback completed.",
+                    details={
+                        "rollback_phase": "completed",
+                        "transaction_state": self.request.transaction.state.value,
+                    },
+                )
+
+
+def _normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> MetadataDict:
+    """Normalize user metadata with the existing schema-aware error prefix."""
+    return normalize_metadata(
+        metadata,
+        field_name="metadata",
+        label=f"Metadata for schema {schema_name}",
+    )
+
+
+def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
+    """Return the canonical locator after locator-resolution hooks run."""
+    if not context.planned_locators:
+        raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
+    return context.planned_locators[0]
+
+
+def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
+    """Return derived metadata with non-fatal hook warnings included."""
+    metadata = normalize_metadata(context.derived_metadata, field_name="derived_metadata")
+    if context.warnings:
+        warnings_metadata: list[JsonValue] = [warning.to_metadata() for warning in context.warnings]
+        metadata["hook_warnings"] = warnings_metadata
+    return normalize_metadata(metadata, field_name="derived_metadata")
+
+
+def _add_classification_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
+    """Add cheap artifact classification metadata without overwriting caller values."""
+    classification = classify_artifact(
+        locator,
+        original_path=context.original_path,
+        original_filename=context.original_filename,
+        suffixes=context.suffixes,
+    )
+    existing = context.derived_metadata.get(CLASSIFICATION_METADATA_KEY)
+    if isinstance(existing, Mapping):
+        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = {
+            **classification,
+            **existing,
+        }
+    elif existing is None:
+        context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
+
+
+def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
+    """Return a storage plan adjusted to a hook-resolved canonical locator."""
+    if plan.locator == locator:
+        return plan
+    return replace(
+        plan,
+        locator=locator,
+        adapter=_adapter_name(locator),
+        storage_relative_path=locator.relative_path,
+        resolved_directory=_directory_from_locator(locator),
+        resolved_filename=_filename_from_locator(locator),
+    )
+
+
+def _naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
+    """Build record naming metadata from storage planning outputs."""
+    metadata: MetadataDict = {}
+    if plan.storage_relative_path is not None:
+        metadata["storage_relative_path"] = plan.storage_relative_path
+    if plan.resolved_directory is not None:
+        metadata["resolved_directory"] = plan.resolved_directory
+    if plan.resolved_filename is not None:
+        metadata["resolved_filename"] = plan.resolved_filename
+    return metadata
+
+
+def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
+    """Infer a storage target kind from a writer when it declares one."""
+    if artifact_writer is None:
+        return "file"
+    target_kind = getattr(artifact_writer, "target_kind", "file")
+    if target_kind in {"file", "directory"}:
+        return cast(TargetKind, target_kind)
+    return "file"
+
+
+def _write_mode_from_writer(artifact_writer: ArtifactWriter | None) -> WriteMode:
+    """Infer a storage write mode from a writer when it declares one."""
+    if artifact_writer is None:
+        return "reference"
+    write_mode = getattr(artifact_writer, "write_mode", "write")
+    if write_mode in {"copy", "move", "write", "reference"}:
+        return cast(WriteMode, write_mode)
+    return "write"
+
+
+def _adapter_name(locator: ArtifactLocator) -> str | None:
+    """Return the storage adapter name implied by a locator."""
+    if locator.kind == "path":
+        return "local"
+    if locator.kind == "urlpath":
+        return "fsspec"
+    return None
+
+
+def _filename_from_locator(locator: ArtifactLocator) -> str:
+    """Return the final filename-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).name
+    return locator.value.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _directory_from_locator(locator: ArtifactLocator) -> str:
+    """Return the directory-like component from a locator."""
+    if locator.kind == "path":
+        return Path(locator.value).parent.as_posix()
+    return locator.value.rstrip("/").rsplit("/", 1)[0]
+
+
+def _directory_from_relative_path(relative_path: str | None) -> str | None:
+    """Return the directory component from a storage-relative path."""
+    if relative_path is None:
+        return None
+    directory = Path(relative_path).parent.as_posix()
+    return "" if directory == "." else directory
+
+
+def _validation_audit_level(report: ValidationReport) -> str:
+    """Return the audit level for a validation report."""
+    if report.errors:
+        return "error"
+    if report.warnings:
+        return "warning"
+    return "info"
+
+
+def _validation_audit_message(report: ValidationReport) -> str:
+    """Return a concise validation audit message."""
+    if report.errors:
+        return "Metadata validation failed."
+    if report.warnings:
+        return "Metadata validation completed with warnings."
+    return "Metadata validation succeeded."
+
+
+def _validation_audit_details(report: ValidationReport) -> dict[str, object]:
+    """Return validation issue summaries for audit events."""
+    return {
+        "validation": {
+            "error_count": len(report.errors),
+            "warning_count": len(report.warnings),
+            "issues": [
+                {
+                    "path": issue.path,
+                    "message": issue.message,
+                    "severity": issue.severity,
+                    "code": issue.code,
+                    "hint": issue.hint,
+                }
+                for issue in report.issues
+            ],
+        }
+    }
+
+
+def _storage_plan_audit_details(plan: StoragePlan) -> dict[str, object]:
+    """Return storage plan details that are safe for audit logging."""
+    return {
+        "target_kind": plan.target_kind,
+        "write_mode": plan.write_mode,
+        "checksum": plan.checksum,
+        "ogcat_owned": plan.ogcat_owned,
+        "profile": plan.profile,
+        "adapter": plan.adapter,
+        "time_added": plan.time_added,
+        "storage_relative_path": plan.storage_relative_path,
+        "resolved_directory": plan.resolved_directory,
+        "resolved_filename": plan.resolved_filename,
+    }
+
+
+def _rollback_errors_audit_details(rollback_errors: list[RollbackFailure]) -> list[dict[str, str]]:
+    """Return rollback failure summaries for audit events."""
+    return [
+        {
+            "description": failure.description,
+            "exception_type": type(failure.exception).__name__,
+            "exception_message": str(failure.exception),
+        }
+        for failure in rollback_errors
+    ]
+
+
+def _require_record_id(record: CatalogRecord) -> str:
+    """Return a persisted record id."""
+    if record.id is None:
+        raise RuntimeError("Repository returned a persisted record without an id.")
+    return record.id

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -1,9 +1,23 @@
-"""Internal coordinator for catalog add operations."""
+"""Internal operation runner interfaces and the add-operation implementation.
+
+``Catalog`` owns public API argument handling, schema selection, and transaction
+creation. Operation runners own the operation lifecycle once those inputs are
+prepared. The module-level ``OperationRunner`` ABC is intentionally generic so
+future operation families, such as artifact updates, can implement the same
+``run()`` command interface without pretending they are add operations.
+
+``AddOperationRunner`` is the concrete runner for the current add lifecycle. It
+uses a template-style flow: ``run()`` fixes the ordering of validation, locator
+resolution, storage planning, artifact writing, metadata collection, record
+staging, commit, and rollback, while private phase methods keep each step
+separately testable and replaceable by future sibling runners.
+"""
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, cast
 
@@ -19,6 +33,14 @@ from ogcat.hooks import (
     OperationSource,
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
+from ogcat.operation_helpers import (
+    adapter_name,
+    artifact_locator_from_context,
+    directory_from_locator,
+    filename_from_locator,
+    naming_metadata_from_storage_plan,
+    normalize_metadata_for_schema,
+)
 from ogcat.spec import RecordSchema
 from ogcat.storage import StoragePlan, TargetKind, WriteMode, plan_storage
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
@@ -30,7 +52,7 @@ DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 _PhaseSetter = Callable[[str], None]
 
 
-class _OperationAuditEmitter(Protocol):
+class OperationAuditEmitter(Protocol):
     """Callable used by the runner to emit catalog operation audit events."""
 
     def __call__(
@@ -48,7 +70,7 @@ class _OperationAuditEmitter(Protocol):
         ...
 
 
-class _MetadataValidationReporter(Protocol):
+class MetadataValidationReporter(Protocol):
     """Callable used by the runner to validate operation metadata."""
 
     def __call__(
@@ -62,7 +84,7 @@ class _MetadataValidationReporter(Protocol):
         ...
 
 
-class _ArtifactRecordBuilder(Protocol):
+class ArtifactRecordBuilder(Protocol):
     """Callable used by the runner to build a catalog record."""
 
     def __call__(
@@ -85,20 +107,20 @@ class _ArtifactRecordBuilder(Protocol):
 
 
 @dataclass(slots=True)
-class _OperationRunnerDependencies:
-    """Catalog-owned collaborators used by an add operation runner."""
+class OperationServices:
+    """Catalog-owned services shared by internal operation runners."""
 
     catalog_root: Path
     hook_manager: HookManager
     schema_name: Callable[[str | None], str]
-    metadata_validation_report: _MetadataValidationReporter
-    build_artifact_record: _ArtifactRecordBuilder
-    emit_operation_audit: _OperationAuditEmitter
+    metadata_validation_report: MetadataValidationReporter
+    build_artifact_record: ArtifactRecordBuilder
+    emit_operation_audit: OperationAuditEmitter
     emit_hook_lifecycle_audit: HookLifecycleCallback
 
 
 @dataclass(slots=True)
-class _AddOperationRequest:
+class AddOperationRequest:
     """Inputs required to run one catalog add operation."""
 
     transaction: UnitOfWork
@@ -132,12 +154,21 @@ class _AddOperationPlan:
     validation_report: ValidationReport
 
 
-@dataclass(slots=True)
-class OperationRunner:
-    """Internal coordinator for one add-operation lifecycle."""
+class OperationRunner(ABC):
+    """Explicit command interface for internal operation runners."""
 
-    dependencies: _OperationRunnerDependencies
-    request: _AddOperationRequest
+    @abstractmethod
+    def run(self) -> CatalogRecord:
+        """Run the operation and return the persisted or staged record."""
+        ...
+
+
+@dataclass(slots=True)
+class AddOperationRunner(OperationRunner):
+    """Template-method coordinator for one internal add-operation lifecycle."""
+
+    dependencies: OperationServices
+    request: AddOperationRequest
 
     def run(self) -> CatalogRecord:
         """Run the add operation and return the persisted or staged record."""
@@ -229,7 +260,7 @@ class OperationRunner:
         set_phase(HOOK_PHASES["before_validate_metadata"].name)
         hook_dispatcher.before_validate_metadata(context)
         set_phase("validation")
-        context.user_metadata = _normalize_metadata_for_schema(
+        context.user_metadata = normalize_metadata_for_schema(
             context.user_metadata,
             schema_name=self.dependencies.schema_name(self.request.schema_record_type),
         )
@@ -262,7 +293,7 @@ class OperationRunner:
         context.planned_locators = [self.request.locator_factory(context)]
         set_phase(HOOK_PHASES["resolve_artifact_locator"].name)
         hook_dispatcher.resolve_artifact_locator(context)
-        canonical_locator = _artifact_locator_from_context(context)
+        canonical_locator = artifact_locator_from_context(context)
         context.planned_locators[0] = canonical_locator
         return canonical_locator
 
@@ -284,10 +315,10 @@ class OperationRunner:
                 target_kind=_target_kind_from_writer(self.request.artifact_writer),
                 write_mode=_write_mode_from_writer(self.request.artifact_writer),
                 ogcat_owned=self.request.artifact_writer is not None,
-                adapter=_adapter_name(locator),
+                adapter=adapter_name(locator),
                 storage_relative_path=locator.relative_path,
-                resolved_directory=_directory_from_locator(locator),
-                resolved_filename=_filename_from_locator(locator),
+                resolved_directory=directory_from_locator(locator),
+                resolved_filename=filename_from_locator(locator),
             )
         )
         storage_plan = context.storage_plan
@@ -304,7 +335,7 @@ class OperationRunner:
             locator=locator,
         )
         if self.request.naming_metadata is not None:
-            self.request.naming_metadata.update(_naming_metadata_from_storage_plan(storage_plan))
+            self.request.naming_metadata.update(naming_metadata_from_storage_plan(storage_plan))
         return _AddOperationPlan(
             context=context,
             locator=locator,
@@ -380,7 +411,7 @@ class OperationRunner:
         """Stage the catalog record and run record-write hooks."""
         set_phase(HOOK_PHASES["before_record_write"].name)
         hook_dispatcher.before_record_write(add_plan.context)
-        add_plan.context.user_metadata = _normalize_metadata_for_schema(
+        add_plan.context.user_metadata = normalize_metadata_for_schema(
             add_plan.context.user_metadata,
             schema_name=self.dependencies.schema_name(self.request.schema_record_type),
         )
@@ -507,22 +538,6 @@ class OperationRunner:
                 )
 
 
-def _normalize_metadata_for_schema(metadata: object, *, schema_name: str) -> MetadataDict:
-    """Normalize user metadata with the existing schema-aware error prefix."""
-    return normalize_metadata(
-        metadata,
-        field_name="metadata",
-        label=f"Metadata for schema {schema_name}",
-    )
-
-
-def _artifact_locator_from_context(context: OperationContext) -> ArtifactLocator:
-    """Return the canonical locator after locator-resolution hooks run."""
-    if not context.planned_locators:
-        raise ValueError("resolve_artifact_locator hook removed the planned artifact locator.")
-    return context.planned_locators[0]
-
-
 def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
     """Return derived metadata with non-fatal hook warnings included."""
     metadata = normalize_metadata(context.derived_metadata, field_name="derived_metadata")
@@ -550,32 +565,6 @@ def _add_classification_metadata(context: OperationContext, locator: ArtifactLoc
         context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
 
 
-def _storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> StoragePlan:
-    """Return a storage plan adjusted to a hook-resolved canonical locator."""
-    if plan.locator == locator:
-        return plan
-    return replace(
-        plan,
-        locator=locator,
-        adapter=_adapter_name(locator),
-        storage_relative_path=locator.relative_path,
-        resolved_directory=_directory_from_locator(locator),
-        resolved_filename=_filename_from_locator(locator),
-    )
-
-
-def _naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
-    """Build record naming metadata from storage planning outputs."""
-    metadata: MetadataDict = {}
-    if plan.storage_relative_path is not None:
-        metadata["storage_relative_path"] = plan.storage_relative_path
-    if plan.resolved_directory is not None:
-        metadata["resolved_directory"] = plan.resolved_directory
-    if plan.resolved_filename is not None:
-        metadata["resolved_filename"] = plan.resolved_filename
-    return metadata
-
-
 def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
     """Infer a storage target kind from a writer when it declares one."""
     if artifact_writer is None:
@@ -594,37 +583,6 @@ def _write_mode_from_writer(artifact_writer: ArtifactWriter | None) -> WriteMode
     if write_mode in {"copy", "move", "write", "reference"}:
         return cast(WriteMode, write_mode)
     return "write"
-
-
-def _adapter_name(locator: ArtifactLocator) -> str | None:
-    """Return the storage adapter name implied by a locator."""
-    if locator.kind == "path":
-        return "local"
-    if locator.kind == "urlpath":
-        return "fsspec"
-    return None
-
-
-def _filename_from_locator(locator: ArtifactLocator) -> str:
-    """Return the final filename-like component from a locator."""
-    if locator.kind == "path":
-        return Path(locator.value).name
-    return locator.value.rstrip("/").rsplit("/", 1)[-1]
-
-
-def _directory_from_locator(locator: ArtifactLocator) -> str:
-    """Return the directory-like component from a locator."""
-    if locator.kind == "path":
-        return Path(locator.value).parent.as_posix()
-    return locator.value.rstrip("/").rsplit("/", 1)[0]
-
-
-def _directory_from_relative_path(relative_path: str | None) -> str | None:
-    """Return the directory component from a storage-relative path."""
-    if relative_path is None:
-        return None
-    directory = Path(relative_path).parent.as_posix()
-    return "" if directory == "." else directory
 
 
 def _validation_audit_level(report: ValidationReport) -> str:

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -1,0 +1,304 @@
+"""Regression tests for the internal add-operation lifecycle phases."""
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogSpec,
+    MetadataFieldDescription,
+    OperationContext,
+    OperationSource,
+    PluginRegistry,
+    RecordSchema,
+    ValidationReport,
+)
+
+
+def test_add_file_lifecycle_preserves_hook_order_and_file_storage(tmp_path: Path) -> None:
+    """add_file runs hooks in lifecycle order and stores the copied file."""
+    calls: list[str] = []
+
+    class LifecycleHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append("before_validate_metadata")
+
+        def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+            calls.append(f"after_validate_metadata:{report.ok}")
+
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            calls.append("resolve_artifact_locator")
+
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            calls.append("extract_metadata")
+            return {"extract_hook": context.operation_type}
+
+        def before_record_write(self, context: OperationContext) -> None:
+            calls.append("before_record_write")
+
+        def after_record_write(self, context: OperationContext) -> None:
+            calls.append(f"after_record_write:{context.record_id is not None}")
+
+        def before_commit(self, context: OperationContext) -> None:
+            calls.append("before_commit")
+
+        def after_commit(self, context: OperationContext) -> None:
+            calls.append("after_commit")
+
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        plugins=PluginRegistry([LifecycleHook()]),
+    )
+
+    record = catalog.add_file(source)
+
+    assert calls == [
+        "before_validate_metadata",
+        "after_validate_metadata:True",
+        "resolve_artifact_locator",
+        "extract_metadata",
+        "before_record_write",
+        "after_record_write:True",
+        "before_commit",
+        "after_commit",
+    ]
+    assert record.stored_abspath is not None
+    assert Path(record.stored_abspath).exists()
+    assert record.derived_metadata["extract_hook"] == "add_file"
+
+
+def test_record_only_add_artifact_skips_artifact_write(tmp_path: Path) -> None:
+    """Record-only add_artifact stores the locator without creating the target."""
+    target = tmp_path / "generated.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=OperationSource(kind="text", descriptor="record only"),
+    )
+
+    assert record.locator == ArtifactLocator.path(target)
+    assert record.stored_abspath == str(target)
+    assert not target.exists()
+    assert catalog.repository.all() == [record]
+
+
+def test_writer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path) -> None:
+    """Writer-backed add_artifact writes the target and persists writer metadata."""
+
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
+            context.derived_metadata["writer_text_length"] = len(str(source.metadata["text"]))
+
+    target = tmp_path / "outputs" / "generated.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=OperationSource(kind="text", descriptor="inline text", metadata={"text": "hello"}),
+        artifact_writer=TextWriter(),
+    )
+
+    assert target.read_text(encoding="utf-8") == "hello"
+    assert record.derived_metadata["writer_text_length"] == 5
+
+
+def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path) -> None:
+    """A post-write hook failure rolls back writer cleanup and the staged record."""
+    rollback_calls: list[str] = []
+
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text("created", encoding="utf-8")
+
+            def rollback() -> None:
+                rollback_calls.append("writer")
+                target_path.unlink(missing_ok=True)
+
+            context.rollback(rollback, description="remove generated text")
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop after writer")
+
+    target = tmp_path / "outputs" / "generated.txt"
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="artifacts"),
+        plugins=PluginRegistry([FailingHook()]),
+    )
+
+    with pytest.raises(RuntimeError, match="stop after writer"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            source=OperationSource(kind="text", descriptor="inline text"),
+            artifact_writer=TextWriter(),
+        )
+
+    assert rollback_calls == ["writer"]
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path: Path) -> None:
+    """Validation errors still call after_validate_metadata and stop before writes."""
+    calls: list[str] = []
+
+    class ValidationHook:
+        def before_validate_metadata(self, context: OperationContext) -> None:
+            calls.append("before_validate_metadata")
+
+        def after_validate_metadata(self, context: OperationContext, report: ValidationReport) -> None:
+            calls.append(f"after_validate_metadata:{report.ok}")
+
+        def resolve_artifact_locator(self, context: OperationContext) -> None:
+            calls.append("resolve_artifact_locator")
+
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            calls.append("writer")
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.write_text("should not happen", encoding="utf-8")
+
+    target = tmp_path / "outputs" / "generated.txt"
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="artifacts",
+            default_schema=RecordSchema(
+                metadata_fields=[
+                    MetadataFieldDescription(
+                        name="title",
+                        description="Required title.",
+                        required=True,
+                    )
+                ]
+            ),
+        ),
+        plugins=PluginRegistry([ValidationHook()]),
+    )
+
+    with pytest.raises(ValueError, match="Missing required metadata for schema default: title"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            metadata={},
+            source=OperationSource(kind="text", descriptor="inline text"),
+            artifact_writer=TextWriter(),
+        )
+
+    assert calls == ["before_validate_metadata", "after_validate_metadata:False"]
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_derived_metadata_from_writer_extract_hook_and_record_hook_persists(tmp_path: Path) -> None:
+    """Derived metadata mutations from write, extract, and record phases persist."""
+
+    class MetadataHook:
+        def extract_metadata(self, context: OperationContext) -> dict[str, object]:
+            return {"extract_hook": True}
+
+        def before_record_write(self, context: OperationContext) -> None:
+            context.derived_metadata["record_hook"] = context.record_type
+
+    class TextWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text("payload", encoding="utf-8")
+            context.derived_metadata["writer"] = source.kind
+
+    target = tmp_path / "outputs" / "metadata.txt"
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="artifacts"),
+        plugins=PluginRegistry([MetadataHook()]),
+    )
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=OperationSource(kind="text", descriptor="inline text"),
+        artifact_writer=TextWriter(),
+    )
+
+    assert record.derived_metadata["writer"] == "text"
+    assert record.derived_metadata["extract_hook"] is True
+    assert record.derived_metadata["record_hook"] == "generated_text"
+
+
+def test_writer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: Path) -> None:
+    """A failing writer rolls back registered cleanup before any record exists."""
+    rollback_calls: list[str] = []
+
+    class FailingWriter:
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            target_path = target.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text("partial", encoding="utf-8")
+
+            def rollback() -> None:
+                rollback_calls.append("writer")
+                target_path.unlink(missing_ok=True)
+
+            context.rollback(rollback, description="remove partial writer output")
+            raise OSError("writer failed")
+
+    target = tmp_path / "outputs" / "partial.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(OSError, match="writer failed"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            source=OperationSource(kind="text", descriptor="inline text"),
+            artifact_writer=FailingWriter(),
+        )
+
+    assert rollback_calls == ["writer"]
+    assert not target.exists()
+    assert catalog.repository.all() == []

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -1,20 +1,67 @@
 """Regression tests for the internal add-operation lifecycle phases."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+import ogcat.catalog as catalog_module
 from ogcat import (
     ArtifactLocator,
     Catalog,
+    CatalogRecord,
     CatalogSpec,
     MetadataFieldDescription,
     OperationContext,
     OperationSource,
+    OperationState,
     PluginRegistry,
     RecordSchema,
     ValidationReport,
 )
+
+
+def test_run_add_operation_delegates_to_operation_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog add setup delegates the lifecycle to OperationRunner."""
+    captured: dict[str, Any] = {}
+
+    class FakeRunner:
+        def __init__(self, *, dependencies: object, request: object) -> None:
+            captured["dependencies"] = dependencies
+            captured["request"] = request
+
+        def run(self) -> CatalogRecord:
+            request = captured["request"]
+            return CatalogRecord(
+                catalog="artifacts",
+                time_added="2026-05-14T00:00:00+00:00",
+                id="runner",
+                record_type=request.record_type,
+                locator=ArtifactLocator(kind="uri", value="s3://bucket/delegated.zarr"),
+            )
+
+    monkeypatch.setattr(catalog_module, "OperationRunner", FakeRunner)
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+        metadata={"title": "Delegated"},
+    )
+
+    dependencies = captured["dependencies"]
+    request = captured["request"]
+    assert dependencies.catalog_root == catalog.root
+    assert dependencies.hook_manager is catalog.hook_manager
+    assert request.transaction.repository is catalog.repository
+    assert request.commit is True
+    assert request.operation_type == "add_artifact"
+    assert request.record_type == "external_reference"
+    assert request.metadata == {"title": "Delegated"}
+    assert record.id == "runner"
 
 
 def test_add_file_lifecycle_preserves_hook_order_and_file_storage(tmp_path: Path) -> None:
@@ -163,6 +210,60 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
     assert rollback_calls == ["writer"]
     assert not target.exists()
     assert catalog.repository.all() == []
+
+
+def test_operation_runner_preserves_failure_audit_phase_and_rollback(tmp_path: Path) -> None:
+    """Runner-owned failures keep the existing failure phase and rollback audit."""
+
+    class FailingHook:
+        def before_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("stop before record")
+
+    source = tmp_path / "failure.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        plugins=PluginRegistry([FailingHook()]),
+    )
+
+    with pytest.raises(RuntimeError, match="stop before record"):
+        catalog.add_file(source)
+
+    events = catalog.audit_events()
+    failure = next(event for event in events if event.event_type == "failure")
+    rollback_events = [event for event in events if event.event_type == "rollback"]
+    assert failure.details["phase"] == "before_record_write"
+    assert [event.message for event in rollback_events] == ["Rollback started.", "Rollback completed."]
+    assert catalog.repository.all() == []
+    assert source.exists()
+
+
+def test_operation_runner_preserves_caller_owned_transaction_on_hook_failure(tmp_path: Path) -> None:
+    """Caller-owned transactions remain staged when post-record hooks fail."""
+
+    class FailingAfterWriteHook:
+        def after_record_write(self, context: OperationContext) -> None:
+            raise RuntimeError("external transaction hook failure")
+
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="artifacts"),
+        plugins=PluginRegistry([FailingAfterWriteHook()]),
+    )
+
+    with catalog.transaction() as transaction:
+        with pytest.raises(RuntimeError, match="external transaction hook failure"):
+            catalog.add_artifact(
+                record_type="external_reference",
+                locator=ArtifactLocator(kind="uri", value="s3://bucket/data.zarr"),
+                transaction=transaction,
+            )
+
+        assert transaction.state is OperationState.STAGED
+        assert len(catalog.repository.all()) == 1
+        transaction.rollback()
+        assert catalog.repository.all() == []
 
 
 def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path: Path) -> None:

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -1,11 +1,9 @@
 """Regression tests for the internal add-operation lifecycle phases."""
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-import ogcat.catalog as catalog_module
 from ogcat import (
     ArtifactLocator,
     Catalog,
@@ -19,6 +17,7 @@ from ogcat import (
     RecordSchema,
     ValidationReport,
 )
+from ogcat.operation_runner import AddOperationRequest, OperationRunner
 
 
 def test_run_add_operation_delegates_to_operation_runner(
@@ -26,24 +25,29 @@ def test_run_add_operation_delegates_to_operation_runner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Catalog add setup delegates the lifecycle to OperationRunner."""
-    captured: dict[str, Any] = {}
+    requests: list[AddOperationRequest] = []
+    runners: list[OperationRunner] = []
 
-    class FakeRunner:
-        def __init__(self, *, dependencies: object, request: object) -> None:
-            captured["dependencies"] = dependencies
-            captured["request"] = request
+    class FakeRunner(OperationRunner):
+        def __init__(self, request: AddOperationRequest) -> None:
+            self.request = request
 
         def run(self) -> CatalogRecord:
-            request = captured["request"]
             return CatalogRecord(
                 catalog="artifacts",
                 time_added="2026-05-14T00:00:00+00:00",
                 id="runner",
-                record_type=request.record_type,
+                record_type=self.request.record_type,
                 locator=ArtifactLocator(kind="uri", value="s3://bucket/delegated.zarr"),
             )
 
-    monkeypatch.setattr(catalog_module, "OperationRunner", FakeRunner)
+    def build_fake_runner(self: Catalog, request: AddOperationRequest) -> OperationRunner:
+        requests.append(request)
+        runner = FakeRunner(request)
+        runners.append(runner)
+        return runner
+
+    monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     record = catalog.add_artifact(
@@ -52,10 +56,10 @@ def test_run_add_operation_delegates_to_operation_runner(
         metadata={"title": "Delegated"},
     )
 
-    dependencies = captured["dependencies"]
-    request = captured["request"]
-    assert dependencies.catalog_root == catalog.root
-    assert dependencies.hook_manager is catalog.hook_manager
+    assert len(requests) == 1
+    assert len(runners) == 1
+    request = requests[0]
+    assert isinstance(runners[0], OperationRunner)
     assert request.transaction.repository is catalog.repository
     assert request.commit is True
     assert request.operation_type == "add_artifact"


### PR DESCRIPTION
## Summary
- Extract the add-operation flow from `Catalog._run_add_operation()` into a private internal `OperationRunner` coordinator.
- Keep `Catalog` as the public setup/API layer while preserving hook order, audit behavior, rollback semantics, and caller-owned transaction handling.
- Add focused regression coverage for delegation, validation boundaries, writer-backed and record-only adds, and rollback paths.

## Testing
- Added lifecycle regression tests for add-file, add-artifact, validation failure, writer failure, hook failure, derived metadata propagation, and caller-owned transactions.
- Linting, formatting, type checking, and the full pytest suite passed locally.