### PR TITLE
Add replica tree views and storage-backed replica handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ descriptions, and locating stored paths.
 ## Scope
 
 - local catalogs centred on managed file ingest
-- a self-describing catalog layout with `catalog.json`, `db.json`, and `files/`
+- a self-describing catalog layout with `catalog.json`, `db.json`, and `data/`
 - path-based managed ingest using `copy` or `move`
 - reference records for existing local paths, URIs, and explicit URI/urlpath locators
 - flexible JSON-serialisable user metadata
@@ -37,7 +37,7 @@ descriptions, and locating stored paths.
 - Records: each record stores reserved top-level fields plus `user_metadata`, `derived_metadata`,
   and `naming_metadata`. Records now also carry a small `record_type` and `locator` so the model
   can grow beyond copied or moved local files without changing the basic catalog shape.
-- Naming and templates: managed files default to UUID primary paths under `files/objects/`.
+- Naming and templates: managed files default to UUID primary paths under `data/objects/`.
   Directory and filename templates produce human-readable symlink replicas or regenerated views.
 - Derived metadata extractors: optional extractors can add lightweight summaries after ingest. The current implementation includes a netCDF extractor when `xarray` is installed.
 - Hooks and plugins: projects can register Python hook objects to add domain-specific metadata,
@@ -52,12 +52,15 @@ Each catalog root is self-describing:
 <catalog-root>/
   catalog.json
   db.json
-  files/
+  data/
+    files/
+    objects/
 ```
 
 - `catalog.json`: catalog specification, default schema, and optional named record schemas
 - `db.json`: TinyDB-backed record store
-- `files/`: managed storage root for ingested files
+- `data/files/`: human-readable template replicas and template-primary artifacts
+- `data/objects/`: UUID primary objects for default managed ingest
 
 ## Installation
 
@@ -180,7 +183,7 @@ catalog = Catalog.create("example-catalog", spec, plugins=plugins)
 See [docs/design-note-hooks-plugins.md](docs/design-note-hooks-plugins.md) for hook lifecycle,
 rollback, and transaction examples.
 
-Use `add_file()` when ogcat should manage a local copy or move into the catalog's `files/` tree.
+Use `add_file()` when ogcat should manage a local copy or move into the catalog's `data/objects/` tree.
 Use `add_reference()` when the artifact already exists and ogcat should only record a local path,
 URI, URL path, or explicit `ArtifactLocator`. Use `add_artifact()` with an `OperationSource` and
 artifact writer when a plugin or helper should materialise new data before the record is written.
@@ -311,7 +314,7 @@ uv run python -m http.server 8000
 ## Storage Model
 
 Current storage is still centred on path-backed managed ingest for the MVP. Files added with
-`add_file()` are copied or moved into the catalog's `files/objects/` tree by default, and the
+`add_file()` are copied or moved into the catalog's `data/objects/` tree by default, and the
 resulting primary path is recorded in the catalog database alongside metadata and naming
 information. Template-derived paths are linked replicas that can be regenerated after metadata or
 template changes. Existing paths, URIs, and explicit URI/urlpath locators can be recorded with

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ descriptions, and locating stored paths.
 - Records: each record stores reserved top-level fields plus `user_metadata`, `derived_metadata`,
   and `naming_metadata`. Records now also carry a small `record_type` and `locator` so the model
   can grow beyond copied or moved local files without changing the basic catalog shape.
-- Naming and templates: file placement under `files/` is driven by simple directory and filename templates evaluated from record id, source filename parts, timestamps, and user metadata.
+- Naming and templates: managed files default to UUID primary paths under `files/objects/`.
+  Directory and filename templates produce human-readable symlink replicas or regenerated views.
 - Derived metadata extractors: optional extractors can add lightweight summaries after ingest. The current implementation includes a netCDF extractor when `xarray` is installed.
 - Hooks and plugins: projects can register Python hook objects to add domain-specific metadata,
   validation, rollback, and lifecycle behavior without adding that logic to `ogcat` core.
@@ -186,6 +187,10 @@ artifact writer when a plugin or helper should materialise new data before the r
 See `ogcat.writers` for small helper wrappers around in-memory data, path-backed transforms, and zip
 extraction examples.
 
+By default, `add_file()` stores the primary artifact under a UUID path and creates a template-based
+symlink replica for human-readable browsing. Pass `primary_location="template"` when the template
+path should be the primary storage location.
+
 Use `catalog.plan_artifact_storage(...)` to dry-run a planned target before writing. The returned
 `StoragePlan` contains the locator, write intent, and resolved naming outputs; pass record metadata
 explicitly when calling `add_artifact(storage_plan=...)`. The plan is available to hooks and artifact
@@ -194,6 +199,10 @@ ogcat derives a plan from the writer's declared `target_kind` and `write_mode` w
 Domain logic can create directory-like artifacts such as NetCDF collections or `.zarr` stores while
 ogcat core records only generic locators and metadata. Artifact writers remain the place where
 filesystem work and rollback registration happen.
+
+Use `catalog.plan_view(root, template, mode="symlink", ...)` to dry-run a generated symlink view
+from current catalog metadata. The returned plan reports collisions, unsupported locators, and
+missing primary paths before `plan.apply()` creates any links.
 
 ## CLI
 
@@ -301,11 +310,12 @@ uv run python -m http.server 8000
 
 ## Storage Model
 
-Current storage is still centred on path-based managed ingest for the MVP. Files added with
-`add_file()` are copied or moved into the catalog's `files/` tree, and the resulting stored path is
-recorded in the catalog database alongside metadata and naming information. Existing paths, URIs,
-and explicit URI/urlpath locators can be recorded with `add_reference()` without copying or moving
-data.
+Current storage is still centred on path-backed managed ingest for the MVP. Files added with
+`add_file()` are copied or moved into the catalog's `files/objects/` tree by default, and the
+resulting primary path is recorded in the catalog database alongside metadata and naming
+information. Template-derived paths are linked replicas that can be regenerated after metadata or
+template changes. Existing paths, URIs, and explicit URI/urlpath locators can be recorded with
+`add_reference()` without copying or moving data.
 
 Records now also include a minimal locator block:
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ API reference
    models
    search
    storage
+   replicas
    hooks
    validation
    writers-transactions

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -26,7 +26,7 @@ Models and specifications
 
 .. autoclass:: ogcat.CatalogSpec
    :members:
-   :exclude-members: catalog_name, db_backend, db_path, files_root, default_operation, field_resolution_order, default_schema, record_schemas
+   :exclude-members: catalog_name, db_backend, db_path, files_root, objects_root, default_operation, field_resolution_order, default_schema, record_schemas
    :member-order: bysource
 
 .. autoclass:: ogcat.RecordSchema

--- a/docs/api/replicas.rst
+++ b/docs/api/replicas.rst
@@ -1,0 +1,6 @@
+Replica views
+=============
+
+.. automodule:: ogcat.replicas
+   :members:
+   :member-order: bysource

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,10 @@ stop the internal model from assuming every record is a copied or moved local fi
 For the current MVP:
 
 - `add_file()` still performs managed ingest by copy or move
-- managed file records store a `path` locator
+- managed file records store a `path` locator for the primary artifact, which
+  defaults to a UUID-backed path under `files/objects/`
+- schema templates create derived symlink replicas and generated views rather
+  than defining the primary path by default
 - compatibility fields `stored_abspath` and `stored_relpath` remain present for today's APIs and
   CLI
 - `Catalog.path()` resolves only path-backed records and returns `None` for records that are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,10 +25,15 @@ The catalog root is self-describing:
 <catalog-root>/
   catalog.json
   db.json
-  files/
+  data/
+    files/
+    objects/
 ```
 
-`catalog.json` defines how the catalog behaves. `db.json` stores records. `files/` is the managed storage root for ingested files.
+`catalog.json` defines how the catalog behaves. `db.json` stores records.
+`data/files/` holds human-readable template replicas and template-primary
+artifacts. `data/objects/` holds UUID primary objects for default managed
+ingest.
 
 ## First Pass Artifact Generalisation
 
@@ -45,7 +50,7 @@ For the current MVP:
 
 - `add_file()` still performs managed ingest by copy or move
 - managed file records store a `path` locator for the primary artifact, which
-  defaults to a UUID-backed path under `files/objects/`
+  defaults to a UUID-backed path under `data/objects/`
 - schema templates create derived symlink replicas and generated views rather
   than defining the primary path by default
 - compatibility fields `stored_abspath` and `stored_relpath` remain present for today's APIs and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,5 +138,5 @@ ogcat spec set FIELD=VALUE ... --catalog <root>
 including ``display_fields`` when configured.
 
 ``ogcat spec set`` supports simple fields such as ``catalog_name``,
-``default_operation``, and ``field_resolution_order``. ``files_root`` changes
-are rejected because they require a dedicated file migration operation.
+``default_operation``, and ``field_resolution_order``. Storage root changes
+are rejected because they require a dedicated migration operation.

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -44,7 +44,9 @@ Use the three catalog add methods for different storage responsibilities:
 ## Managed files
 
 ``catalog.add_file()`` copies or moves the source file into the catalog's
-``files/`` tree and records a ``path`` locator pointing at the stored copy.
+``files/objects/`` tree by default and records a ``path`` locator pointing at
+that UUID-backed primary copy. The configured directory and filename templates
+create a human-readable symlink replica, not the canonical artifact path.
 
 ```python
 record = catalog.add_file(
@@ -52,23 +54,36 @@ record = catalog.add_file(
     metadata={"species": "CO2"},
     operation="copy",     # or "move"
 )
-print(record.path())      # path inside files/
+print(record.path())      # primary UUID path inside files/objects/
 ```
 
-The storage location is derived from directory and filename templates stored
-in ``catalog.json``.  The defaults are:
+The human-readable replica location is derived from directory and filename
+templates stored in ``catalog.json``. The defaults are:
 
 ```
 directory: {year_added}/{original_stem}
 filename:  {title_slug|original_stem}{original_suffix}
 ```
 
+Pass ``primary_location="template"`` to keep the older template-primary
+behavior:
+
+```python
+record = catalog.add_file(
+    Path("data.nc"),
+    metadata={"species": "CO2"},
+    primary_location="template",
+)
+```
+
 ## Storage plans
 
 ``Catalog.plan_artifact_storage()`` performs the planning part of an add operation
-without writing data or inserting a record.  It validates metadata, applies the
-same naming templates, lets locator-resolution hooks adjust the result, and
-returns a ``StoragePlan``.
+without writing data or inserting a record. It validates metadata, applies the
+primary placement policy, lets locator-resolution hooks adjust the result, and
+returns a ``StoragePlan``. The default primary placement is UUID-backed; pass
+``primary_location="template"`` when schema templates should define the primary
+target.
 
 ```python
 plan = catalog.plan_artifact_storage(
@@ -83,6 +98,29 @@ print(plan.locator)
 target kind, write mode, storage-relative path, resolved directory, and resolved
 filename.  It does not carry record metadata; pass metadata again to
 ``add_artifact(...)`` when turning a storage plan into a record.
+
+## Generated replica views
+
+Use ``Catalog.plan_view()`` to build generated human-readable views from current
+record metadata and primary locators. Planning is a dry run: it renders target
+paths, reports duplicate paths and unsupported records, and does not create
+links.
+
+```python
+plan = catalog.plan_view(
+    root="./by-product",
+    template="{product}/{species}/{id}_{original_filename}",
+    mode="symlink",
+    where={"provenance": "derived"},
+)
+print(plan.collisions)
+result = plan.apply()
+print(result.created)
+```
+
+For v1, only local symlink replicas are supported. URI and URL-path records are
+reported as unsupported for local views, and missing primary paths are reported
+before applying unless ``skip_errors=True`` is passed to ``apply()``.
 
 ## Overriding template-derived storage paths
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -33,7 +33,7 @@ directly, but ogcat does not interpret them beyond recording the string value.
 Use the three catalog add methods for different storage responsibilities:
 
 - ``Catalog.add_file(...)`` is for managed local ingest. It copies or moves a
-  local source into the catalog's ``files/`` tree.
+  local source into the catalog's ``data/objects/`` tree by default.
 - ``Catalog.add_reference(...)`` is for artifacts that already exist. It records
   a local path, URI, URI locator, or URL-path locator without copying, moving,
   or writing artifact data.
@@ -44,7 +44,7 @@ Use the three catalog add methods for different storage responsibilities:
 ## Managed files
 
 ``catalog.add_file()`` copies or moves the source file into the catalog's
-``files/objects/`` tree by default and records a ``path`` locator pointing at
+``data/objects/`` tree by default and records a ``path`` locator pointing at
 that UUID-backed primary copy. The configured directory and filename templates
 create a human-readable symlink replica, not the canonical artifact path.
 
@@ -54,7 +54,7 @@ record = catalog.add_file(
     metadata={"species": "CO2"},
     operation="copy",     # or "move"
 )
-print(record.path())      # primary UUID path inside files/objects/
+print(record.path())      # primary UUID path inside data/objects/
 ```
 
 The human-readable replica location is derived from directory and filename
@@ -135,7 +135,7 @@ from pathlib import Path
 from ogcat import ArtifactLocator, UnzipSingleFileArtifactWriter, path_source
 
 archive_path = Path("incoming/GCP-GridFEDv2023.1_2018.zip")
-target_path = catalog.root / "files" / "flux/raw/GridFED/v2023.1/co2-o2/GCP-GridFEDv2023.1_2018.nc"
+target_path = catalog.root / "data" / "files" / "flux/raw/GridFED/v2023.1/co2-o2/GCP-GridFEDv2023.1_2018.nc"
 
 plan = catalog.plan_artifact_storage(
     archive_path,
@@ -176,7 +176,7 @@ filesystem side effects and rollback registration.
 To catalog a file that should stay in place, use ``add_reference()``. For local
 paths, ogcat infers the path locator, original filename, suffixes, and original
 path. The file is not copied or moved, and it does not need to be under the
-catalog's managed ``files/`` root.
+catalog's managed ``data/files/`` root.
 
 ```python
 catalog.add_reference(
@@ -204,5 +204,6 @@ storage adapters. Install the optional dependency with
 <catalog-root>/
   catalog.json      catalog specification and schemas
   db.json           TinyDB record store
-  files/            managed file storage tree
+  data/files/       human-readable template replica tree
+  data/objects/     UUID primary object storage tree
 ```

--- a/docs/design-note-artifact-locators.md
+++ b/docs/design-note-artifact-locators.md
@@ -16,7 +16,7 @@ The locator shape is intentionally minimal:
 {
   "kind": "path",
   "value": "/abs/path/to/object",
-  "relative_path": "files/example.nc"
+  "relative_path": "data/objects/ab/abcdef.nc"
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,8 @@ records, and retrieve the stored path.
 uv run ogcat init ./my-catalog --name demo
 ```
 
-This writes ``my-catalog/catalog.json`` and creates ``my-catalog/files/``.
+This writes ``my-catalog/catalog.json`` and creates ``my-catalog/data/files/``
+and ``my-catalog/data/objects/``.
 
 ## Add a file
 
@@ -19,7 +20,7 @@ uv run ogcat add ./report.pdf \
   --meta title="Q1 Report" author="Alice" year=2024
 ```
 
-The file is copied into the catalog's ``files/`` tree.  The record id is
+The file is copied into the catalog's ``data/objects/`` tree.  The record id is
 printed to stdout.
 
 ## Search

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ There is no manager API in the code today. If this appears, it should sit on top
 
 Future work: support creating catalogs from data that already exists on disk.
 
-The current implementation assumes managed ingest into the catalog's own `files/` tree. A practical next step is a scan or import workflow that can build records from existing data with explicit rules, rather than requiring each file to be added one at a time through the current path-based flow.
+The current implementation assumes managed ingest into the catalog's own `data/objects/` tree. A practical next step is a scan or import workflow that can build records from existing data with explicit rules, rather than requiring each file to be added one at a time through the current path-based flow.
 
 ## Longer-Term Direction
 

--- a/docs/tutorials/basic-catalog.md
+++ b/docs/tutorials/basic-catalog.md
@@ -86,7 +86,7 @@ with TemporaryDirectory(prefix="ogcat-tutorial-") as tmp:
     )
 ```
 
-`add_file()` copies the source file into the catalog's managed `files/` tree.
+`add_file()` copies the source file into the catalog's managed `data/objects/` tree.
 `add_artifact()` records a locator and metadata without copying or moving data.
 
 ## Search and inspect records

--- a/docs/tutorials/verification-games-recipes.md
+++ b/docs/tutorials/verification-games-recipes.md
@@ -116,7 +116,7 @@ print(example_flux_cdl())
 | Method | Use it when | Storage effect |
 | --- | --- | --- |
 | `add_reference(...)` | The artifact already exists and should stay where it is. | Records a local path, URI, or URL path; does not copy, move, or write data. |
-| `add_file(...)` | ogcat should manage a local copy or move a finished file into catalog storage. | Copies or moves one local file into the catalog `files_root`. |
+| `add_file(...)` | ogcat should manage a local copy or move a finished file into catalog storage. | Copies or moves one local file into the catalog object storage root and, by default, creates a readable template symlink under `files_root`. |
 | `add_artifact(...)` with a `StoragePlan` and writer | Domain code should create the output while ogcat handles planning, record creation, and rollback hooks. | The writer materialises the planned file or directory, then ogcat records it. |
 
 For the detailed storage model, see

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -7,6 +7,14 @@ from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationConte
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
+from ogcat.replicas import (
+    ReplicaApplyResult,
+    ReplicaMode,
+    ReplicaPlanItem,
+    ReplicaRole,
+    ReplicaState,
+    ReplicaViewPlan,
+)
 from ogcat.search import FieldPath, SearchOp, SearchQuery, SearchTerm
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.storage import (
@@ -67,6 +75,12 @@ __all__ = [
     "OperationContext",
     "OperationSource",
     "PluginRegistry",
+    "ReplicaApplyResult",
+    "ReplicaMode",
+    "ReplicaPlanItem",
+    "ReplicaRole",
+    "ReplicaState",
+    "ReplicaViewPlan",
     "RollbackFailure",
     "RecordSchema",
     "FieldPath",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -49,7 +49,12 @@ from ogcat.operation_runner import (
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
-from ogcat.replicas import ReplicaMode, ReplicaViewPlan, plan_replica_view, replica_template_context
+from ogcat.replicas import (
+    ReplicaMode,
+    ReplicaViewPlan,
+    materialize_template_link_replica,
+    plan_replica_view,
+)
 from ogcat.repository import CatalogRepository
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
@@ -133,6 +138,7 @@ class Catalog:
         root_path.mkdir(parents=True, exist_ok=True)
         spec.write(root_path / "catalog.json")
         (root_path / spec.files_root).mkdir(parents=True, exist_ok=True)
+        (root_path / spec.objects_root).mkdir(parents=True, exist_ok=True)
         repository = _open_repository(root_path, spec)
         return cls(
             root=root_path,
@@ -228,6 +234,7 @@ class Catalog:
 
         timestamp = _utc_timestamp()
         files_root = self.root / self.spec.files_root
+        objects_root = self.root / self.spec.objects_root
         naming_metadata: MetadataDict = {
             "record_schema": "default" if record_type is None else record_type,
             "directory_template": directory_template,
@@ -248,7 +255,8 @@ class Catalog:
             )
             if resolved_primary_location == "uuid":
                 target, catalog_relative_path, storage_relative_path = _uuid_storage_path(
-                    files_root=files_root,
+                    catalog_root=self.root,
+                    objects_root=objects_root,
                     artifact_uuid=artifact_uuid,
                     original_path=source,
                 )
@@ -260,13 +268,14 @@ class Catalog:
                 return ArtifactLocator.from_path(target, relative_path=catalog_relative_path)
 
             storage_adapter = LocalStorageAdapter()
-            target, rel_path, _resolved_filename = render_storage_location(
+            target, _catalog_relative_path, _resolved_filename = render_storage_location(
                 files_root=files_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
                 context=naming_context,
                 exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
             )
+            catalog_relative_path = target.relative_to(self.root).as_posix()
             storage_relative_path = target.relative_to(files_root).as_posix()
             naming_metadata["resolved_filename"] = _resolved_filename
             naming_metadata["primary_storage_relative_path"] = storage_relative_path
@@ -274,14 +283,15 @@ class Catalog:
                 storage_relative_path
             )
             naming_metadata["primary_resolved_filename"] = _resolved_filename
-            return ArtifactLocator.from_path(target, relative_path=rel_path)
+            return ArtifactLocator.from_path(target, relative_path=catalog_relative_path)
 
         def plan_local_file_storage(
             context: OperationContext,
             locator: ArtifactLocator,
         ) -> StoragePlan:
             """Build the storage plan for a managed local file."""
-            storage_relative_path = _storage_relative_path_for_locator(locator, files_root=files_root)
+            storage_root = objects_root if resolved_primary_location == "uuid" else files_root
+            storage_relative_path = _storage_relative_path_for_locator(locator, storage_root=storage_root)
             return plan_storage(
                 locator,
                 target_kind="file",
@@ -961,6 +971,7 @@ class Catalog:
         """Return a serialisable summary of catalog configuration and contents."""
         db_path = self.root / self.spec.db_path
         files_root = self.root / self.spec.files_root
+        objects_root = self.root / self.spec.objects_root
         default_schema = self.spec.get_schema()
         return {
             "catalog_name": self.spec.catalog_name,
@@ -968,6 +979,7 @@ class Catalog:
             "backend": self.spec.db_backend,
             "database_path": str(db_path),
             "files_root": str(files_root),
+            "objects_root": str(objects_root),
             "default_operation": self.spec.default_operation,
             "directory_template": default_schema.directory_template,
             "filename_template": default_schema.filename_template,
@@ -1130,11 +1142,13 @@ class Catalog:
         """Update simple catalog spec fields and persist ``catalog.json``.
 
         Supported fields are ``catalog_name``, ``default_operation``, and
-        ``field_resolution_order``. ``files_root`` changes require a dedicated
+        ``field_resolution_order``. Storage root changes require a dedicated
         migration operation and are intentionally rejected here.
         """
-        if "files_root" in fields:
-            raise ValueError("Changing files_root requires a file-root migration operation.")
+        forbidden_storage_roots = {"files_root", "objects_root"}.intersection(fields)
+        if forbidden_storage_roots:
+            joined = ", ".join(sorted(forbidden_storage_roots))
+            raise ValueError(f"Changing {joined} requires a storage-root migration operation.")
         allowed_fields = {"catalog_name", "default_operation", "field_resolution_order"}
         unknown_fields = sorted(field for field in fields if field not in allowed_fields)
         if unknown_fields:
@@ -1221,36 +1235,20 @@ class Catalog:
         filename_template: str,
     ) -> CatalogRecord:
         """Create and record the default template symlink replica."""
-        primary_path = record.path()
-        if primary_path is None:
-            return record
-        files_root = self.root / self.spec.files_root
-        target, catalog_relative_path, resolved_filename = render_storage_location(
-            files_root=files_root,
+        materialized = materialize_template_link_replica(
+            catalog_root=self.root,
+            files_root=self.root / self.spec.files_root,
+            record=record,
             directory_template=directory_template,
             filename_template=filename_template,
-            context=replica_template_context(record),
-            exists=lambda candidate: candidate.exists() or candidate.is_symlink(),
+            register_rollback=lambda action, description: transaction.register_rollback(
+                action,
+                description=description,
+            ),
         )
-        target.parent.mkdir(parents=True, exist_ok=True)
-        transaction.register_rollback(
-            lambda path=target: path.unlink(missing_ok=True),
-            description=f"remove template symlink replica {target}",
-        )
-        target.symlink_to(primary_path)
-
-        template_storage_relative_path = target.relative_to(files_root).as_posix()
-        updated_naming_metadata = dict(record.naming_metadata)
-        updated_naming_metadata.update(
-            {
-                "template_replica_path": str(target),
-                "template_replica_relative_path": catalog_relative_path,
-                "template_replica_storage_relative_path": template_storage_relative_path,
-                "template_resolved_directory": directory_from_relative_path(template_storage_relative_path),
-                "template_resolved_filename": resolved_filename,
-            }
-        )
-        updated_record = replace(record, naming_metadata=updated_naming_metadata)
+        if materialized is None:
+            return record
+        updated_record = replace(record, naming_metadata=materialized.naming_metadata)
         updated_record = transaction.update_staged_record(updated_record)
         self._emit_operation_audit(
             context,
@@ -1259,8 +1257,8 @@ class Catalog:
             details={
                 "replica_role": "template_link",
                 "replica_mode": "symlink",
-                "replica_path": str(target),
-                "primary_path": str(primary_path),
+                "replica_path": str(materialized.target_path),
+                "primary_path": str(materialized.primary_path),
             },
             locator=record.locator,
         )
@@ -1293,7 +1291,7 @@ class Catalog:
         if primary_location == "uuid":
             return _render_uuid_planned_locator(
                 catalog_root=self.root,
-                files_root=self.root / self.spec.files_root,
+                objects_root=self.root / self.spec.objects_root,
                 storage_root=storage_root,
                 artifact_uuid=artifact_uuid,
                 original_path=naming_source,
@@ -1328,14 +1326,14 @@ class Catalog:
         else:
             files_root = Path(storage_root).expanduser().resolve()
         storage_adapter = LocalStorageAdapter()
-        target, rel_path, resolved_filename = render_storage_location(
+        target, _catalog_relative_path, resolved_filename = render_storage_location(
             files_root=files_root,
             directory_template=directory_template,
             filename_template=filename_template,
             context=naming_context,
             exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
         )
-        relative_path = rel_path if storage_root is None else None
+        relative_path = target.relative_to(self.root).as_posix() if storage_root is None else None
         storage_relative_path = target.relative_to(files_root).as_posix()
         resolved_directory = Path(storage_relative_path).parent.as_posix()
         if resolved_directory == ".":
@@ -1689,6 +1687,7 @@ class Catalog:
             "db_backend": self.spec.db_backend,
             "db_path": self.spec.db_path,
             "files_root": self.spec.files_root,
+            "objects_root": self.spec.objects_root,
             "default_operation": self.spec.default_operation,
             "field_resolution_order": list(self.spec.field_resolution_order),
             "default_record_schema": self.spec.default_record_schema,
@@ -1718,29 +1717,30 @@ def _coerce_primary_location(value: object) -> PrimaryLocation:
 
 def _uuid_storage_path(
     *,
-    files_root: Path,
+    catalog_root: Path,
+    objects_root: Path,
     artifact_uuid: str,
     original_path: Path,
 ) -> tuple[Path, str, str]:
     """Return the UUID primary path and relative path metadata."""
     _stem, suffix = _split_name_and_suffixes(original_path.name)
-    storage_relative_path = f"objects/{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
-    target = files_root / storage_relative_path
-    catalog_relative_path = target.relative_to(files_root.parent).as_posix()
+    storage_relative_path = f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
+    target = objects_root / storage_relative_path
+    catalog_relative_path = target.relative_to(catalog_root).as_posix()
     return target, catalog_relative_path, storage_relative_path
 
 
 def _render_uuid_planned_locator(
     *,
     catalog_root: Path,
-    files_root: Path,
+    objects_root: Path,
     storage_root: str | Path | None,
     artifact_uuid: str,
     original_path: Path,
 ) -> PlannedLocatorResult:
     """Render a UUID primary locator for local or fsspec storage roots."""
     _stem, suffix = _split_name_and_suffixes(original_path.name)
-    storage_relative_path = f"objects/{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
+    storage_relative_path = f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
     resolved_directory = directory_from_relative_path(storage_relative_path)
     resolved_filename = Path(storage_relative_path).name
 
@@ -1752,7 +1752,7 @@ def _render_uuid_planned_locator(
             resolved_filename,
         )
 
-    target_root = files_root if storage_root is None else Path(storage_root).expanduser().resolve()
+    target_root = objects_root if storage_root is None else Path(storage_root).expanduser().resolve()
     target = target_root / storage_relative_path
     relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
     return (
@@ -1910,23 +1910,15 @@ def _coerce_metadata_input(
     return normalize_metadata_for_schema(metadata, schema_name=schema_name)
 
 
-def _storage_relative_path_for_locator(locator: ArtifactLocator, *, files_root: Path) -> str | None:
+def _storage_relative_path_for_locator(locator: ArtifactLocator, *, storage_root: Path) -> str | None:
     """Return a storage-root-relative path for a locator when available."""
     if locator.kind == "path":
         locator_path = Path(locator.value)
         try:
-            return locator_path.relative_to(files_root).as_posix()
+            return locator_path.relative_to(storage_root).as_posix()
         except ValueError:
             return locator.relative_path
     return locator.relative_path
-
-
-def _path_from_locator(locator: ArtifactLocator) -> Path:
-    """Return a local path from a path-backed artifact locator."""
-    path = locator.as_path()
-    if path is None:
-        raise ValueError("Managed file operations require a path-backed artifact locator.")
-    return path
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -30,7 +30,7 @@ from ogcat.hooks import (
     validate_hook_objects,
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
-from ogcat.naming import build_naming_context, render_storage_location
+from ogcat.naming import _split_name_and_suffixes, build_naming_context, render_storage_location
 from ogcat.operation_helpers import (
     adapter_name,
     artifact_locator_from_context,
@@ -49,6 +49,7 @@ from ogcat.operation_runner import (
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
+from ogcat.replicas import ReplicaMode, ReplicaViewPlan, plan_replica_view, replica_template_context
 from ogcat.repository import CatalogRepository
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
@@ -68,9 +69,11 @@ ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
+PrimaryLocation = Literal["uuid", "template"]
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
+RecordPostProcessor = Callable[[UnitOfWork, OperationContext, CatalogRecord], CatalogRecord]
 
 
 @dataclass(slots=True)
@@ -189,6 +192,7 @@ class Catalog:
         metadata: Mapping[Any, Any] | None = None,
         operation: str | None = None,
         record_type: str | None = None,
+        primary_location: PrimaryLocation = "uuid",
     ) -> CatalogRecord:
         """Add a local file using managed copy or move.
 
@@ -197,6 +201,9 @@ class Catalog:
             metadata: JSON-compatible user metadata.
             operation: ``"copy"`` or ``"move"``. Defaults to the catalog spec.
             record_type: Optional named schema to validate against.
+            primary_location: ``"uuid"`` stores the primary artifact under a
+                UUID path and creates a template symlink replica. ``"template"``
+                stores the primary artifact at the rendered template path.
 
         Returns:
             Persisted catalog record.
@@ -217,6 +224,7 @@ class Catalog:
         chosen_operation = operation or self.spec.default_operation
         if chosen_operation not in {"copy", "move"}:
             raise ValueError(f"Unsupported operation: {chosen_operation}")
+        resolved_primary_location = _coerce_primary_location(primary_location)
 
         timestamp = _utc_timestamp()
         files_root = self.root / self.spec.files_root
@@ -224,17 +232,33 @@ class Catalog:
             "record_schema": "default" if record_type is None else record_type,
             "directory_template": directory_template,
             "filename_template": filename_template,
+            "primary_location": resolved_primary_location,
         }
 
         def resolve_local_file_locator(context: OperationContext) -> ArtifactLocator:
             """Resolve the managed-file storage path for this operation."""
+            artifact_uuid = context.operation_id
+            naming_metadata["artifact_uuid"] = artifact_uuid
             naming_context = build_naming_context(
-                record_id=context.operation_id,
-                operation_id=context.operation_id,
+                record_id=artifact_uuid,
+                operation_id=artifact_uuid,
                 original_path=source,
                 metadata=context.user_metadata,
                 date_added=timestamp[:10],
             )
+            if resolved_primary_location == "uuid":
+                target, catalog_relative_path, storage_relative_path = _uuid_storage_path(
+                    files_root=files_root,
+                    artifact_uuid=artifact_uuid,
+                    original_path=source,
+                )
+                naming_metadata["primary_storage_relative_path"] = storage_relative_path
+                naming_metadata["primary_resolved_directory"] = directory_from_relative_path(
+                    storage_relative_path
+                )
+                naming_metadata["primary_resolved_filename"] = target.name
+                return ArtifactLocator.from_path(target, relative_path=catalog_relative_path)
+
             storage_adapter = LocalStorageAdapter()
             target, rel_path, _resolved_filename = render_storage_location(
                 files_root=files_root,
@@ -243,7 +267,13 @@ class Catalog:
                 context=naming_context,
                 exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
             )
+            storage_relative_path = target.relative_to(files_root).as_posix()
             naming_metadata["resolved_filename"] = _resolved_filename
+            naming_metadata["primary_storage_relative_path"] = storage_relative_path
+            naming_metadata["primary_resolved_directory"] = directory_from_relative_path(
+                storage_relative_path
+            )
+            naming_metadata["primary_resolved_filename"] = _resolved_filename
             return ArtifactLocator.from_path(target, relative_path=rel_path)
 
         def plan_local_file_storage(
@@ -251,15 +281,18 @@ class Catalog:
             locator: ArtifactLocator,
         ) -> StoragePlan:
             """Build the storage plan for a managed local file."""
+            storage_relative_path = _storage_relative_path_for_locator(locator, files_root=files_root)
             return plan_storage(
                 locator,
                 target_kind="file",
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
                 adapter=adapter_name(locator),
-                storage_relative_path=locator.relative_path,
-                resolved_directory=directory_from_relative_path(locator.relative_path),
+                storage_relative_path=storage_relative_path,
+                resolved_directory=directory_from_relative_path(storage_relative_path),
                 resolved_filename=filename_from_locator(locator),
+                artifact_uuid=context.operation_id,
+                primary_location=resolved_primary_location,
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
@@ -272,6 +305,25 @@ class Catalog:
         artifact_writer: ArtifactWriter = (
             CopyArtifactWriter() if chosen_operation == "copy" else MoveArtifactWriter()
         )
+        record_post_processor: RecordPostProcessor | None = None
+        if resolved_primary_location == "uuid":
+
+            def create_default_template_replica(
+                transaction: UnitOfWork,
+                context: OperationContext,
+                record: CatalogRecord,
+            ) -> CatalogRecord:
+                """Create the default template symlink replica for a UUID primary."""
+                return self._create_template_link_replica(
+                    transaction=transaction,
+                    context=context,
+                    record=record,
+                    directory_template=directory_template,
+                    filename_template=filename_template,
+                )
+
+            record_post_processor = create_default_template_replica
+
         with self.transaction() as transaction:
             return self._run_add_operation(
                 transaction=transaction,
@@ -293,6 +345,7 @@ class Catalog:
                 storage_plan_factory=plan_local_file_storage,
                 artifact_writer=artifact_writer,
                 derived_metadata_collector=collect_file_metadata,
+                record_post_processor=record_post_processor,
             )
 
     def plan_artifact_storage(
@@ -306,6 +359,7 @@ class Catalog:
         write_mode: WriteMode | None = None,
         ogcat_owned: bool = True,
         storage_root: str | Path | None = None,
+        primary_location: PrimaryLocation = "uuid",
     ) -> StoragePlan:
         """Plan artifact storage without writing data or a catalog record.
 
@@ -324,6 +378,9 @@ class Catalog:
             ogcat_owned: Whether ogcat should treat the target as managed.
             storage_root: Optional local root or fsspec URL root for rendered
                 template targets.
+            primary_location: ``"uuid"`` plans a UUID primary path.
+                ``"template"`` plans the rendered schema template as the
+                primary path. Ignored when ``locator`` is supplied.
 
         Returns:
             Planned storage decision.
@@ -334,6 +391,7 @@ class Catalog:
         user_metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
         resolved_record_type = "managed_artifact" if record_type is None else record_type
         resolved_write_mode = write_mode or ("write" if ogcat_owned else "reference")
+        resolved_primary_location = _coerce_primary_location(primary_location)
         source_path = None if path is None else Path(path).expanduser().resolve()
         timestamp = _utc_timestamp()
         operation_id = uuid4().hex
@@ -382,6 +440,7 @@ class Catalog:
                 source_path=source_path,
                 storage_root=storage_root,
                 date_added=timestamp[:10],
+                primary_location=resolved_primary_location,
             )
         else:
             planned_locator = locator
@@ -405,6 +464,8 @@ class Catalog:
             storage_relative_path=storage_relative_path,
             resolved_directory=resolved_directory,
             resolved_filename=resolved_filename,
+            artifact_uuid=operation_id if locator is None and resolved_primary_location == "uuid" else None,
+            primary_location="user_provided" if locator is not None else resolved_primary_location,
         )
         context.storage_plan = plan
         return plan
@@ -721,6 +782,53 @@ class Catalog:
             except ValueError as exc:
                 raise ValueError(f"artifact batch item {index}: {exc}") from exc
         return records
+
+    def plan_view(
+        self,
+        root: str | Path,
+        template: str,
+        *,
+        mode: ReplicaMode = "symlink",
+        query: SearchQuery | None = None,
+        where: Mapping[str, object] | None = None,
+        contains: Mapping[str, object] | None = None,
+        regex: Mapping[str, str] | None = None,
+        match: Mapping[str, str] | None = None,
+        exists: Sequence[str] | None = None,
+        missing: Sequence[str] | None = None,
+        ignore_case: bool = False,
+    ) -> ReplicaViewPlan:
+        """Plan a generated replica view without mutating records or files.
+
+        Args:
+            root: Root directory for the generated view.
+            template: Combined path template relative to ``root``.
+            mode: Replica materialisation mode. Only ``"symlink"`` is
+                supported.
+            query: Optional pre-built search query.
+            where: Equality filters.
+            contains: Substring or list-membership filters.
+            regex: Regular-expression filters.
+            match: Glob or substring filters.
+            exists: Fields that must be present.
+            missing: Fields that must be absent.
+            ignore_case: Whether string comparisons should be case-insensitive.
+
+        Returns:
+            Dry-run replica view plan.
+        """
+        records = self.search(
+            query=query,
+            where=where,
+            contains=contains,
+            regex=regex,
+            match=match,
+            exists=exists,
+            missing=missing,
+            ignore_case=ignore_case,
+            as_record_set=False,
+        )
+        return plan_replica_view(root=root, template=template, records=records, mode=mode)
 
     @overload
     def search(
@@ -1103,6 +1211,61 @@ class Catalog:
             naming_metadata=normalized_naming_metadata,
         )
 
+    def _create_template_link_replica(
+        self,
+        *,
+        transaction: UnitOfWork,
+        context: OperationContext,
+        record: CatalogRecord,
+        directory_template: str,
+        filename_template: str,
+    ) -> CatalogRecord:
+        """Create and record the default template symlink replica."""
+        primary_path = record.path()
+        if primary_path is None:
+            return record
+        files_root = self.root / self.spec.files_root
+        target, catalog_relative_path, resolved_filename = render_storage_location(
+            files_root=files_root,
+            directory_template=directory_template,
+            filename_template=filename_template,
+            context=replica_template_context(record),
+            exists=lambda candidate: candidate.exists() or candidate.is_symlink(),
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        transaction.register_rollback(
+            lambda path=target: path.unlink(missing_ok=True),
+            description=f"remove template symlink replica {target}",
+        )
+        target.symlink_to(primary_path)
+
+        template_storage_relative_path = target.relative_to(files_root).as_posix()
+        updated_naming_metadata = dict(record.naming_metadata)
+        updated_naming_metadata.update(
+            {
+                "template_replica_path": str(target),
+                "template_replica_relative_path": catalog_relative_path,
+                "template_replica_storage_relative_path": template_storage_relative_path,
+                "template_resolved_directory": directory_from_relative_path(template_storage_relative_path),
+                "template_resolved_filename": resolved_filename,
+            }
+        )
+        updated_record = replace(record, naming_metadata=updated_naming_metadata)
+        updated_record = transaction.update_staged_record(updated_record)
+        self._emit_operation_audit(
+            context,
+            event_type="replica",
+            message="Template symlink replica created.",
+            details={
+                "replica_role": "template_link",
+                "replica_mode": "symlink",
+                "replica_path": str(target),
+                "primary_path": str(primary_path),
+            },
+            locator=record.locator,
+        )
+        return updated_record
+
     def _render_planned_locator(
         self,
         *,
@@ -1112,6 +1275,7 @@ class Catalog:
         source_path: Path | None,
         storage_root: str | Path | None,
         date_added: str,
+        primary_location: PrimaryLocation,
     ) -> PlannedLocatorResult:
         """Render schema naming templates into a local or fsspec target locator."""
         directory_template = _require_template(schema.directory_template, field_name="directory_template")
@@ -1124,6 +1288,16 @@ class Catalog:
             metadata=context.user_metadata,
             date_added=date_added,
         )
+        artifact_uuid = context.operation_id
+        naming_context["artifact_uuid"] = artifact_uuid
+        if primary_location == "uuid":
+            return _render_uuid_planned_locator(
+                catalog_root=self.root,
+                files_root=self.root / self.spec.files_root,
+                storage_root=storage_root,
+                artifact_uuid=artifact_uuid,
+                original_path=naming_source,
+            )
 
         if storage_root is not None and _is_urlpath_root(storage_root):
             root_url = str(storage_root).rstrip("/")
@@ -1349,6 +1523,7 @@ class Catalog:
         storage_plan_factory: StoragePlanFactory | None = None,
         artifact_writer: ArtifactWriter | None = None,
         derived_metadata_collector: DerivedMetadataCollector | None = None,
+        record_post_processor: RecordPostProcessor | None = None,
     ) -> CatalogRecord:
         """Run the shared add operation lifecycle for file and record-only adds."""
         request = AddOperationRequest(
@@ -1371,6 +1546,7 @@ class Catalog:
             storage_plan_factory=storage_plan_factory,
             artifact_writer=artifact_writer,
             derived_metadata_collector=derived_metadata_collector,
+            record_post_processor=record_post_processor,
         )
         return self._build_add_operation_runner(request).run()
 
@@ -1533,6 +1709,60 @@ def _utc_timestamp() -> str:
     return timestamp.replace("+00:00", "Z")
 
 
+def _coerce_primary_location(value: object) -> PrimaryLocation:
+    """Return a supported primary placement policy."""
+    if value in {"uuid", "template"}:
+        return cast(PrimaryLocation, value)
+    raise ValueError("primary_location must be 'uuid' or 'template'.")
+
+
+def _uuid_storage_path(
+    *,
+    files_root: Path,
+    artifact_uuid: str,
+    original_path: Path,
+) -> tuple[Path, str, str]:
+    """Return the UUID primary path and relative path metadata."""
+    _stem, suffix = _split_name_and_suffixes(original_path.name)
+    storage_relative_path = f"objects/{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
+    target = files_root / storage_relative_path
+    catalog_relative_path = target.relative_to(files_root.parent).as_posix()
+    return target, catalog_relative_path, storage_relative_path
+
+
+def _render_uuid_planned_locator(
+    *,
+    catalog_root: Path,
+    files_root: Path,
+    storage_root: str | Path | None,
+    artifact_uuid: str,
+    original_path: Path,
+) -> PlannedLocatorResult:
+    """Render a UUID primary locator for local or fsspec storage roots."""
+    _stem, suffix = _split_name_and_suffixes(original_path.name)
+    storage_relative_path = f"objects/{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
+    resolved_directory = directory_from_relative_path(storage_relative_path)
+    resolved_filename = Path(storage_relative_path).name
+
+    if storage_root is not None and _is_urlpath_root(storage_root):
+        return (
+            ArtifactLocator.from_urlpath(_join_urlpath(str(storage_root).rstrip("/"), storage_relative_path)),
+            storage_relative_path,
+            resolved_directory,
+            resolved_filename,
+        )
+
+    target_root = files_root if storage_root is None else Path(storage_root).expanduser().resolve()
+    target = target_root / storage_relative_path
+    relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
+    return (
+        ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path,
+        resolved_directory,
+        resolved_filename,
+    )
+
+
 def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     """Create the configured repository for a catalog spec."""
     if spec.db_backend != "tinydb":
@@ -1678,6 +1908,17 @@ def _coerce_metadata_input(
 ) -> MetadataDict:
     """Copy user metadata after preserving existing non-dictionary errors."""
     return normalize_metadata_for_schema(metadata, schema_name=schema_name)
+
+
+def _storage_relative_path_for_locator(locator: ArtifactLocator, *, files_root: Path) -> str | None:
+    """Return a storage-root-relative path for a locator when available."""
+    if locator.kind == "path":
+        locator_path = Path(locator.value)
+        try:
+            return locator_path.relative_to(files_root).as_posix()
+        except ValueError:
+            return locator.relative_path
+    return locator.relative_path
 
 
 def _path_from_locator(locator: ArtifactLocator) -> Path:

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -660,6 +660,7 @@ def info(
     table.add_row("backend", str(description["backend"]))
     table.add_row("database path", str(description["database_path"]))
     table.add_row("files root", str(description["files_root"]))
+    table.add_row("objects root", str(description["objects_root"]))
     table.add_row("default operation", str(description["default_operation"]))
     table.add_row("directory template", str(description["directory_template"]))
     table.add_row("filename template", str(description["filename_template"]))

--- a/src/ogcat/operation_helpers.py
+++ b/src/ogcat/operation_helpers.py
@@ -50,12 +50,19 @@ def storage_plan_with_locator(plan: StoragePlan, locator: ArtifactLocator) -> St
 def naming_metadata_from_storage_plan(plan: StoragePlan) -> MetadataDict:
     """Build record naming metadata from storage planning outputs."""
     metadata: MetadataDict = {}
+    if plan.artifact_uuid is not None:
+        metadata["artifact_uuid"] = plan.artifact_uuid
+    if plan.primary_location is not None:
+        metadata["primary_location"] = plan.primary_location
     if plan.storage_relative_path is not None:
         metadata["storage_relative_path"] = plan.storage_relative_path
+        metadata["primary_storage_relative_path"] = plan.storage_relative_path
     if plan.resolved_directory is not None:
         metadata["resolved_directory"] = plan.resolved_directory
+        metadata["primary_resolved_directory"] = plan.resolved_directory
     if plan.resolved_filename is not None:
         metadata["resolved_filename"] = plan.resolved_filename
+        metadata["primary_resolved_filename"] = plan.resolved_filename
     return metadata
 
 

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -49,6 +49,7 @@ from ogcat.validation import ValidationReport
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
+RecordPostProcessor = Callable[[UnitOfWork, OperationContext, CatalogRecord], CatalogRecord]
 _PhaseSetter = Callable[[str], None]
 
 
@@ -142,6 +143,7 @@ class AddOperationRequest:
     storage_plan_factory: StoragePlanFactory | None = None
     artifact_writer: ArtifactWriter | None = None
     derived_metadata_collector: DerivedMetadataCollector | None = None
+    record_post_processor: RecordPostProcessor | None = None
 
 
 @dataclass(slots=True)
@@ -444,6 +446,13 @@ class AddOperationRunner(OperationRunner):
             },
             locator=add_plan.locator,
         )
+        if self.request.record_post_processor is not None:
+            set_phase("record-post-processing")
+            persisted = self.request.record_post_processor(
+                self.request.transaction,
+                add_plan.context,
+                persisted,
+            )
         set_phase(HOOK_PHASES["after_record_write"].name)
         hook_dispatcher.after_record_write(add_plan.context)
         return persisted
@@ -636,6 +645,8 @@ def _storage_plan_audit_details(plan: StoragePlan) -> dict[str, object]:
         "storage_relative_path": plan.storage_relative_path,
         "resolved_directory": plan.resolved_directory,
         "resolved_filename": plan.resolved_filename,
+        "artifact_uuid": plan.artifact_uuid,
+        "primary_location": plan.primary_location,
     }
 
 

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -8,20 +8,22 @@ from __future__ import annotations
 
 import os
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 from typing import Literal
 
-from ogcat.models import CatalogRecord
+from ogcat.models import CatalogRecord, MetadataDict
 from ogcat.naming import (
     _RESERVED_TEMPLATE_FIELDS,
     _normalise_segment,
     _split_name_and_suffixes,
     build_naming_context,
+    render_storage_location,
     render_template,
 )
+from ogcat.operation_helpers import directory_from_relative_path
 
 ReplicaMode = Literal["symlink"]
 ReplicaRole = Literal["template_link", "view_link"]
@@ -107,6 +109,29 @@ class ReplicaApplyResult:
             ReplicaState.ERROR,
         }
         return [item for item in self.items if item.state in error_states]
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateLinkReplicaMaterialization:
+    """Materialized default template replica details.
+
+    Args:
+        primary_path: Local primary path the symlink points at.
+        target_path: Local template replica symlink path.
+        catalog_relative_path: Replica path relative to the catalog root.
+        storage_relative_path: Replica path relative to the readable files root.
+        resolved_directory: Rendered template replica directory.
+        resolved_filename: Rendered template replica filename.
+        naming_metadata: Naming metadata to merge onto the catalog record.
+    """
+
+    primary_path: Path
+    target_path: Path
+    catalog_relative_path: str
+    storage_relative_path: str
+    resolved_directory: str
+    resolved_filename: str
+    naming_metadata: MetadataDict
 
 
 @dataclass(frozen=True, slots=True)
@@ -258,6 +283,72 @@ def replica_template_context(record: CatalogRecord) -> dict[str, object]:
         }
     )
     return context
+
+
+def materialize_template_link_replica(
+    *,
+    catalog_root: Path,
+    files_root: Path,
+    record: CatalogRecord,
+    directory_template: str,
+    filename_template: str,
+    register_rollback: Callable[[Callable[[], None], str], object] | None = None,
+) -> TemplateLinkReplicaMaterialization | None:
+    """Create the default template symlink replica for a path-backed record.
+
+    Args:
+        catalog_root: Catalog root used for catalog-relative path metadata.
+        files_root: Human-readable template replica root.
+        record: Record whose primary path should be linked.
+        directory_template: Directory template to render.
+        filename_template: Filename template to render.
+        register_rollback: Optional rollback registration callback accepting an
+            action and a human-readable description.
+
+    Returns:
+        Materialized replica details, or ``None`` if the record is not
+        path-backed.
+    """
+    primary_path = record.path()
+    if primary_path is None:
+        return None
+    target, _catalog_relative_path, resolved_filename = render_storage_location(
+        files_root=files_root,
+        directory_template=directory_template,
+        filename_template=filename_template,
+        context=replica_template_context(record),
+        exists=lambda candidate: candidate.exists() or candidate.is_symlink(),
+    )
+    catalog_relative_path = target.relative_to(catalog_root).as_posix()
+    storage_relative_path = target.relative_to(files_root).as_posix()
+    resolved_directory = directory_from_relative_path(storage_relative_path) or ""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if register_rollback is not None:
+        register_rollback(
+            lambda path=target: path.unlink(missing_ok=True),
+            f"remove template symlink replica {target}",
+        )
+    target.symlink_to(primary_path)
+
+    naming_metadata = dict(record.naming_metadata)
+    naming_metadata.update(
+        {
+            "template_replica_path": str(target),
+            "template_replica_relative_path": catalog_relative_path,
+            "template_replica_storage_relative_path": storage_relative_path,
+            "template_resolved_directory": resolved_directory,
+            "template_resolved_filename": resolved_filename,
+        }
+    )
+    return TemplateLinkReplicaMaterialization(
+        primary_path=primary_path,
+        target_path=target,
+        catalog_relative_path=catalog_relative_path,
+        storage_relative_path=storage_relative_path,
+        resolved_directory=resolved_directory,
+        resolved_filename=resolved_filename,
+        naming_metadata=naming_metadata,
+    )
 
 
 def _plan_record_replica(
@@ -413,6 +504,8 @@ __all__ = [
     "ReplicaRole",
     "ReplicaState",
     "ReplicaViewPlan",
+    "TemplateLinkReplicaMaterialization",
+    "materialize_template_link_replica",
     "plan_replica_view",
     "replica_template_context",
 ]

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -1,0 +1,403 @@
+"""Replica and generated view helpers.
+
+Replica views are derived filesystem state.  They point at catalogued primary
+artifacts but do not change catalog records.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+from ogcat.models import CatalogRecord
+from ogcat.naming import (
+    _RESERVED_TEMPLATE_FIELDS,
+    _normalise_segment,
+    _split_name_and_suffixes,
+    build_naming_context,
+    render_template,
+)
+
+ReplicaMode = Literal["symlink"]
+ReplicaRole = Literal["template_link", "view_link"]
+
+
+class ReplicaState(StrEnum):
+    """Lifecycle or diagnostic state for one planned replica."""
+
+    PLANNED = "planned"
+    CREATED = "created"
+    UP_TO_DATE = "up_to_date"
+    COLLISION = "collision"
+    UNSUPPORTED = "unsupported"
+    MISSING_TARGET = "missing_target"
+    ERROR = "error"
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicaPlanItem:
+    """One planned or applied replica path.
+
+    Args:
+        record_id: Catalog record id when available.
+        source_path: Primary local path the replica should point at.
+        target_path: Replica path to create or validate.
+        mode: Replica materialisation mode.
+        role: Semantic role of the replica.
+        state: Current plan or apply state.
+        message: Optional human-readable diagnostic.
+    """
+
+    record_id: str | None
+    source_path: Path | None
+    target_path: Path
+    mode: ReplicaMode = "symlink"
+    role: ReplicaRole = "view_link"
+    state: ReplicaState = ReplicaState.PLANNED
+    message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicaApplyResult:
+    """Result from applying a replica view plan."""
+
+    items: tuple[ReplicaPlanItem, ...]
+
+    @property
+    def created(self) -> list[ReplicaPlanItem]:
+        """Return replicas created by this apply call."""
+        return [item for item in self.items if item.state == ReplicaState.CREATED]
+
+    @property
+    def up_to_date(self) -> list[ReplicaPlanItem]:
+        """Return replicas that already pointed at the desired target."""
+        return [item for item in self.items if item.state == ReplicaState.UP_TO_DATE]
+
+    @property
+    def skipped(self) -> list[ReplicaPlanItem]:
+        """Return replicas skipped because they were not actionable."""
+        skipped_states = {
+            ReplicaState.COLLISION,
+            ReplicaState.UNSUPPORTED,
+            ReplicaState.MISSING_TARGET,
+        }
+        return [item for item in self.items if item.state in skipped_states]
+
+    @property
+    def errors(self) -> list[ReplicaPlanItem]:
+        """Return replicas with blocking errors."""
+        error_states = {
+            ReplicaState.COLLISION,
+            ReplicaState.UNSUPPORTED,
+            ReplicaState.MISSING_TARGET,
+            ReplicaState.ERROR,
+        }
+        return [item for item in self.items if item.state in error_states]
+
+
+@dataclass(frozen=True, slots=True)
+class ReplicaViewPlan:
+    """Dry-run plan for a generated replica view.
+
+    Args:
+        root: Root directory for generated view paths.
+        template: Path template rendered for each record.
+        mode: Replica materialisation mode.
+        items: Planned replica items.
+    """
+
+    root: Path
+    template: str
+    mode: ReplicaMode
+    items: tuple[ReplicaPlanItem, ...]
+
+    @property
+    def collisions(self) -> list[ReplicaPlanItem]:
+        """Return planned items that cannot be applied because of collisions."""
+        return [item for item in self.items if item.state == ReplicaState.COLLISION]
+
+    @property
+    def unsupported(self) -> list[ReplicaPlanItem]:
+        """Return planned items whose source cannot be linked locally."""
+        return [item for item in self.items if item.state == ReplicaState.UNSUPPORTED]
+
+    @property
+    def missing_targets(self) -> list[ReplicaPlanItem]:
+        """Return planned items whose primary local target is missing."""
+        return [item for item in self.items if item.state == ReplicaState.MISSING_TARGET]
+
+    def apply(self, *, skip_errors: bool = False) -> ReplicaApplyResult:
+        """Create symlink replicas described by this plan.
+
+        Args:
+            skip_errors: Whether to skip invalid items instead of raising before
+                creating links.
+
+        Returns:
+            Per-item apply result.
+
+        Raises:
+            ValueError: If the plan contains blocking items and ``skip_errors``
+                is false.
+        """
+        blocking = [
+            item
+            for item in self.items
+            if item.state in {ReplicaState.COLLISION, ReplicaState.UNSUPPORTED, ReplicaState.MISSING_TARGET}
+        ]
+        if blocking and not skip_errors:
+            raise ValueError(_format_blocking_items(blocking))
+
+        results: list[ReplicaPlanItem] = []
+        for item in self.items:
+            if item.state in {ReplicaState.COLLISION, ReplicaState.UNSUPPORTED, ReplicaState.MISSING_TARGET}:
+                results.append(item)
+                continue
+            try:
+                results.append(_apply_symlink_item(item))
+            except OSError as exc:
+                error_item = replace(item, state=ReplicaState.ERROR, message=str(exc))
+                if not skip_errors:
+                    raise ValueError(_format_blocking_items([error_item])) from exc
+                results.append(error_item)
+        return ReplicaApplyResult(tuple(results))
+
+
+def plan_replica_view(
+    *,
+    root: str | Path,
+    template: str,
+    records: Sequence[CatalogRecord],
+    mode: ReplicaMode = "symlink",
+    role: ReplicaRole = "view_link",
+) -> ReplicaViewPlan:
+    """Plan a generated local replica view for records.
+
+    Args:
+        root: Root directory for rendered replica paths.
+        template: Combined path template relative to ``root``.
+        records: Catalog records to include in the view.
+        mode: Replica materialisation mode. Only ``"symlink"`` is supported.
+        role: Semantic role for planned replicas.
+
+    Returns:
+        Dry-run replica view plan.
+    """
+    if mode != "symlink":
+        raise ValueError("Only symlink replica views are supported.")
+
+    root_path = Path(root).expanduser().resolve()
+    items = [
+        _plan_record_replica(root=root_path, template=template, record=record, mode=mode, role=role)
+        for record in records
+    ]
+    return ReplicaViewPlan(
+        root=root_path,
+        template=template,
+        mode=mode,
+        items=tuple(_mark_duplicate_targets(items)),
+    )
+
+
+def replica_template_context(record: CatalogRecord) -> dict[str, object]:
+    """Build a template context from record metadata and locator fields."""
+    context: dict[str, object] = {}
+    context.update(record.derived_metadata)
+    context.update(record.user_metadata)
+
+    artifact_uuid = record.naming_metadata.get("artifact_uuid")
+    record_id = "" if record.id is None else str(record.id)
+    uuid_value = str(artifact_uuid or record_id)
+    original_name = _record_original_name(record)
+    naming_metadata = {
+        key: value for key, value in record.user_metadata.items() if key not in _RESERVED_TEMPLATE_FIELDS
+    }
+    context.update(
+        build_naming_context(
+            record_id=record_id,
+            operation_id=uuid_value,
+            original_path=Path(original_name),
+            metadata=naming_metadata,
+            date_added=record.time_added[:10],
+        )
+    )
+    locator_path = record.path()
+    locator_name = "" if locator_path is None else locator_path.name
+    locator_stem, locator_suffix = _split_name_and_suffixes(locator_name)
+
+    context.update(
+        {
+            "id": record_id,
+            "uuid": uuid_value,
+            "artifact_uuid": uuid_value,
+            "operation_id": uuid_value,
+            "date_added": record.time_added[:10],
+            "year_added": record.time_added[:4],
+            "record_type": record.record_type,
+            "storage_mode": record.storage_mode or "",
+            "locator_kind": record.locator.kind,
+            "locator_value": record.locator.value,
+            "locator_filename": locator_name,
+            "locator_stem": _normalise_segment(locator_stem) if locator_stem else "",
+            "locator_suffix": locator_suffix,
+            "stored_relpath": record.stored_relpath or "",
+            "path": "" if locator_path is None else str(locator_path),
+        }
+    )
+    return context
+
+
+def _plan_record_replica(
+    *,
+    root: Path,
+    template: str,
+    record: CatalogRecord,
+    mode: ReplicaMode,
+    role: ReplicaRole,
+) -> ReplicaPlanItem:
+    """Plan one record's local replica link."""
+    target_path = _render_replica_path(root, template, replica_template_context(record))
+    source_path = record.path()
+    record_id = None if record.id is None else str(record.id)
+    if source_path is None:
+        return ReplicaPlanItem(
+            record_id=record_id,
+            source_path=None,
+            target_path=target_path,
+            mode=mode,
+            role=role,
+            state=ReplicaState.UNSUPPORTED,
+            message=f"Record {record_id or '<unpersisted>'} is not path-backed.",
+        )
+    if not source_path.exists():
+        return ReplicaPlanItem(
+            record_id=record_id,
+            source_path=source_path,
+            target_path=target_path,
+            mode=mode,
+            role=role,
+            state=ReplicaState.MISSING_TARGET,
+            message=f"Primary target does not exist: {source_path}",
+        )
+    existing_state = _existing_target_state(target_path, source_path)
+    if existing_state is not None:
+        return replace(
+            ReplicaPlanItem(
+                record_id=record_id,
+                source_path=source_path,
+                target_path=target_path,
+                mode=mode,
+                role=role,
+            ),
+            state=existing_state[0],
+            message=existing_state[1],
+        )
+    return ReplicaPlanItem(
+        record_id=record_id,
+        source_path=source_path,
+        target_path=target_path,
+        mode=mode,
+        role=role,
+    )
+
+
+def _mark_duplicate_targets(items: list[ReplicaPlanItem]) -> list[ReplicaPlanItem]:
+    """Mark plan-internal duplicate targets as collisions."""
+    counts = Counter(item.target_path for item in items)
+    duplicate_targets = {path for path, count in counts.items() if count > 1}
+    if not duplicate_targets:
+        return items
+    marked: list[ReplicaPlanItem] = []
+    for item in items:
+        if item.target_path in duplicate_targets:
+            marked.append(
+                replace(
+                    item,
+                    state=ReplicaState.COLLISION,
+                    message=f"Multiple records render to the same replica path: {item.target_path}",
+                )
+            )
+        else:
+            marked.append(item)
+    return marked
+
+
+def _apply_symlink_item(item: ReplicaPlanItem) -> ReplicaPlanItem:
+    """Apply one symlink plan item."""
+    if item.source_path is None:
+        return replace(item, state=ReplicaState.UNSUPPORTED)
+    existing_state = _existing_target_state(item.target_path, item.source_path)
+    if existing_state is not None:
+        return replace(item, state=existing_state[0], message=existing_state[1])
+    item.target_path.parent.mkdir(parents=True, exist_ok=True)
+    item.target_path.symlink_to(item.source_path)
+    return replace(item, state=ReplicaState.CREATED)
+
+
+def _existing_target_state(target_path: Path, source_path: Path) -> tuple[ReplicaState, str] | None:
+    """Return the state implied by an existing target path."""
+    if not target_path.exists() and not target_path.is_symlink():
+        return None
+    if target_path.is_symlink() and _symlink_points_to(target_path, source_path):
+        return ReplicaState.UP_TO_DATE, f"Replica already points at {source_path}"
+    return ReplicaState.COLLISION, f"Replica path already exists: {target_path}"
+
+
+def _symlink_points_to(link_path: Path, source_path: Path) -> bool:
+    """Return whether a symlink points at a source path."""
+    try:
+        link_target = Path(os.readlink(link_path))
+    except OSError:
+        return False
+    if not link_target.is_absolute():
+        link_target = (link_path.parent / link_target).resolve()
+    else:
+        link_target = link_target.resolve()
+    return link_target == source_path.resolve()
+
+
+def _render_replica_path(root: Path, template: str, context: dict[str, object]) -> Path:
+    """Render a safe relative replica path under ``root``."""
+    rendered = render_template(template, context)
+    parts = [part for part in rendered.replace("\\", "/").split("/") if part]
+    if not parts:
+        raise ValueError("Replica template rendered an empty path.")
+    if any(part in {".", ".."} for part in parts) or Path(rendered).is_absolute():
+        raise ValueError(f"Replica template must render a relative path below the view root: {rendered}")
+    return root.joinpath(*(_normalise_segment(part) for part in parts))
+
+
+def _record_original_name(record: CatalogRecord) -> str:
+    """Return the best filename-like value available for a record."""
+    if record.original_filename:
+        return record.original_filename
+    locator_path = record.path()
+    if locator_path is not None:
+        return locator_path.name
+    locator_value = record.locator.value.rstrip("/")
+    if locator_value:
+        return locator_value.rsplit("/", 1)[-1]
+    return "artifact"
+
+
+def _format_blocking_items(items: Sequence[ReplicaPlanItem]) -> str:
+    """Format replica plan blockers for exceptions."""
+    messages = [item.message or f"{item.state}: {item.target_path}" for item in items]
+    return "Replica view contains blocking item(s): " + "; ".join(messages)
+
+
+__all__ = [
+    "ReplicaApplyResult",
+    "ReplicaMode",
+    "ReplicaPlanItem",
+    "ReplicaRole",
+    "ReplicaState",
+    "ReplicaViewPlan",
+    "plan_replica_view",
+    "replica_template_context",
+]

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -91,9 +91,10 @@ class ReplicaApplyResult:
 
     @property
     def skipped(self) -> list[ReplicaPlanItem]:
-        """Return replicas skipped because they were not actionable."""
+        """Return replicas skipped or left unapplied when errors were skipped."""
         skipped_states = {
             ReplicaState.COLLISION,
+            ReplicaState.ERROR,
             ReplicaState.UNSUPPORTED,
             ReplicaState.MISSING_TARGET,
         }
@@ -328,7 +329,7 @@ def materialize_template_link_replica(
             lambda path=target: path.unlink(missing_ok=True),
             f"remove template symlink replica {target}",
         )
-    target.symlink_to(primary_path)
+    target.symlink_to(_relative_symlink_target(primary_path, link_path=target))
 
     naming_metadata = dict(record.naming_metadata)
     naming_metadata.update(
@@ -440,7 +441,7 @@ def _apply_symlink_item(item: ReplicaPlanItem) -> ReplicaPlanItem:
     if existing_state is not None:
         return replace(item, state=existing_state[0], message=existing_state[1])
     item.target_path.parent.mkdir(parents=True, exist_ok=True)
-    item.target_path.symlink_to(item.source_path)
+    item.target_path.symlink_to(_relative_symlink_target(item.source_path, link_path=item.target_path))
     return replace(item, state=ReplicaState.CREATED)
 
 
@@ -464,6 +465,14 @@ def _symlink_points_to(link_path: Path, source_path: Path) -> bool:
     else:
         link_target = link_target.resolve()
     return link_target == source_path.resolve()
+
+
+def _relative_symlink_target(source_path: Path, *, link_path: Path) -> str | Path:
+    """Return a relative symlink target when the platform can represent one."""
+    try:
+        return os.path.relpath(source_path, start=link_path.parent)
+    except ValueError:
+        return source_path
 
 
 def _render_replica_path(root: Path, template: str, context: dict[str, object]) -> Path:

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -39,6 +39,15 @@ class ReplicaState(StrEnum):
     ERROR = "error"
 
 
+_BLOCKING_STATES = frozenset(
+    {
+        ReplicaState.COLLISION,
+        ReplicaState.UNSUPPORTED,
+        ReplicaState.MISSING_TARGET,
+    }
+)
+
+
 @dataclass(frozen=True, slots=True)
 class ReplicaPlanItem:
     """One planned or applied replica path.
@@ -145,21 +154,20 @@ class ReplicaViewPlan:
             ValueError: If the plan contains blocking items and ``skip_errors``
                 is false.
         """
-        blocking = [
-            item
-            for item in self.items
-            if item.state in {ReplicaState.COLLISION, ReplicaState.UNSUPPORTED, ReplicaState.MISSING_TARGET}
-        ]
+        blocking = [item for item in self.items if item.state in _BLOCKING_STATES]
         if blocking and not skip_errors:
             raise ValueError(_format_blocking_items(blocking))
 
         results: list[ReplicaPlanItem] = []
         for item in self.items:
-            if item.state in {ReplicaState.COLLISION, ReplicaState.UNSUPPORTED, ReplicaState.MISSING_TARGET}:
+            if item.state in _BLOCKING_STATES:
                 results.append(item)
                 continue
             try:
-                results.append(_apply_symlink_item(item))
+                applied = _apply_symlink_item(item)
+                if applied.state in _BLOCKING_STATES and not skip_errors:
+                    raise ValueError(_format_blocking_items([applied]))
+                results.append(applied)
             except OSError as exc:
                 error_item = replace(item, state=ReplicaState.ERROR, message=str(exc))
                 if not skip_errors:
@@ -331,6 +339,12 @@ def _apply_symlink_item(item: ReplicaPlanItem) -> ReplicaPlanItem:
     """Apply one symlink plan item."""
     if item.source_path is None:
         return replace(item, state=ReplicaState.UNSUPPORTED)
+    if not item.source_path.exists():
+        return replace(
+            item,
+            state=ReplicaState.MISSING_TARGET,
+            message=f"Primary target does not exist: {item.source_path}",
+        )
     existing_state = _existing_target_state(item.target_path, item.source_path)
     if existing_state is not None:
         return replace(item, state=existing_state[0], message=existing_state[1])
@@ -367,9 +381,10 @@ def _render_replica_path(root: Path, template: str, context: dict[str, object]) 
     parts = [part for part in rendered.replace("\\", "/").split("/") if part]
     if not parts:
         raise ValueError("Replica template rendered an empty path.")
-    if any(part in {".", ".."} for part in parts) or Path(rendered).is_absolute():
+    normalised_parts = [_normalise_segment(part) for part in parts]
+    if any(part in {".", ".."} for part in normalised_parts) or Path(rendered).is_absolute():
         raise ValueError(f"Replica template must render a relative path below the view root: {rendered}")
-    return root.joinpath(*(_normalise_segment(part) for part in parts))
+    return root.joinpath(*normalised_parts)
 
 
 def _record_original_name(record: CatalogRecord) -> str:

--- a/src/ogcat/spec.py
+++ b/src/ogcat/spec.py
@@ -11,6 +11,8 @@ from ogcat.models import MetadataFieldDescription
 
 DEFAULT_DIRECTORY_TEMPLATE = "{year_added}/{original_stem}"
 DEFAULT_FILENAME_TEMPLATE = "{title_slug|original_stem}{original_suffix}"
+DEFAULT_FILES_ROOT = "data/files"
+DEFAULT_OBJECTS_ROOT = "data/objects"
 
 
 @dataclass(slots=True)
@@ -102,7 +104,10 @@ class CatalogSpec:
         db_backend: Repository backend identifier. Only ``"tinydb"`` is
             supported today.
         db_path: Database path relative to the catalog root.
-        files_root: Managed file root relative to the catalog root.
+        files_root: Human-readable managed file view root relative to the
+            catalog root.
+        objects_root: UUID primary object storage root relative to the catalog
+            root.
         default_operation: Default managed-file operation.
         field_resolution_order: Namespace order for flattened search fields.
         default_record_schema: Name of the fallback schema in ``record_schemas``.
@@ -113,7 +118,8 @@ class CatalogSpec:
     catalog_name: str
     db_backend: str = "tinydb"
     db_path: str = "db.json"
-    files_root: str = "files"
+    files_root: str = DEFAULT_FILES_ROOT
+    objects_root: str = ""
     default_operation: Literal["copy", "move"] = "copy"
     field_resolution_order: list[str] = field(
         default_factory=lambda: ["top_level", "user_metadata", "derived_metadata"]
@@ -127,6 +133,8 @@ class CatalogSpec:
         self.default_record_schema = str(self.default_record_schema).strip()
         if not self.default_record_schema:
             raise ValueError("default_record_schema cannot be empty.")
+        self.files_root = str(self.files_root)
+        self.objects_root = str(self.objects_root or _default_objects_root(self.files_root))
         record_schemas = _coerce_record_schema_mapping(self.record_schemas)
         default_schema = _coerce_record_schema(self.default_schema, field_name="default_schema")
         if default_schema is not None:
@@ -158,6 +166,7 @@ class CatalogSpec:
             "db_backend": self.db_backend,
             "db_path": self.db_path,
             "files_root": self.files_root,
+            "objects_root": self.objects_root,
             "default_operation": self.default_operation,
             "field_resolution_order": list(self.field_resolution_order),
             "default_record_schema": self.default_record_schema,
@@ -175,7 +184,13 @@ class CatalogSpec:
             catalog_name=str(data["catalog_name"]),
             db_backend=str(data.get("db_backend", "tinydb")),
             db_path=str(data.get("db_path", "db.json")),
-            files_root=str(data.get("files_root", "files")),
+            files_root=str(data.get("files_root", DEFAULT_FILES_ROOT)),
+            objects_root=str(
+                data.get(
+                    "objects_root",
+                    _default_objects_root(str(data.get("files_root", DEFAULT_FILES_ROOT))),
+                )
+            ),
             default_operation=data.get("default_operation", "copy"),  # type: ignore[arg-type]
             field_resolution_order=[
                 str(item)
@@ -237,6 +252,13 @@ def _default_record_schema() -> RecordSchema:
         directory_template=DEFAULT_DIRECTORY_TEMPLATE,
         filename_template=DEFAULT_FILENAME_TEMPLATE,
     )
+
+
+def _default_objects_root(files_root: str) -> str:
+    """Return the default UUID object root for a managed files root."""
+    if files_root == DEFAULT_FILES_ROOT:
+        return DEFAULT_OBJECTS_ROOT
+    return f"{files_root.rstrip('/')}/objects"
 
 
 def _coerce_record_schema(value: object, *, field_name: str) -> RecordSchema | None:

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -44,6 +44,9 @@ class StoragePlan:
         resolved_directory: Optional rendered directory path for template-based
             storage.
         resolved_filename: Optional rendered filename or final path component.
+        artifact_uuid: Optional UUID-style artifact storage identifier.
+        primary_location: Optional primary placement policy, such as ``"uuid"``
+            or ``"template"``.
     """
 
     locator: ArtifactLocator
@@ -57,6 +60,8 @@ class StoragePlan:
     storage_relative_path: str | None = None
     resolved_directory: str | None = None
     resolved_filename: str | None = None
+    artifact_uuid: str | None = None
+    primary_location: str | None = None
 
 
 class StorageAdapter(Protocol):
@@ -231,6 +236,8 @@ def plan_storage(
     storage_relative_path: str | None = None,
     resolved_directory: str | None = None,
     resolved_filename: str | None = None,
+    artifact_uuid: str | None = None,
+    primary_location: str | None = None,
 ) -> StoragePlan:
     """Build a storage plan from already-resolved storage decisions.
 
@@ -250,6 +257,9 @@ def plan_storage(
         resolved_directory: Optional rendered directory path for template-based
             storage.
         resolved_filename: Optional rendered filename or final path component.
+        artifact_uuid: Optional UUID-style artifact storage identifier.
+        primary_location: Optional primary placement policy, such as ``"uuid"``
+            or ``"template"``.
 
     Returns:
         Storage plan describing the target and intended write.
@@ -266,6 +276,8 @@ def plan_storage(
         storage_relative_path=storage_relative_path,
         resolved_directory=resolved_directory,
         resolved_filename=resolved_filename,
+        artifact_uuid=artifact_uuid,
+        primary_location=primary_location,
     )
 
 

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -20,6 +20,7 @@ from ogcat.models import ArtifactLocator
 TargetKind = Literal["file", "directory"]
 WriteMode = Literal["copy", "move", "write", "reference"]
 ChecksumPolicy = Literal["none"]
+StoragePrimaryLocation = Literal["uuid", "template", "user_provided"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,8 +46,8 @@ class StoragePlan:
             storage.
         resolved_filename: Optional rendered filename or final path component.
         artifact_uuid: Optional UUID-style artifact storage identifier.
-        primary_location: Optional primary placement policy, such as ``"uuid"``
-            or ``"template"``.
+        primary_location: Optional primary placement policy, such as ``"uuid"``,
+            ``"template"``, or ``"user_provided"``.
     """
 
     locator: ArtifactLocator
@@ -61,7 +62,7 @@ class StoragePlan:
     resolved_directory: str | None = None
     resolved_filename: str | None = None
     artifact_uuid: str | None = None
-    primary_location: str | None = None
+    primary_location: StoragePrimaryLocation | None = None
 
 
 class StorageAdapter(Protocol):
@@ -237,7 +238,7 @@ def plan_storage(
     resolved_directory: str | None = None,
     resolved_filename: str | None = None,
     artifact_uuid: str | None = None,
-    primary_location: str | None = None,
+    primary_location: StoragePrimaryLocation | None = None,
 ) -> StoragePlan:
     """Build a storage plan from already-resolved storage decisions.
 
@@ -258,8 +259,8 @@ def plan_storage(
             storage.
         resolved_filename: Optional rendered filename or final path component.
         artifact_uuid: Optional UUID-style artifact storage identifier.
-        primary_location: Optional primary placement policy, such as ``"uuid"``
-            or ``"template"``.
+        primary_location: Optional primary placement policy, such as ``"uuid"``,
+            ``"template"``, or ``"user_provided"``.
 
     Returns:
         Storage plan describing the target and intended write.
@@ -437,6 +438,7 @@ __all__ = [
     "LocalStorageAdapter",
     "StorageAdapter",
     "StoragePlan",
+    "StoragePrimaryLocation",
     "TargetKind",
     "WriteMode",
     "adapter_for_locator",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,3 +1,4 @@
+import os
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -49,6 +50,23 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     assert record.suffixes == [".nc"]
     assert record.storage_mode == "copy"
     assert record.naming_metadata["primary_location"] == "uuid"
+
+
+def test_add_file_template_replica_uses_relative_symlink_target(tmp_path: Path) -> None:
+    """Default template replicas use relative links so movable catalogs are less brittle."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "relative.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source)
+    replica_path = _template_replica_path(record)
+
+    assert replica_path.is_symlink()
+    assert not Path(os.readlink(replica_path)).is_absolute()
+    assert replica_path.resolve() == _stored_path(record)
 
 
 def test_add_file_can_store_primary_at_template_path(tmp_path: Path) -> None:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -36,8 +36,8 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     record = catalog.add_file(source)
 
     artifact_uuid = str(record.naming_metadata["artifact_uuid"])
-    expected_primary = root / "files" / "objects" / artifact_uuid[:2] / f"{artifact_uuid}.nc"
-    expected_replica = root / "files" / record.time_added[:4] / "example" / "example.nc"
+    expected_primary = root / "data" / "objects" / artifact_uuid[:2] / f"{artifact_uuid}.nc"
+    expected_replica = root / "data" / "files" / record.time_added[:4] / "example" / "example.nc"
     assert _stored_path(record) == expected_primary
     assert record.record_type == "managed_file"
     assert record.locator == ArtifactLocator.path(expected_primary, relative_path=record.stored_relpath)
@@ -63,7 +63,7 @@ def test_add_file_can_store_primary_at_template_path(tmp_path: Path) -> None:
 
     record = catalog.add_file(source, primary_location="template")
 
-    expected = root / "files" / record.time_added[:4] / "example" / "example.nc"
+    expected = root / "data" / "files" / record.time_added[:4] / "example" / "example.nc"
     assert _stored_path(record) == expected
     assert expected.exists()
     assert not expected.is_symlink()
@@ -110,6 +110,7 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
 
     expected = (
         root
+        / "data"
         / "files"
         / "CO2"
         / "EUROPE"
@@ -164,7 +165,7 @@ def test_add_file_uses_record_type_schema_for_naming(tmp_path: Path) -> None:
         metadata={"product": "CTE-HR", "species": "CO2", "year": 2024, "month": 1},
     )
 
-    expected = root / "files" / "CO2" / "GLOBAL" / "CTE-HR" / "CTE-HR_CO2_202401.nc"
+    expected = root / "data" / "files" / "CO2" / "GLOBAL" / "CTE-HR" / "CTE-HR_CO2_202401.nc"
     assert _stored_path(record).parent.parent.name == "objects"
     assert expected.is_symlink()
     assert expected.resolve() == _stored_path(record)
@@ -202,7 +203,7 @@ def test_add_file_preserves_empty_schema_directory_template(tmp_path: Path) -> N
 
     record = catalog.add_file(source, record_type="flux", metadata={"product": "CTE-HR"})
 
-    expected = root / "files" / "CTE-HR.nc"
+    expected = root / "data" / "files" / "CTE-HR.nc"
     assert _stored_path(record).parent.parent.name == "objects"
     assert expected.is_symlink()
     assert expected.resolve() == _stored_path(record)
@@ -350,7 +351,7 @@ def test_add_file_uses_readable_list_metadata_in_naming_templates(tmp_path: Path
 
     record = catalog.add_file(source, metadata={"tags": ["a", "b", "c"]})
 
-    replica_path = root / "files" / "a-b-c" / "a-b-c.nc"
+    replica_path = root / "data" / "files" / "a-b-c" / "a-b-c.nc"
     assert replica_path.is_symlink()
     assert replica_path.resolve() == _stored_path(record)
     assert _template_replica_path(record) == replica_path
@@ -511,7 +512,8 @@ def test_add_file_rejects_metadata_that_clobbers_reserved_template_fields(
         catalog.add_file(source, metadata={field_name: "user-value"})
 
     assert catalog.repository.all() == []
-    assert list((root / "files").rglob("reserved.nc")) == []
+    assert list((root / "data" / "files").rglob("reserved.nc")) == []
+    assert list((root / "data" / "objects").rglob("reserved.nc")) == []
 
 
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:
@@ -525,7 +527,9 @@ def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> 
 
     record = catalog.add_file(source)
 
-    expected = root / "files" / record.time_added[:4] / "anthropogenic.202401" / "anthropogenic.202401.nc"
+    expected = (
+        root / "data" / "files" / record.time_added[:4] / "anthropogenic.202401" / "anthropogenic.202401.nc"
+    )
     assert expected.is_symlink()
     assert expected.resolve() == _stored_path(record)
     assert _template_replica_path(record) == expected
@@ -544,7 +548,7 @@ def test_add_file_preserves_compressed_suffixes(tmp_path: Path) -> None:
 
     record = catalog.add_file(source)
 
-    expected = root / "files" / record.time_added[:4] / "archive" / "archive.tar.gz"
+    expected = root / "data" / "files" / record.time_added[:4] / "archive" / "archive.tar.gz"
     assert expected.is_symlink()
     assert expected.resolve() == _stored_path(record)
     assert _template_replica_path(record) == expected
@@ -647,14 +651,15 @@ def test_add_file_rolls_back_record_when_naming_fails(
     def fail_render_storage_location(*args: object, **kwargs: object) -> None:
         raise ValueError("simulated naming failure")
 
-    monkeypatch.setattr("ogcat.catalog.render_storage_location", fail_render_storage_location)
+    monkeypatch.setattr("ogcat.replicas.render_storage_location", fail_render_storage_location)
 
     with pytest.raises(ValueError, match="simulated naming failure"):
         catalog.add_file(source)
 
     assert catalog.describe()["record_count"] == 0
     assert catalog.repository.all() == []
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "objects").rglob("*.nc")) == []
 
 
 def test_add_file_rolls_back_record_after_staged_insert_before_file_write(
@@ -672,13 +677,14 @@ def test_add_file_rolls_back_record_after_staged_insert_before_file_write(
     def fail_before_file_write(*args: object, **kwargs: object) -> None:
         raise RuntimeError("simulated post-insert failure")
 
-    monkeypatch.setattr("ogcat.catalog.render_storage_location", fail_before_file_write)
+    monkeypatch.setattr("ogcat.replicas.render_storage_location", fail_before_file_write)
 
     with pytest.raises(RuntimeError, match="simulated post-insert failure"):
         catalog.add_file(source)
 
     assert catalog.repository.all() == []
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "objects").rglob("*.nc")) == []
 
 
 def test_add_file_removes_partial_target_when_copy_fails(
@@ -703,7 +709,7 @@ def test_add_file_removes_partial_target_when_copy_fails(
         catalog.add_file(source)
 
     assert catalog.describe()["record_count"] == 0
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
 
 
 def test_add_file_removes_copied_target_when_record_write_fails(
@@ -728,7 +734,7 @@ def test_add_file_removes_copied_target_when_record_write_fails(
 
     assert source.exists()
     assert catalog.describe()["record_count"] == 0
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
 
 
 def test_add_file_removes_copied_target_when_metadata_extraction_fails(
@@ -753,7 +759,7 @@ def test_add_file_removes_copied_target_when_metadata_extraction_fails(
 
     assert source.exists()
     assert catalog.describe()["record_count"] == 0
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
 
 
 def test_add_file_restores_moved_file_when_record_write_fails(
@@ -776,7 +782,7 @@ def test_add_file_restores_moved_file_when_record_write_fails(
     with pytest.raises(OSError, match="simulated record write failure"):
         catalog.add_file(source, operation="move")
 
-    assert list((root / "files").rglob("*.nc")) == []
+    assert list((root / "data" / "files").rglob("*.nc")) == []
     assert source.exists()
     assert source.read_text(encoding="utf-8") == "dummy"
     assert catalog.describe()["record_count"] == 0

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -18,7 +18,13 @@ def _stored_path(record: CatalogRecord) -> Path:
     return Path(record.stored_abspath)
 
 
+def _template_replica_path(record: CatalogRecord) -> Path:
+    assert "template_replica_path" in record.naming_metadata
+    return Path(str(record.naming_metadata["template_replica_path"]))
+
+
 def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
+    """Default managed ingest writes a UUID primary and a template symlink replica."""
     source_dir = tmp_path / "source"
     source_dir.mkdir()
     source = source_dir / "example.nc"
@@ -29,14 +35,40 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
 
     record = catalog.add_file(source)
 
-    expected = root / "files" / record.time_added[:4] / "example" / "example.nc"
-    assert _stored_path(record) == expected
+    artifact_uuid = str(record.naming_metadata["artifact_uuid"])
+    expected_primary = root / "files" / "objects" / artifact_uuid[:2] / f"{artifact_uuid}.nc"
+    expected_replica = root / "files" / record.time_added[:4] / "example" / "example.nc"
+    assert _stored_path(record) == expected_primary
     assert record.record_type == "managed_file"
-    assert record.locator == ArtifactLocator.path(expected, relative_path=record.stored_relpath)
-    assert expected.exists()
+    assert record.locator == ArtifactLocator.path(expected_primary, relative_path=record.stored_relpath)
+    assert expected_primary.exists()
+    assert expected_replica.is_symlink()
+    assert expected_replica.resolve() == expected_primary
+    assert _template_replica_path(record) == expected_replica
     assert record.original_filename == "example.nc"
     assert record.suffixes == [".nc"]
     assert record.storage_mode == "copy"
+    assert record.naming_metadata["primary_location"] == "uuid"
+
+
+def test_add_file_can_store_primary_at_template_path(tmp_path: Path) -> None:
+    """Callers can request the template path as the primary artifact location."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source, primary_location="template")
+
+    expected = root / "files" / record.time_added[:4] / "example" / "example.nc"
+    assert _stored_path(record) == expected
+    assert expected.exists()
+    assert not expected.is_symlink()
+    assert "template_replica_path" not in record.naming_metadata
+    assert record.naming_metadata["primary_location"] == "template"
 
 
 def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -> None:
@@ -86,8 +118,10 @@ def test_add_file_supports_flux_style_templates_when_requested(tmp_path: Path) -
         / "anthropogenic"
         / "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc"
     )
-    assert _stored_path(record) == expected
-    assert expected.exists()
+    assert _stored_path(record).parent.parent.name == "objects"
+    assert expected.is_symlink()
+    assert expected.resolve() == _stored_path(record)
+    assert _template_replica_path(record) == expected
     assert record.original_filename == "anthropogenic.202401.nc"
     assert record.storage_mode == "copy"
 
@@ -131,10 +165,12 @@ def test_add_file_uses_record_type_schema_for_naming(tmp_path: Path) -> None:
     )
 
     expected = root / "files" / "CO2" / "GLOBAL" / "CTE-HR" / "CTE-HR_CO2_202401.nc"
-    assert _stored_path(record) == expected
+    assert _stored_path(record).parent.parent.name == "objects"
+    assert expected.is_symlink()
+    assert expected.resolve() == _stored_path(record)
     assert record.record_type == "flux"
     assert record.naming_metadata["record_schema"] == "flux"
-    assert expected.exists()
+    assert _template_replica_path(record) == expected
 
 
 def test_add_file_preserves_empty_schema_directory_template(tmp_path: Path) -> None:
@@ -167,9 +203,11 @@ def test_add_file_preserves_empty_schema_directory_template(tmp_path: Path) -> N
     record = catalog.add_file(source, record_type="flux", metadata={"product": "CTE-HR"})
 
     expected = root / "files" / "CTE-HR.nc"
-    assert _stored_path(record) == expected
+    assert _stored_path(record).parent.parent.name == "objects"
+    assert expected.is_symlink()
+    assert expected.resolve() == _stored_path(record)
     assert record.naming_metadata["directory_template"] == ""
-    assert expected.exists()
+    assert _template_replica_path(record) == expected
 
 
 def test_add_file_rejects_unknown_explicit_record_schema(tmp_path: Path) -> None:
@@ -289,7 +327,7 @@ def test_add_file_does_not_truncate_fractional_year_metadata_for_naming(tmp_path
 
     record = catalog.add_file(source, metadata={"year": 2024.9, "month": 1})
 
-    assert _stored_path(record).name == "floatyear.nc"
+    assert _template_replica_path(record).name == "floatyear.nc"
 
 
 def test_add_file_uses_readable_list_metadata_in_naming_templates(tmp_path: Path) -> None:
@@ -312,7 +350,10 @@ def test_add_file_uses_readable_list_metadata_in_naming_templates(tmp_path: Path
 
     record = catalog.add_file(source, metadata={"tags": ["a", "b", "c"]})
 
-    assert _stored_path(record) == root / "files" / "a-b-c" / "a-b-c.nc"
+    replica_path = root / "files" / "a-b-c" / "a-b-c.nc"
+    assert replica_path.is_symlink()
+    assert replica_path.resolve() == _stored_path(record)
+    assert _template_replica_path(record) == replica_path
 
 
 def test_add_file_normalizes_path_metadata_before_tinydb_insert(
@@ -430,6 +471,7 @@ def test_plan_artifact_storage_normalizes_metadata_before_naming(tmp_path: Path)
     plan = catalog.plan_artifact_storage(
         path=source,
         metadata={"tags": ("a", "b"), "source_path": Path("named")},
+        primary_location="template",
     )
 
     assert plan.resolved_directory == "a-b"
@@ -484,7 +526,9 @@ def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> 
     record = catalog.add_file(source)
 
     expected = root / "files" / record.time_added[:4] / "anthropogenic.202401" / "anthropogenic.202401.nc"
-    assert _stored_path(record) == expected
+    assert expected.is_symlink()
+    assert expected.resolve() == _stored_path(record)
+    assert _template_replica_path(record) == expected
     assert record.original_filename == "anthropogenic.202401.nc"
     assert record.suffixes == [".202401", ".nc"]
 
@@ -501,7 +545,9 @@ def test_add_file_preserves_compressed_suffixes(tmp_path: Path) -> None:
     record = catalog.add_file(source)
 
     expected = root / "files" / record.time_added[:4] / "archive" / "archive.tar.gz"
-    assert _stored_path(record) == expected
+    assert expected.is_symlink()
+    assert expected.resolve() == _stored_path(record)
+    assert _template_replica_path(record) == expected
     assert record.original_filename == "archive.tar.gz"
     assert record.suffixes == [".tar", ".gz"]
 
@@ -544,8 +590,8 @@ def test_add_file_appends_numeric_suffix_on_collision(tmp_path: Path) -> None:
     first_record = catalog.add_file(first, metadata=metadata)
     second_record = catalog.add_file(second, metadata=metadata)
 
-    assert _stored_path(first_record).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc"
-    assert _stored_path(second_record).name == "CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401_2.nc"
+    assert _template_replica_path(first_record).name == ("CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401.nc")
+    assert _template_replica_path(second_record).name == ("CTE-HR_v4.2_CO2_EUROPE_anthropogenic_202401_2.nc")
 
 
 def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -> None:
@@ -571,8 +617,8 @@ def test_add_file_collision_suffixing_preserves_full_extension(tmp_path: Path) -
     first_record = catalog.add_file(first)
     second_record = catalog.add_file(second)
 
-    assert _stored_path(first_record).name == "bundle.tar.gz"
-    assert _stored_path(second_record).name == "bundle_2.tar.gz"
+    assert _template_replica_path(first_record).name == "bundle.tar.gz"
+    assert _template_replica_path(second_record).name == "bundle_2.tar.gz"
 
 
 def test_add_file_rolls_back_record_when_copy_fails(tmp_path: Path) -> None:
@@ -682,7 +728,7 @@ def test_add_file_removes_copied_target_when_record_write_fails(
 
     assert source.exists()
     assert catalog.describe()["record_count"] == 0
-    assert list((root / "files").rglob("copied.nc")) == []
+    assert list((root / "files").rglob("*.nc")) == []
 
 
 def test_add_file_removes_copied_target_when_metadata_extraction_fails(
@@ -707,7 +753,7 @@ def test_add_file_removes_copied_target_when_metadata_extraction_fails(
 
     assert source.exists()
     assert catalog.describe()["record_count"] == 0
-    assert list((root / "files").rglob("metadata.nc")) == []
+    assert list((root / "files").rglob("*.nc")) == []
 
 
 def test_add_file_restores_moved_file_when_record_write_fails(
@@ -730,7 +776,7 @@ def test_add_file_restores_moved_file_when_record_write_fails(
     with pytest.raises(OSError, match="simulated record write failure"):
         catalog.add_file(source, operation="move")
 
-    assert list((root / "files").rglob("moved.nc")) == []
+    assert list((root / "files").rglob("*.nc")) == []
     assert source.exists()
     assert source.read_text(encoding="utf-8") == "dummy"
     assert catalog.describe()["record_count"] == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,7 +281,9 @@ def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
     assert "path" in stdout
     assert _record_id(record) in stdout
     assert "CO2" in stdout
-    assert "anthropogenic" in stdout
+    resolved_path = record.path()
+    assert resolved_path is not None
+    assert resolved_path.name in stdout
     assert "files" in stdout
     assert "product" not in stdout
     assert "CTE-HR" not in stdout
@@ -831,7 +833,8 @@ def test_search_paths_skips_non_path_backed_records(tmp_path: Path) -> None:
     assert result.exit_code == 0
     lines = [line for line in strip_ansi(result.stdout).splitlines() if line.strip()]
     assert len(lines) == 1
-    assert lines[0].endswith("source.nc")
+    stored_record = catalog.search(where={"species": "CO2"}, as_record_set=False)[0]
+    assert lines[0] == str(stored_record.path())
 
 
 def test_search_ids_and_paths_are_not_capped_by_default(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,10 +283,27 @@ def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
     assert "CO2" in stdout
     resolved_path = record.path()
     assert resolved_path is not None
-    assert resolved_path.name in stdout
     assert "files" in stdout
     assert "product" not in stdout
     assert "CTE-HR" not in stdout
+
+    plain_result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--where",
+            "species=CO2",
+            "--fields",
+            "id,species,path",
+            "--format",
+            "pipe",
+        ],
+    )
+
+    assert plain_result.exit_code == 0
+    assert str(resolved_path) in strip_ansi(plain_result.stdout)
 
 
 def test_search_uses_schema_display_fields_when_fields_are_omitted(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -283,7 +283,7 @@ def test_search_fields_selects_human_output_columns(tmp_path: Path) -> None:
     assert "CO2" in stdout
     resolved_path = record.path()
     assert resolved_path is not None
-    assert "files" in stdout
+    assert "objects" in stdout
     assert "product" not in stdout
     assert "CTE-HR" not in stdout
 
@@ -711,7 +711,19 @@ def test_spec_cli_rejects_files_root_update(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 1
-    assert "Changing files_root requires a file-root migration operation." in strip_ansi(result.stderr)
+    assert "Changing files_root requires a storage-root migration operation." in strip_ansi(result.stderr)
+
+
+def test_spec_cli_rejects_objects_root_update(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    result = runner.invoke(
+        app,
+        ["spec", "set", "objects_root=renamed-objects", "--catalog", str(catalog.root)],
+    )
+
+    assert result.exit_code == 1
+    assert "Changing objects_root requires a storage-root migration operation." in strip_ansi(result.stderr)
 
 
 def test_add_accepts_multiple_metadata_items_after_single_meta_flag(tmp_path: Path) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -362,7 +362,8 @@ def test_before_validate_hook_can_mutate_metadata_for_validation_and_naming(tmp_
     record = catalog.add_file(source)
 
     assert record.user_metadata["title"] == "from-hook"
-    assert Path(record.stored_abspath or "").name == "from-hook.nc"
+    assert Path(str(record.naming_metadata["template_replica_path"])).name == "from-hook.nc"
+    assert Path(record.stored_abspath or "").parent.parent.name == "objects"
 
 
 def test_resolve_artifact_locator_replacement_controls_add_file_target(tmp_path: Path) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -403,7 +403,7 @@ def test_resolve_artifact_locator_removal_fails_clearly(tmp_path: Path) -> None:
         catalog.add_file(source)
 
     assert catalog.repository.all() == []
-    assert not list((root / "files").rglob("missing-locator.nc"))
+    assert not list((root / "data" / "files").rglob("missing-locator.nc"))
 
 
 def test_hook_failure_rolls_back_staged_record_and_copied_file(tmp_path: Path) -> None:
@@ -425,7 +425,7 @@ def test_hook_failure_rolls_back_staged_record_and_copied_file(tmp_path: Path) -
 
     assert rollback_calls == ["external"]
     assert catalog.repository.all() == []
-    assert list((root / "files").rglob("failure.nc")) == []
+    assert list((root / "data" / "files").rglob("failure.nc")) == []
     assert source.exists()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,7 +14,8 @@ def test_create_and_open_catalog(tmp_path: Path) -> None:
     assert created.root == reopened.root
     assert (root / "catalog.json").exists()
     assert (root / "db.json").exists()
-    assert (root / "files").exists()
+    assert (root / "data" / "files").exists()
+    assert (root / "data" / "objects").exists()
     assert reopened.spec.catalog_name == "fluxes"
 
 
@@ -65,6 +66,22 @@ def test_catalog_spec_round_trips_via_catalog_json(tmp_path: Path) -> None:
         },
     ]
     assert reloaded == spec
+
+
+def test_catalog_spec_defaults_to_split_data_roots() -> None:
+    """New catalogs default readable views and UUID primaries to sibling data roots."""
+    spec = CatalogSpec(catalog_name="files")
+
+    assert spec.files_root == "data/files"
+    assert spec.objects_root == "data/objects"
+
+
+def test_catalog_spec_keeps_legacy_object_root_for_existing_files_root() -> None:
+    """Existing catalog JSON without objects_root keeps UUID objects under files/objects."""
+    spec = CatalogSpec.from_dict({"catalog_name": "files", "files_root": "files"})
+
+    assert spec.files_root == "files"
+    assert spec.objects_root == "files/objects"
 
 
 def test_catalog_spec_round_trips_record_schemas(tmp_path: Path) -> None:
@@ -367,9 +384,20 @@ def test_catalog_update_spec_rejects_files_root_without_migration(tmp_path: Path
     try:
         catalog.update_spec(files_root="renamed-files")
     except ValueError as exc:
-        assert "Changing files_root requires a file-root migration operation." in str(exc)
+        assert "Changing files_root requires a storage-root migration operation." in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Expected files_root update to be rejected")
+
+
+def test_catalog_update_spec_rejects_objects_root_without_migration(tmp_path: Path) -> None:
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    try:
+        catalog.update_spec(objects_root="renamed-objects")
+    except ValueError as exc:
+        assert "Changing objects_root requires a storage-root migration operation." in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected objects_root update to be rejected")
 
 
 def test_record_schema_fallbacks_preserve_empty_templates() -> None:

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -109,6 +109,37 @@ def test_view_reports_missing_primary_targets(tmp_path: Path) -> None:
     assert result.skipped[0].state == ReplicaState.MISSING_TARGET
 
 
+def test_apply_rechecks_missing_primary_targets_after_planning(tmp_path: Path) -> None:
+    """Apply should not create a broken link when a planned primary disappears."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    primary_path = record.path()
+    assert primary_path is not None
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+    target_path = plan.items[0].target_path
+    primary_path.unlink()
+
+    with pytest.raises(ValueError, match="Primary target does not exist"):
+        plan.apply()
+
+    assert not target_path.exists()
+    assert not target_path.is_symlink()
+
+    result = plan.apply(skip_errors=True)
+    assert result.skipped[0].state == ReplicaState.MISSING_TARGET
+    assert not target_path.exists()
+    assert not target_path.is_symlink()
+
+
+def test_plan_view_rejects_normalized_parent_segments(tmp_path: Path) -> None:
+    """Whitespace-padded parent-directory segments must not escape the view root."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": " .. "})
+
+    with pytest.raises(ValueError, match="relative path below the view root"):
+        catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+
+
 def test_view_regeneration_uses_updated_metadata_without_moving_primary(tmp_path: Path) -> None:
     """Regenerated views use current metadata while the primary UUID path stays put."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -51,6 +52,7 @@ def test_apply_symlink_view_creates_links_and_is_idempotent(tmp_path: Path) -> N
     link_path = result.created[0].target_path
 
     assert link_path.is_symlink()
+    assert not Path(os.readlink(link_path)).is_absolute()
     assert link_path.resolve() == primary_path
 
     second_result = catalog.plan_view(
@@ -60,6 +62,32 @@ def test_apply_symlink_view_creates_links_and_is_idempotent(tmp_path: Path) -> N
 
     assert second_result.created == []
     assert second_result.up_to_date[0].target_path == link_path
+
+
+def test_apply_skip_errors_reports_symlink_oserror_as_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """skip_errors=True reports symlink failures in both skipped and errors."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+
+    def fail_symlink_to(
+        self: Path,
+        target: str | Path,
+        target_is_directory: bool = False,
+    ) -> None:
+        raise OSError("simulated symlink failure")
+
+    monkeypatch.setattr(Path, "symlink_to", fail_symlink_to)
+
+    with pytest.raises(ValueError, match="simulated symlink failure"):
+        plan.apply()
+    result = plan.apply(skip_errors=True)
+
+    assert result.skipped[0].state == ReplicaState.ERROR
+    assert result.errors[0].state == ReplicaState.ERROR
 
 
 def test_view_reports_template_collisions(tmp_path: Path) -> None:

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -1,0 +1,126 @@
+"""Replica view planning and symlink application tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import Catalog, CatalogRecord, CatalogSpec, ReplicaState
+
+
+def _record_id(record: CatalogRecord) -> str:
+    """Return a persisted record id for test setup."""
+    assert record.id is not None
+    return record.id
+
+
+def _source_file(tmp_path: Path, name: str, text: str = "payload") -> Path:
+    """Create a source file for replica tests."""
+    source = tmp_path / "source" / name
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(text, encoding="utf-8")
+    return source
+
+
+def test_plan_view_does_not_create_links(tmp_path: Path) -> None:
+    """Planning a view is a dry run with no filesystem side effects."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    view_root = tmp_path / "view"
+
+    plan = catalog.plan_view(view_root, "{product}/{id}_{original_filename}")
+
+    assert len(plan.items) == 1
+    item = plan.items[0]
+    assert item.state == ReplicaState.PLANNED
+    assert item.source_path == record.path()
+    assert item.target_path == view_root / "flux" / f"{_record_id(record)}_alpha.nc"
+    assert not view_root.exists()
+
+
+def test_apply_symlink_view_creates_links_and_is_idempotent(tmp_path: Path) -> None:
+    """Applying a symlink view creates links and re-apply reports them up to date."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    primary_path = record.path()
+    assert primary_path is not None
+
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+    result = plan.apply()
+    link_path = result.created[0].target_path
+
+    assert link_path.is_symlink()
+    assert link_path.resolve() == primary_path
+
+    second_result = catalog.plan_view(
+        tmp_path / "view",
+        "{product}/{id}_{original_filename}",
+    ).apply()
+
+    assert second_result.created == []
+    assert second_result.up_to_date[0].target_path == link_path
+
+
+def test_view_reports_template_collisions(tmp_path: Path) -> None:
+    """Plans report duplicate rendered paths before creating any links."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    catalog.add_file(_source_file(tmp_path, "beta.nc"), metadata={"product": "flux"})
+    view_root = tmp_path / "view"
+
+    plan = catalog.plan_view(view_root, "same-name.nc")
+
+    assert len(plan.collisions) == 2
+    with pytest.raises(ValueError, match="same-name.nc"):
+        plan.apply()
+    assert not view_root.exists()
+
+
+def test_view_reports_unsupported_non_path_locators(tmp_path: Path) -> None:
+    """URI records are reported as unsupported for local symlink views."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    catalog.add_reference(uri="https://example.org/data.nc", metadata={"product": "remote"})
+
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+
+    assert len(plan.unsupported) == 1
+    assert plan.unsupported[0].state == ReplicaState.UNSUPPORTED
+    with pytest.raises(ValueError, match="not path-backed"):
+        plan.apply()
+    result = plan.apply(skip_errors=True)
+    assert result.skipped[0].state == ReplicaState.UNSUPPORTED
+
+
+def test_view_reports_missing_primary_targets(tmp_path: Path) -> None:
+    """Missing primary paths are reported and can be skipped."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    primary_path = record.path()
+    assert primary_path is not None
+    primary_path.unlink()
+
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+
+    assert len(plan.missing_targets) == 1
+    with pytest.raises(ValueError, match="Primary target does not exist"):
+        plan.apply()
+    result = plan.apply(skip_errors=True)
+    assert result.skipped[0].state == ReplicaState.MISSING_TARGET
+
+
+def test_view_regeneration_uses_updated_metadata_without_moving_primary(tmp_path: Path) -> None:
+    """Regenerated views use current metadata while the primary UUID path stays put."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "old"})
+    record_id = _record_id(record)
+    primary_path = record.path()
+    assert primary_path is not None
+
+    updated = catalog.update_metadata(record_id, {"product": "new"}, mode="shallow_merge")
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+    result = plan.apply()
+
+    assert updated.path() == primary_path
+    assert result.created[0].target_path == tmp_path / "view" / "new" / f"{record_id}_alpha.nc"
+    assert result.created[0].target_path.resolve() == primary_path

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -22,8 +22,8 @@ from ogcat.storage import (
 )
 
 
-def test_plan_artifact_storage_renders_local_template_without_writing(tmp_path: Path) -> None:
-    """Planning renders local templates but does not create files or records."""
+def test_plan_artifact_storage_uses_uuid_primary_without_writing(tmp_path: Path) -> None:
+    """Planning defaults to a UUID primary path without creating files or records."""
     source = tmp_path / "source.nc"
     source.write_text("payload", encoding="utf-8")
     root = tmp_path / "catalog"
@@ -44,15 +44,53 @@ def test_plan_artifact_storage_renders_local_template_without_writing(tmp_path: 
         write_mode="copy",
     )
 
-    expected = root / "files" / "CO2" / "2024" / "paris.nc"
-    assert plan.locator == ArtifactLocator.from_path(expected, relative_path="files/CO2/2024/paris.nc")
+    assert plan.artifact_uuid is not None
+    expected = root / "files" / "objects" / plan.artifact_uuid[:2] / f"{plan.artifact_uuid}.nc"
+    assert plan.locator == ArtifactLocator.from_path(
+        expected,
+        relative_path=f"files/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc",
+    )
     assert plan.write_mode == "copy"
-    assert plan.storage_relative_path == "CO2/2024/paris.nc"
-    assert plan.resolved_directory == "CO2/2024"
-    assert plan.resolved_filename == "paris.nc"
+    assert plan.locator.relative_path == f"files/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.storage_relative_path == f"objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.resolved_directory == f"objects/{plan.artifact_uuid[:2]}"
+    assert plan.resolved_filename == f"{plan.artifact_uuid}.nc"
+    assert plan.primary_location == "uuid"
     assert plan.ogcat_owned
     assert not expected.exists()
     assert catalog.repository.all() == []
+
+
+def test_plan_artifact_storage_can_use_template_primary(tmp_path: Path) -> None:
+    """Planning can still use schema templates as the primary path."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{species}/{year}",
+                filename_template="{title}{original_suffix}",
+            ),
+        ),
+    )
+
+    plan = catalog.plan_artifact_storage(
+        source,
+        metadata={"species": "CO2", "year": 2024, "title": "paris"},
+        write_mode="copy",
+        primary_location="template",
+    )
+
+    expected = root / "files" / "CO2" / "2024" / "paris.nc"
+    assert plan.locator == ArtifactLocator.from_path(expected, relative_path="files/CO2/2024/paris.nc")
+    assert plan.storage_relative_path == "CO2/2024/paris.nc"
+    assert plan.resolved_directory == "CO2/2024"
+    assert plan.resolved_filename == "paris.nc"
+    assert plan.primary_location == "template"
+    assert not expected.exists()
 
 
 def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path) -> None:
@@ -66,7 +104,11 @@ def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path
     )
 
     metadata: MetadataDict = {"title": "planned"}
-    plan = catalog.plan_artifact_storage(metadata=metadata, write_mode="reference")
+    plan = catalog.plan_artifact_storage(
+        metadata=metadata,
+        write_mode="reference",
+        primary_location="template",
+    )
     record = catalog.add_artifact(
         record_type="managed_artifact",
         storage_plan=plan,
@@ -102,7 +144,7 @@ def test_plan_artifact_storage_collision_uses_storage_adapter_exists(
 
     monkeypatch.setattr(LocalStorageAdapter, "exists", fake_exists)
 
-    plan = catalog.plan_artifact_storage(source, write_mode="copy")
+    plan = catalog.plan_artifact_storage(source, write_mode="copy", primary_location="template")
 
     assert Path(plan.locator.value).name == "fixed_2.nc"
     assert [Path(value).name for value in seen] == ["fixed.nc", "fixed_2.nc"]
@@ -145,6 +187,7 @@ def test_plan_artifact_storage_urlpath_root_does_not_import_fsspec(
         metadata={"species": "CO2", "title": "remote"},
         storage_root="s3://bucket/prefix",
         write_mode="copy",
+        primary_location="template",
     )
 
     assert plan.locator == ArtifactLocator.from_urlpath(
@@ -180,6 +223,7 @@ def test_urlpath_storage_root_does_not_populate_stored_relpath(
         metadata={"species": "CO2", "title": "remote"},
         storage_root="s3://bucket/prefix",
         write_mode="reference",
+        primary_location="template",
     )
     record = catalog.add_artifact(
         record_type="managed_file",
@@ -229,7 +273,12 @@ def test_plan_artifact_storage_urlpath_root_uses_available_collision_check(
 
     monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", fake_exists)
 
-    plan = catalog.plan_artifact_storage(source, storage_root="s3://bucket/prefix", write_mode="copy")
+    plan = catalog.plan_artifact_storage(
+        source,
+        storage_root="s3://bucket/prefix",
+        write_mode="copy",
+        primary_location="template",
+    )
 
     assert plan.locator == ArtifactLocator.from_urlpath(
         "s3://bucket/prefix/2026/source/fixed_2.nc",
@@ -264,6 +313,7 @@ def test_plan_artifact_storage_custom_local_root_has_no_catalog_relative_path(tm
         storage_root=external_root,
         write_mode="reference",
         ogcat_owned=False,
+        primary_location="template",
     )
     record = catalog.add_artifact(
         record_type="external_file",
@@ -277,6 +327,26 @@ def test_plan_artifact_storage_custom_local_root_has_no_catalog_relative_path(tm
     assert plan.resolved_filename == "external.nc"
     assert record.stored_relpath is None
     assert record.locator.relative_path is None
+
+
+def test_plan_artifact_storage_explicit_locator_overrides_primary_location(tmp_path: Path) -> None:
+    """Explicit locators remain caller-selected primary storage locations."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    target = tmp_path / "chosen" / "artifact.nc"
+
+    plan = catalog.plan_artifact_storage(
+        source,
+        locator=ArtifactLocator.from_path(target),
+        write_mode="reference",
+    )
+
+    assert plan.locator == ArtifactLocator.from_path(target)
+    assert plan.primary_location == "user_provided"
+    assert plan.artifact_uuid is None
+    assert plan.resolved_directory == str(target.parent)
+    assert plan.resolved_filename == "artifact.nc"
 
 
 def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -45,15 +45,15 @@ def test_plan_artifact_storage_uses_uuid_primary_without_writing(tmp_path: Path)
     )
 
     assert plan.artifact_uuid is not None
-    expected = root / "files" / "objects" / plan.artifact_uuid[:2] / f"{plan.artifact_uuid}.nc"
+    expected = root / "data" / "objects" / plan.artifact_uuid[:2] / f"{plan.artifact_uuid}.nc"
     assert plan.locator == ArtifactLocator.from_path(
         expected,
-        relative_path=f"files/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc",
+        relative_path=f"data/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc",
     )
     assert plan.write_mode == "copy"
-    assert plan.locator.relative_path == f"files/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
-    assert plan.storage_relative_path == f"objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
-    assert plan.resolved_directory == f"objects/{plan.artifact_uuid[:2]}"
+    assert plan.locator.relative_path == f"data/objects/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.storage_relative_path == f"{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.resolved_directory == plan.artifact_uuid[:2]
     assert plan.resolved_filename == f"{plan.artifact_uuid}.nc"
     assert plan.primary_location == "uuid"
     assert plan.ogcat_owned
@@ -84,8 +84,8 @@ def test_plan_artifact_storage_can_use_template_primary(tmp_path: Path) -> None:
         primary_location="template",
     )
 
-    expected = root / "files" / "CO2" / "2024" / "paris.nc"
-    assert plan.locator == ArtifactLocator.from_path(expected, relative_path="files/CO2/2024/paris.nc")
+    expected = root / "data" / "files" / "CO2" / "2024" / "paris.nc"
+    assert plan.locator == ArtifactLocator.from_path(expected, relative_path="data/files/CO2/2024/paris.nc")
     assert plan.storage_relative_path == "CO2/2024/paris.nc"
     assert plan.resolved_directory == "CO2/2024"
     assert plan.resolved_filename == "paris.nc"
@@ -117,7 +117,7 @@ def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path
 
     assert plan.time_added is not None
     assert record.time_added == plan.time_added
-    assert record.locator.relative_path == f"files/{plan.time_added[:4]}/planned.txt"
+    assert record.locator.relative_path == f"data/files/{plan.time_added[:4]}/planned.txt"
     assert record.user_metadata == metadata
     assert record.naming_metadata["resolved_filename"] == "planned.txt"
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -430,6 +430,7 @@ def test_plan_artifact_storage_can_allocate_zarr_directory_name(tmp_path: Path) 
         metadata={"species": "CO2", "domain": "EUROPE", "title": "my_store"},
         target_kind="directory",
         write_mode="write",
+        primary_location="template",
     )
 
     assert plan.target_kind == "directory"


### PR DESCRIPTION
## Summary
- Add replica tree view support and wire replica operations through storage-backed structures
- Update catalog, storage, and replica modules to reflect the new view-tree behavior
- Refresh API and architecture docs to describe the replica workflow and storage model
- Extend tests across CLI, hooks, replicas, storage, writers, and add flows

## Testing
- Updated and expanded automated test coverage for replica, storage, CLI, hook, and writer paths
- Not run (not requested)