### PR TITLE
[codex] Finish storage planning boundary cleanup

### DIFF
--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import getpass
-import importlib.util
 import os
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -30,7 +29,7 @@ from ogcat.hooks import (
     validate_hook_objects,
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
-from ogcat.naming import _split_name_and_suffixes, build_naming_context, render_storage_location
+from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.operation_helpers import (
     adapter_name,
     artifact_locator_from_context,
@@ -65,6 +64,12 @@ from ogcat.storage import (
     WriteMode,
     plan_storage,
 )
+from ogcat.storage_planning import (
+    PrimaryLocation,
+    _render_planned_locator,
+    _storage_relative_path_for_locator,
+    _uuid_storage_path,
+)
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
@@ -73,8 +78,6 @@ from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
-PlannedLocatorResult = tuple[ArtifactLocator, str | None, str | None, str | None]
-PrimaryLocation = Literal["uuid", "template"]
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
@@ -438,15 +441,21 @@ class Catalog:
         validation_report.raise_for_errors()
 
         if locator is None:
+            directory_template = _require_template(schema.directory_template, field_name="directory_template")
+            filename_template = _require_template(schema.filename_template, field_name="filename_template")
             (
                 planned_locator,
                 storage_relative_path,
                 resolved_directory,
                 resolved_filename,
-            ) = self._render_planned_locator(
-                context=context,
-                schema=schema,
-                record_type=record_type,
+            ) = _render_planned_locator(
+                catalog_root=self.root,
+                files_root=self.root / self.spec.files_root,
+                objects_root=self.root / self.spec.objects_root,
+                operation_id=context.operation_id,
+                metadata=context.user_metadata,
+                directory_template=directory_template,
+                filename_template=filename_template,
                 source_path=source_path,
                 storage_root=storage_root,
                 date_added=timestamp[:10],
@@ -1264,87 +1273,6 @@ class Catalog:
         )
         return updated_record
 
-    def _render_planned_locator(
-        self,
-        *,
-        context: OperationContext,
-        schema: RecordSchema,
-        record_type: str | None,
-        source_path: Path | None,
-        storage_root: str | Path | None,
-        date_added: str,
-        primary_location: PrimaryLocation,
-    ) -> PlannedLocatorResult:
-        """Render schema naming templates into a local or fsspec target locator."""
-        directory_template = _require_template(schema.directory_template, field_name="directory_template")
-        filename_template = _require_template(schema.filename_template, field_name="filename_template")
-        naming_source = source_path or Path("artifact")
-        naming_context = build_naming_context(
-            record_id=context.operation_id,
-            operation_id=context.operation_id,
-            original_path=naming_source,
-            metadata=context.user_metadata,
-            date_added=date_added,
-        )
-        artifact_uuid = context.operation_id
-        naming_context["artifact_uuid"] = artifact_uuid
-        if primary_location == "uuid":
-            return _render_uuid_planned_locator(
-                catalog_root=self.root,
-                objects_root=self.root / self.spec.objects_root,
-                storage_root=storage_root,
-                artifact_uuid=artifact_uuid,
-                original_path=naming_source,
-            )
-
-        if storage_root is not None and _is_urlpath_root(storage_root):
-            root_url = str(storage_root).rstrip("/")
-            fake_root = Path("/__ogcat_storage__")
-
-            target, _rel_path, resolved_filename = render_storage_location(
-                files_root=fake_root,
-                directory_template=directory_template,
-                filename_template=filename_template,
-                context=naming_context,
-                exists=lambda candidate: _urlpath_exists_if_supported(
-                    _join_urlpath(root_url, candidate.relative_to(fake_root).as_posix())
-                ),
-            )
-            relative_path = target.relative_to(fake_root).as_posix()
-            resolved_directory = str(Path(relative_path).parent)
-            if resolved_directory == ".":
-                resolved_directory = ""
-            return (
-                ArtifactLocator.from_urlpath(_join_urlpath(root_url, relative_path)),
-                relative_path,
-                resolved_directory,
-                resolved_filename,
-            )
-
-        if storage_root is None:
-            files_root = self.root / self.spec.files_root
-        else:
-            files_root = Path(storage_root).expanduser().resolve()
-        storage_adapter = LocalStorageAdapter()
-        target, _catalog_relative_path, resolved_filename = render_storage_location(
-            files_root=files_root,
-            directory_template=directory_template,
-            filename_template=filename_template,
-            context=naming_context,
-            exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
-        )
-        relative_path = target.relative_to(self.root).as_posix() if storage_root is None else None
-        storage_relative_path = target.relative_to(files_root).as_posix()
-        resolved_directory = Path(storage_relative_path).parent.as_posix()
-        if resolved_directory == ".":
-            resolved_directory = ""
-        return (
-            ArtifactLocator.from_path(target, relative_path=relative_path),
-            storage_relative_path,
-            resolved_directory,
-            resolved_filename,
-        )
-
     def _add_artifact_in_transaction(
         self,
         *,
@@ -1715,54 +1643,6 @@ def _coerce_primary_location(value: object) -> PrimaryLocation:
     raise ValueError("primary_location must be 'uuid' or 'template'.")
 
 
-def _uuid_storage_path(
-    *,
-    catalog_root: Path,
-    objects_root: Path,
-    artifact_uuid: str,
-    original_path: Path,
-) -> tuple[Path, str, str]:
-    """Return the UUID primary path and relative path metadata."""
-    _stem, suffix = _split_name_and_suffixes(original_path.name)
-    storage_relative_path = f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
-    target = objects_root / storage_relative_path
-    catalog_relative_path = target.relative_to(catalog_root).as_posix()
-    return target, catalog_relative_path, storage_relative_path
-
-
-def _render_uuid_planned_locator(
-    *,
-    catalog_root: Path,
-    objects_root: Path,
-    storage_root: str | Path | None,
-    artifact_uuid: str,
-    original_path: Path,
-) -> PlannedLocatorResult:
-    """Render a UUID primary locator for local or fsspec storage roots."""
-    _stem, suffix = _split_name_and_suffixes(original_path.name)
-    storage_relative_path = f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
-    resolved_directory = directory_from_relative_path(storage_relative_path)
-    resolved_filename = Path(storage_relative_path).name
-
-    if storage_root is not None and _is_urlpath_root(storage_root):
-        return (
-            ArtifactLocator.from_urlpath(_join_urlpath(str(storage_root).rstrip("/"), storage_relative_path)),
-            storage_relative_path,
-            resolved_directory,
-            resolved_filename,
-        )
-
-    target_root = objects_root if storage_root is None else Path(storage_root).expanduser().resolve()
-    target = target_root / storage_relative_path
-    relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
-    return (
-        ArtifactLocator.from_path(target, relative_path=relative_path),
-        storage_relative_path,
-        resolved_directory,
-        resolved_filename,
-    )
-
-
 def _open_repository(root: Path, spec: CatalogSpec) -> CatalogRepository:
     """Create the configured repository for a catalog spec."""
     if spec.db_backend != "tinydb":
@@ -1869,38 +1749,6 @@ def _reference_locator_and_path(
     return ArtifactLocator.from_path(path), path
 
 
-def _urlpath_exists_if_supported(urlpath: str) -> bool:
-    """Return whether a URL path exists when fsspec is installed.
-
-    Args:
-        urlpath: URL path to check.
-
-    Returns:
-        ``True`` when the fsspec target exists. Returns ``False`` when fsspec or
-        a protocol-specific dependency is not installed so planning can remain a
-        dry-run without optional storage dependencies.
-    """
-    if importlib.util.find_spec("fsspec") is None:
-        return False
-    from ogcat.storage import adapter_for_locator
-
-    locator = ArtifactLocator.from_urlpath(urlpath)
-    try:
-        return adapter_for_locator(locator).exists(locator)
-    except ImportError:
-        return False
-
-
-def _is_urlpath_root(value: str | Path) -> bool:
-    """Return whether a storage root should be treated as an fsspec URL."""
-    return isinstance(value, str) and "://" in value
-
-
-def _join_urlpath(root_url: str, relative_path: str) -> str:
-    """Join an fsspec URL root and relative path without local path coercion."""
-    return f"{root_url.rstrip('/')}/{relative_path.lstrip('/')}"
-
-
 def _coerce_metadata_input(
     metadata: object,
     *,
@@ -1908,17 +1756,6 @@ def _coerce_metadata_input(
 ) -> MetadataDict:
     """Copy user metadata after preserving existing non-dictionary errors."""
     return normalize_metadata_for_schema(metadata, schema_name=schema_name)
-
-
-def _storage_relative_path_for_locator(locator: ArtifactLocator, *, storage_root: Path) -> str | None:
-    """Return a storage-root-relative path for a locator when available."""
-    if locator.kind == "path":
-        locator_path = Path(locator.value)
-        try:
-            return locator_path.relative_to(storage_root).as_posix()
-        except ValueError:
-            return locator.relative_path
-    return locator.relative_path
 
 
 def _require_template(value: str | None, *, field_name: str) -> str:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -48,6 +48,7 @@ from ogcat.operation_runner import (
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
+from ogcat.reference_planning import plan_reference_locator
 from ogcat.replicas import (
     ReplicaMode,
     ReplicaViewPlan,
@@ -66,9 +67,9 @@ from ogcat.storage import (
 )
 from ogcat.storage_planning import (
     PrimaryLocation,
-    _render_planned_locator,
-    _storage_relative_path_for_locator,
-    _uuid_storage_path,
+    render_planned_locator,
+    storage_relative_path_for_locator,
+    uuid_storage_path,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import UnitOfWork
@@ -257,18 +258,21 @@ class Catalog:
                 date_added=timestamp[:10],
             )
             if resolved_primary_location == "uuid":
-                target, catalog_relative_path, storage_relative_path = _uuid_storage_path(
+                uuid_path = uuid_storage_path(
                     catalog_root=self.root,
                     objects_root=objects_root,
                     artifact_uuid=artifact_uuid,
                     original_path=source,
                 )
-                naming_metadata["primary_storage_relative_path"] = storage_relative_path
+                naming_metadata["primary_storage_relative_path"] = uuid_path.storage_relative_path
                 naming_metadata["primary_resolved_directory"] = directory_from_relative_path(
-                    storage_relative_path
+                    uuid_path.storage_relative_path
                 )
-                naming_metadata["primary_resolved_filename"] = target.name
-                return ArtifactLocator.from_path(target, relative_path=catalog_relative_path)
+                naming_metadata["primary_resolved_filename"] = uuid_path.target.name
+                return ArtifactLocator.from_path(
+                    uuid_path.target,
+                    relative_path=uuid_path.catalog_relative_path,
+                )
 
             storage_adapter = LocalStorageAdapter()
             target, _catalog_relative_path, _resolved_filename = render_storage_location(
@@ -294,7 +298,7 @@ class Catalog:
         ) -> StoragePlan:
             """Build the storage plan for a managed local file."""
             storage_root = objects_root if resolved_primary_location == "uuid" else files_root
-            storage_relative_path = _storage_relative_path_for_locator(locator, storage_root=storage_root)
+            storage_relative_path = storage_relative_path_for_locator(locator, storage_root=storage_root)
             return plan_storage(
                 locator,
                 target_kind="file",
@@ -443,12 +447,7 @@ class Catalog:
         if locator is None:
             directory_template = _require_template(schema.directory_template, field_name="directory_template")
             filename_template = _require_template(schema.filename_template, field_name="filename_template")
-            (
-                planned_locator,
-                storage_relative_path,
-                resolved_directory,
-                resolved_filename,
-            ) = _render_planned_locator(
+            planned = render_planned_locator(
                 catalog_root=self.root,
                 files_root=self.root / self.spec.files_root,
                 objects_root=self.root / self.spec.objects_root,
@@ -461,6 +460,10 @@ class Catalog:
                 date_added=timestamp[:10],
                 primary_location=resolved_primary_location,
             )
+            planned_locator = planned.locator
+            storage_relative_path = planned.storage_relative_path
+            resolved_directory = planned.resolved_directory
+            resolved_filename = planned.resolved_filename
         else:
             planned_locator = locator
             storage_relative_path = locator.relative_path
@@ -658,7 +661,9 @@ class Catalog:
         Returns:
             Persisted or staged reference record.
         """
-        locator, local_path = _reference_locator_and_path(reference, uri=uri, urlpath=urlpath)
+        reference_plan = plan_reference_locator(reference, uri=uri, urlpath=urlpath)
+        locator = reference_plan.locator
+        local_path = reference_plan.local_path
         resolved_original_path = original_path
         resolved_original_filename = original_filename
         resolved_suffixes = suffixes
@@ -1717,36 +1722,6 @@ def _merge_metadata(
     if mode == "replace":
         return dict(updates)
     return {**current, **updates}
-
-
-def _reference_locator_and_path(
-    reference: str | Path | ArtifactLocator | None,
-    *,
-    uri: str | None,
-    urlpath: str | None,
-) -> tuple[ArtifactLocator, Path | None]:
-    """Return the locator and local path metadata for a reference input."""
-    supplied = [value is not None for value in (reference, uri, urlpath)]
-    if sum(supplied) != 1:
-        raise ValueError("Pass exactly one of reference, uri, or urlpath.")
-    if uri is not None:
-        return ArtifactLocator(kind="uri", value=str(uri)), None
-    if urlpath is not None:
-        return ArtifactLocator.from_urlpath(str(urlpath)), None
-    assert reference is not None
-    if isinstance(reference, ArtifactLocator):
-        path = reference.as_path()
-        if path is None:
-            return reference, None
-        resolved_path = path.expanduser().resolve()
-        return ArtifactLocator.from_path(resolved_path, relative_path=reference.relative_path), resolved_path
-    if isinstance(reference, str):
-        if "://" in reference:
-            return ArtifactLocator(kind="uri", value=reference), None
-        path = Path(reference).expanduser().resolve()
-        return ArtifactLocator.from_path(path), path
-    path = Path(reference).expanduser().resolve()
-    return ArtifactLocator.from_path(path), path
 
 
 def _coerce_metadata_input(

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -26,6 +26,9 @@ _RESERVED_TEMPLATE_FIELDS = frozenset(
 )
 
 
+RESERVED_TEMPLATE_FIELDS = _RESERVED_TEMPLATE_FIELDS
+
+
 def _normalise_segment(value: str) -> str:
     """Normalise a path or filename segment conservatively."""
     cleaned = value.strip().replace(" ", "_")
@@ -50,6 +53,16 @@ def _split_name_and_suffixes(name: str) -> tuple[str, str]:
     if full_suffix:
         return name[: -len(full_suffix)], full_suffix
     return name, ""
+
+
+def normalise_segment(value: str) -> str:
+    """Normalise a path or filename segment conservatively."""
+    return _normalise_segment(value)
+
+
+def split_name_and_suffixes(name: str) -> tuple[str, str]:
+    """Split a filename into the base name and its naming suffix string."""
+    return _split_name_and_suffixes(name)
 
 
 def _naming_suffixes(name: str) -> list[str]:

--- a/src/ogcat/reference_planning.py
+++ b/src/ogcat/reference_planning.py
@@ -1,0 +1,72 @@
+"""Reference locator coercion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ogcat.models import ArtifactLocator
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceLocatorPlan:
+    """Resolved reference locator and optional local path metadata.
+
+    Args:
+        locator: Locator to record for the referenced artifact.
+        local_path: Resolved local path when the reference is path-backed.
+    """
+
+    locator: ArtifactLocator
+    local_path: Path | None
+
+
+def plan_reference_locator(
+    reference: str | Path | ArtifactLocator | None,
+    *,
+    uri: str | None,
+    urlpath: str | None,
+) -> ReferenceLocatorPlan:
+    """Resolve a reference input into a locator and optional local path.
+
+    Args:
+        reference: Local path, URI-like string, or explicit artifact locator.
+        uri: Explicit URI reference. Mutually exclusive with ``reference`` and
+            ``urlpath``.
+        urlpath: Explicit fsspec-style URL-path reference. Mutually exclusive
+            with ``reference`` and ``uri``.
+
+    Returns:
+        Reference locator plan.
+
+    Raises:
+        ValueError: If callers do not pass exactly one reference input.
+    """
+    supplied = [value is not None for value in (reference, uri, urlpath)]
+    if sum(supplied) != 1:
+        raise ValueError("Pass exactly one of reference, uri, or urlpath.")
+    if uri is not None:
+        return ReferenceLocatorPlan(ArtifactLocator(kind="uri", value=str(uri)), None)
+    if urlpath is not None:
+        return ReferenceLocatorPlan(ArtifactLocator.from_urlpath(str(urlpath)), None)
+    assert reference is not None
+    if isinstance(reference, ArtifactLocator):
+        path = reference.as_path()
+        if path is None:
+            return ReferenceLocatorPlan(reference, None)
+        resolved_path = path.expanduser().resolve()
+        locator = ArtifactLocator.from_path(resolved_path, relative_path=reference.relative_path)
+        return ReferenceLocatorPlan(locator, resolved_path)
+    if isinstance(reference, str):
+        if "://" in reference:
+            return ReferenceLocatorPlan(ArtifactLocator(kind="uri", value=reference), None)
+        path = Path(reference).expanduser().resolve()
+        return ReferenceLocatorPlan(ArtifactLocator.from_path(path), path)
+    path = Path(reference).expanduser().resolve()
+    return ReferenceLocatorPlan(ArtifactLocator.from_path(path), path)
+
+
+__all__ = [
+    "ReferenceLocatorPlan",
+    "plan_reference_locator",
+]

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -16,12 +16,12 @@ from typing import Literal
 
 from ogcat.models import CatalogRecord, MetadataDict
 from ogcat.naming import (
-    _RESERVED_TEMPLATE_FIELDS,
-    _normalise_segment,
-    _split_name_and_suffixes,
+    RESERVED_TEMPLATE_FIELDS,
     build_naming_context,
+    normalise_segment,
     render_storage_location,
     render_template,
+    split_name_and_suffixes,
 )
 from ogcat.operation_helpers import directory_from_relative_path
 
@@ -249,7 +249,7 @@ def replica_template_context(record: CatalogRecord) -> dict[str, object]:
     uuid_value = str(artifact_uuid or record_id)
     original_name = _record_original_name(record)
     naming_metadata = {
-        key: value for key, value in record.user_metadata.items() if key not in _RESERVED_TEMPLATE_FIELDS
+        key: value for key, value in record.user_metadata.items() if key not in RESERVED_TEMPLATE_FIELDS
     }
     context.update(
         build_naming_context(
@@ -262,7 +262,7 @@ def replica_template_context(record: CatalogRecord) -> dict[str, object]:
     )
     locator_path = record.path()
     locator_name = "" if locator_path is None else locator_path.name
-    locator_stem, locator_suffix = _split_name_and_suffixes(locator_name)
+    locator_stem, locator_suffix = split_name_and_suffixes(locator_name)
 
     context.update(
         {
@@ -277,7 +277,7 @@ def replica_template_context(record: CatalogRecord) -> dict[str, object]:
             "locator_kind": record.locator.kind,
             "locator_value": record.locator.value,
             "locator_filename": locator_name,
-            "locator_stem": _normalise_segment(locator_stem) if locator_stem else "",
+            "locator_stem": normalise_segment(locator_stem) if locator_stem else "",
             "locator_suffix": locator_suffix,
             "stored_relpath": record.stored_relpath or "",
             "path": "" if locator_path is None else str(locator_path),
@@ -481,7 +481,7 @@ def _render_replica_path(root: Path, template: str, context: dict[str, object]) 
     parts = [part for part in rendered.replace("\\", "/").split("/") if part]
     if not parts:
         raise ValueError("Replica template rendered an empty path.")
-    normalised_parts = [_normalise_segment(part) for part in parts]
+    normalised_parts = [normalise_segment(part) for part in parts]
     if any(part in {".", ".."} for part in normalised_parts) or Path(rendered).is_absolute():
         raise ValueError(f"Replica template must render a relative path below the view root: {rendered}")
     return root.joinpath(*normalised_parts)

--- a/src/ogcat/storage_planning.py
+++ b/src/ogcat/storage_planning.py
@@ -1,0 +1,276 @@
+"""Storage location planning helpers.
+
+This module contains path and URL selection policy for catalog-managed
+artifacts. It is intentionally separate from storage adapters, which perform
+side effects against already-planned locators.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from ogcat.models import ArtifactLocator
+from ogcat.naming import _split_name_and_suffixes, build_naming_context, render_storage_location
+from ogcat.operation_helpers import directory_from_relative_path
+from ogcat.storage import LocalStorageAdapter
+
+PrimaryLocation: TypeAlias = Literal["uuid", "template"]
+PlannedLocatorResult: TypeAlias = tuple[ArtifactLocator, str | None, str | None, str | None]
+
+
+def _uuid_storage_path(
+    *,
+    catalog_root: Path,
+    objects_root: Path,
+    artifact_uuid: str,
+    original_path: Path,
+) -> tuple[Path, str, str]:
+    """Return the local UUID primary path and relative path metadata.
+
+    Args:
+        catalog_root: Catalog root used to build catalog-relative locator
+            metadata.
+        objects_root: Root directory for UUID-managed object storage.
+        artifact_uuid: Stable artifact identifier used in the target filename.
+        original_path: Original source path used only to preserve naming
+            suffixes.
+
+    Returns:
+        Target path, catalog-relative path, and objects-root-relative path.
+    """
+    storage_relative_path = _uuid_storage_relative_path(
+        artifact_uuid=artifact_uuid,
+        original_path=original_path,
+    )
+    target = objects_root / storage_relative_path
+    catalog_relative_path = target.relative_to(catalog_root).as_posix()
+    return target, catalog_relative_path, storage_relative_path
+
+
+def _render_uuid_planned_locator(
+    *,
+    catalog_root: Path,
+    objects_root: Path,
+    storage_root: str | Path | None,
+    artifact_uuid: str,
+    original_path: Path,
+) -> PlannedLocatorResult:
+    """Render a UUID primary locator for local or fsspec storage roots.
+
+    Args:
+        catalog_root: Catalog root used for catalog-local relative paths.
+        objects_root: Catalog object-storage root used when no explicit storage
+            root is supplied.
+        storage_root: Optional external local root or fsspec URL root.
+        artifact_uuid: Stable artifact identifier used in the target filename.
+        original_path: Original source path used only to preserve naming
+            suffixes.
+
+    Returns:
+        Locator, storage-relative path, resolved directory, and resolved
+        filename.
+    """
+    storage_relative_path = _uuid_storage_relative_path(
+        artifact_uuid=artifact_uuid,
+        original_path=original_path,
+    )
+    resolved_directory = directory_from_relative_path(storage_relative_path)
+    resolved_filename = Path(storage_relative_path).name
+
+    if storage_root is not None and _is_urlpath_root(storage_root):
+        return (
+            ArtifactLocator.from_urlpath(_join_urlpath(str(storage_root), storage_relative_path)),
+            storage_relative_path,
+            resolved_directory,
+            resolved_filename,
+        )
+
+    target_root = objects_root if storage_root is None else Path(storage_root).expanduser().resolve()
+    target = target_root / storage_relative_path
+    relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
+    return (
+        ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path,
+        resolved_directory,
+        resolved_filename,
+    )
+
+
+def _render_planned_locator(
+    *,
+    catalog_root: Path,
+    files_root: Path,
+    objects_root: Path,
+    operation_id: str,
+    metadata: Mapping[str, object],
+    directory_template: str,
+    filename_template: str,
+    source_path: Path | None,
+    storage_root: str | Path | None,
+    date_added: str,
+    primary_location: PrimaryLocation,
+) -> PlannedLocatorResult:
+    """Render schema naming templates into a local or fsspec target locator.
+
+    Args:
+        catalog_root: Catalog root used for catalog-local relative paths.
+        files_root: Catalog template-managed files root.
+        objects_root: Catalog UUID-managed object root.
+        operation_id: Operation id used as the planned artifact UUID.
+        metadata: Normalized metadata available to naming templates.
+        directory_template: Directory naming template from the record schema.
+        filename_template: Filename naming template from the record schema.
+        source_path: Optional source path used for naming context.
+        storage_root: Optional external local root or fsspec URL root.
+        date_added: ISO date string used by date-based templates.
+        primary_location: Primary placement policy to render.
+
+    Returns:
+        Locator, storage-relative path, resolved directory, and resolved
+        filename.
+    """
+    naming_source = source_path or Path("artifact")
+    naming_context = build_naming_context(
+        record_id=operation_id,
+        operation_id=operation_id,
+        original_path=naming_source,
+        metadata=metadata,
+        date_added=date_added,
+    )
+    artifact_uuid = operation_id
+    naming_context["artifact_uuid"] = artifact_uuid
+    if primary_location == "uuid":
+        return _render_uuid_planned_locator(
+            catalog_root=catalog_root,
+            objects_root=objects_root,
+            storage_root=storage_root,
+            artifact_uuid=artifact_uuid,
+            original_path=naming_source,
+        )
+
+    if storage_root is not None and _is_urlpath_root(storage_root):
+        return _render_urlpath_template_locator(
+            root_url=str(storage_root),
+            directory_template=directory_template,
+            filename_template=filename_template,
+            naming_context=naming_context,
+        )
+
+    local_files_root = files_root if storage_root is None else Path(storage_root).expanduser().resolve()
+    storage_adapter = LocalStorageAdapter()
+    target, _catalog_relative_path, resolved_filename = render_storage_location(
+        files_root=local_files_root,
+        directory_template=directory_template,
+        filename_template=filename_template,
+        context=naming_context,
+        exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
+    )
+    relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
+    storage_relative_path = target.relative_to(local_files_root).as_posix()
+    return (
+        ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path,
+        directory_from_relative_path(storage_relative_path),
+        resolved_filename,
+    )
+
+
+def _urlpath_exists_if_supported(urlpath: str) -> bool:
+    """Return whether a URL path exists when fsspec is installed.
+
+    Args:
+        urlpath: URL path to check.
+
+    Returns:
+        ``True`` when the fsspec target exists. Returns ``False`` when fsspec or
+        a protocol-specific dependency is not installed so planning can remain a
+        dry-run without optional storage dependencies.
+    """
+    if importlib.util.find_spec("fsspec") is None:
+        return False
+    from ogcat.storage import adapter_for_locator
+
+    locator = ArtifactLocator.from_urlpath(urlpath)
+    try:
+        return adapter_for_locator(locator).exists(locator)
+    except ImportError:
+        return False
+
+
+def _is_urlpath_root(value: str | Path) -> bool:
+    """Return whether a storage root should be treated as an fsspec URL."""
+    return isinstance(value, str) and "://" in value
+
+
+def _join_urlpath(root_url: str, relative_path: str) -> str:
+    """Join an fsspec URL root and relative path without local path coercion."""
+    return f"{root_url.rstrip('/')}/{relative_path.lstrip('/')}"
+
+
+def _storage_relative_path_for_locator(locator: ArtifactLocator, *, storage_root: Path) -> str | None:
+    """Return a storage-root-relative path for a locator when available.
+
+    Args:
+        locator: Locator to inspect.
+        storage_root: Local storage root used for path-backed locators.
+
+    Returns:
+        Storage-root-relative path, existing locator relative path, or ``None``
+        when no relative storage metadata is available.
+    """
+    if locator.kind == "path":
+        locator_path = Path(locator.value)
+        try:
+            return locator_path.relative_to(storage_root).as_posix()
+        except ValueError:
+            return locator.relative_path
+    return locator.relative_path
+
+
+def _render_urlpath_template_locator(
+    *,
+    root_url: str,
+    directory_template: str,
+    filename_template: str,
+    naming_context: dict[str, object],
+) -> PlannedLocatorResult:
+    """Render a template-managed fsspec URL-path locator.
+
+    Args:
+        root_url: URL-path root under which the rendered path should live.
+        directory_template: Directory naming template from the record schema.
+        filename_template: Filename naming template from the record schema.
+        naming_context: Precomputed naming context used by the templates.
+
+    Returns:
+        Locator, storage-relative path, resolved directory, and resolved
+        filename.
+    """
+    normalized_root_url = root_url.rstrip("/")
+    fake_root = Path("/__ogcat_storage__")
+
+    target, _rel_path, resolved_filename = render_storage_location(
+        files_root=fake_root,
+        directory_template=directory_template,
+        filename_template=filename_template,
+        context=naming_context,
+        exists=lambda candidate: _urlpath_exists_if_supported(
+            _join_urlpath(normalized_root_url, candidate.relative_to(fake_root).as_posix())
+        ),
+    )
+    storage_relative_path = target.relative_to(fake_root).as_posix()
+    return (
+        ArtifactLocator.from_urlpath(_join_urlpath(normalized_root_url, storage_relative_path)),
+        storage_relative_path,
+        directory_from_relative_path(storage_relative_path),
+        resolved_filename,
+    )
+
+
+def _uuid_storage_relative_path(*, artifact_uuid: str, original_path: Path) -> str:
+    """Return the objects-root-relative path for a UUID primary artifact."""
+    _stem, suffix = _split_name_and_suffixes(original_path.name)
+    return f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"

--- a/src/ogcat/storage_planning.py
+++ b/src/ogcat/storage_planning.py
@@ -9,25 +9,57 @@ from __future__ import annotations
 
 import importlib.util
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias
 
 from ogcat.models import ArtifactLocator
-from ogcat.naming import _split_name_and_suffixes, build_naming_context, render_storage_location
+from ogcat.naming import build_naming_context, render_storage_location, split_name_and_suffixes
 from ogcat.operation_helpers import directory_from_relative_path
 from ogcat.storage import LocalStorageAdapter
 
 PrimaryLocation: TypeAlias = Literal["uuid", "template"]
-PlannedLocatorResult: TypeAlias = tuple[ArtifactLocator, str | None, str | None, str | None]
 
 
-def _uuid_storage_path(
+@dataclass(frozen=True, slots=True)
+class PlannedLocator:
+    """Rendered locator and path metadata for a planned storage target.
+
+    Args:
+        locator: Target artifact locator.
+        storage_relative_path: Path relative to the relevant storage root.
+        resolved_directory: Rendered storage directory, when available.
+        resolved_filename: Rendered final path component, when available.
+    """
+
+    locator: ArtifactLocator
+    storage_relative_path: str | None
+    resolved_directory: str | None
+    resolved_filename: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class UuidStoragePath:
+    """Local UUID storage path and relative path metadata.
+
+    Args:
+        target: Local UUID target path.
+        catalog_relative_path: Target path relative to the catalog root.
+        storage_relative_path: Target path relative to the objects root.
+    """
+
+    target: Path
+    catalog_relative_path: str
+    storage_relative_path: str
+
+
+def uuid_storage_path(
     *,
     catalog_root: Path,
     objects_root: Path,
     artifact_uuid: str,
     original_path: Path,
-) -> tuple[Path, str, str]:
+) -> UuidStoragePath:
     """Return the local UUID primary path and relative path metadata.
 
     Args:
@@ -39,7 +71,7 @@ def _uuid_storage_path(
             suffixes.
 
     Returns:
-        Target path, catalog-relative path, and objects-root-relative path.
+        Local UUID storage path and relative path metadata.
     """
     storage_relative_path = _uuid_storage_relative_path(
         artifact_uuid=artifact_uuid,
@@ -47,17 +79,21 @@ def _uuid_storage_path(
     )
     target = objects_root / storage_relative_path
     catalog_relative_path = target.relative_to(catalog_root).as_posix()
-    return target, catalog_relative_path, storage_relative_path
+    return UuidStoragePath(
+        target=target,
+        catalog_relative_path=catalog_relative_path,
+        storage_relative_path=storage_relative_path,
+    )
 
 
-def _render_uuid_planned_locator(
+def render_uuid_planned_locator(
     *,
     catalog_root: Path,
     objects_root: Path,
     storage_root: str | Path | None,
     artifact_uuid: str,
     original_path: Path,
-) -> PlannedLocatorResult:
+) -> PlannedLocator:
     """Render a UUID primary locator for local or fsspec storage roots.
 
     Args:
@@ -70,8 +106,7 @@ def _render_uuid_planned_locator(
             suffixes.
 
     Returns:
-        Locator, storage-relative path, resolved directory, and resolved
-        filename.
+        Rendered locator and path metadata.
     """
     storage_relative_path = _uuid_storage_relative_path(
         artifact_uuid=artifact_uuid,
@@ -81,25 +116,25 @@ def _render_uuid_planned_locator(
     resolved_filename = Path(storage_relative_path).name
 
     if storage_root is not None and _is_urlpath_root(storage_root):
-        return (
-            ArtifactLocator.from_urlpath(_join_urlpath(str(storage_root), storage_relative_path)),
-            storage_relative_path,
-            resolved_directory,
-            resolved_filename,
+        return PlannedLocator(
+            locator=ArtifactLocator.from_urlpath(join_urlpath(str(storage_root), storage_relative_path)),
+            storage_relative_path=storage_relative_path,
+            resolved_directory=resolved_directory,
+            resolved_filename=resolved_filename,
         )
 
     target_root = objects_root if storage_root is None else Path(storage_root).expanduser().resolve()
     target = target_root / storage_relative_path
     relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
-    return (
-        ArtifactLocator.from_path(target, relative_path=relative_path),
-        storage_relative_path,
-        resolved_directory,
-        resolved_filename,
+    return PlannedLocator(
+        locator=ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path=storage_relative_path,
+        resolved_directory=resolved_directory,
+        resolved_filename=resolved_filename,
     )
 
 
-def _render_planned_locator(
+def render_planned_locator(
     *,
     catalog_root: Path,
     files_root: Path,
@@ -112,7 +147,7 @@ def _render_planned_locator(
     storage_root: str | Path | None,
     date_added: str,
     primary_location: PrimaryLocation,
-) -> PlannedLocatorResult:
+) -> PlannedLocator:
     """Render schema naming templates into a local or fsspec target locator.
 
     Args:
@@ -129,8 +164,7 @@ def _render_planned_locator(
         primary_location: Primary placement policy to render.
 
     Returns:
-        Locator, storage-relative path, resolved directory, and resolved
-        filename.
+        Rendered locator and path metadata.
     """
     naming_source = source_path or Path("artifact")
     naming_context = build_naming_context(
@@ -143,7 +177,7 @@ def _render_planned_locator(
     artifact_uuid = operation_id
     naming_context["artifact_uuid"] = artifact_uuid
     if primary_location == "uuid":
-        return _render_uuid_planned_locator(
+        return render_uuid_planned_locator(
             catalog_root=catalog_root,
             objects_root=objects_root,
             storage_root=storage_root,
@@ -170,15 +204,15 @@ def _render_planned_locator(
     )
     relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
     storage_relative_path = target.relative_to(local_files_root).as_posix()
-    return (
-        ArtifactLocator.from_path(target, relative_path=relative_path),
-        storage_relative_path,
-        directory_from_relative_path(storage_relative_path),
-        resolved_filename,
+    return PlannedLocator(
+        locator=ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path=storage_relative_path,
+        resolved_directory=directory_from_relative_path(storage_relative_path),
+        resolved_filename=resolved_filename,
     )
 
 
-def _urlpath_exists_if_supported(urlpath: str) -> bool:
+def urlpath_exists_if_supported(urlpath: str) -> bool:
     """Return whether a URL path exists when fsspec is installed.
 
     Args:
@@ -205,12 +239,12 @@ def _is_urlpath_root(value: str | Path) -> bool:
     return isinstance(value, str) and "://" in value
 
 
-def _join_urlpath(root_url: str, relative_path: str) -> str:
+def join_urlpath(root_url: str, relative_path: str) -> str:
     """Join an fsspec URL root and relative path without local path coercion."""
     return f"{root_url.rstrip('/')}/{relative_path.lstrip('/')}"
 
 
-def _storage_relative_path_for_locator(locator: ArtifactLocator, *, storage_root: Path) -> str | None:
+def storage_relative_path_for_locator(locator: ArtifactLocator, *, storage_root: Path) -> str | None:
     """Return a storage-root-relative path for a locator when available.
 
     Args:
@@ -236,7 +270,7 @@ def _render_urlpath_template_locator(
     directory_template: str,
     filename_template: str,
     naming_context: dict[str, object],
-) -> PlannedLocatorResult:
+) -> PlannedLocator:
     """Render a template-managed fsspec URL-path locator.
 
     Args:
@@ -257,20 +291,33 @@ def _render_urlpath_template_locator(
         directory_template=directory_template,
         filename_template=filename_template,
         context=naming_context,
-        exists=lambda candidate: _urlpath_exists_if_supported(
-            _join_urlpath(normalized_root_url, candidate.relative_to(fake_root).as_posix())
+        exists=lambda candidate: urlpath_exists_if_supported(
+            join_urlpath(normalized_root_url, candidate.relative_to(fake_root).as_posix())
         ),
     )
     storage_relative_path = target.relative_to(fake_root).as_posix()
-    return (
-        ArtifactLocator.from_urlpath(_join_urlpath(normalized_root_url, storage_relative_path)),
-        storage_relative_path,
-        directory_from_relative_path(storage_relative_path),
-        resolved_filename,
+    return PlannedLocator(
+        locator=ArtifactLocator.from_urlpath(join_urlpath(normalized_root_url, storage_relative_path)),
+        storage_relative_path=storage_relative_path,
+        resolved_directory=directory_from_relative_path(storage_relative_path),
+        resolved_filename=resolved_filename,
     )
 
 
 def _uuid_storage_relative_path(*, artifact_uuid: str, original_path: Path) -> str:
     """Return the objects-root-relative path for a UUID primary artifact."""
-    _stem, suffix = _split_name_and_suffixes(original_path.name)
+    _stem, suffix = split_name_and_suffixes(original_path.name)
     return f"{artifact_uuid[:2]}/{artifact_uuid}{suffix}"
+
+
+__all__ = [
+    "PlannedLocator",
+    "PrimaryLocation",
+    "UuidStoragePath",
+    "join_urlpath",
+    "render_planned_locator",
+    "render_uuid_planned_locator",
+    "storage_relative_path_for_locator",
+    "urlpath_exists_if_supported",
+    "uuid_storage_path",
+]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import ogcat.catalog as catalog_module
+import ogcat.storage_planning as storage_planning
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
 from ogcat.hooks import OperationContext, OperationSource
 from ogcat.models import MetadataDict
@@ -20,6 +21,72 @@ from ogcat.storage import (
     register_remove_on_rollback,
     remove_target,
 )
+
+
+def test_storage_planning_uuid_path_preserves_catalog_and_storage_relative_paths(
+    tmp_path: Path,
+) -> None:
+    """UUID path planning keeps catalog-relative and objects-relative metadata distinct."""
+    catalog_root = tmp_path / "catalog"
+    objects_root = catalog_root / "data" / "objects"
+    target, catalog_relative_path, storage_relative_path = storage_planning._uuid_storage_path(
+        catalog_root=catalog_root,
+        objects_root=objects_root,
+        artifact_uuid="abcdef123456",
+        original_path=tmp_path / "archive.tar.gz",
+    )
+
+    assert target == objects_root / "ab" / "abcdef123456.tar.gz"
+    assert catalog_relative_path == "data/objects/ab/abcdef123456.tar.gz"
+    assert storage_relative_path == "ab/abcdef123456.tar.gz"
+
+
+def test_storage_planning_joins_urlpath_roots_without_path_coercion() -> None:
+    """URL path joins should preserve the protocol while normalizing boundary slashes."""
+    assert storage_planning._join_urlpath("s3://bucket/prefix/", "/nested/file.nc") == (
+        "s3://bucket/prefix/nested/file.nc"
+    )
+
+
+def test_storage_planning_relative_path_prefers_local_storage_root(
+    tmp_path: Path,
+) -> None:
+    """Storage-relative metadata is relative to the root when the locator is underneath it."""
+    storage_root = tmp_path / "objects"
+    locator = ArtifactLocator.from_path(
+        storage_root / "ab" / "artifact.nc",
+        relative_path="data/objects/ab/artifact.nc",
+    )
+
+    assert storage_planning._storage_relative_path_for_locator(locator, storage_root=storage_root) == (
+        "ab/artifact.nc"
+    )
+
+
+def test_storage_planning_relative_path_falls_back_to_locator_metadata(
+    tmp_path: Path,
+) -> None:
+    """External local and URL-path locators keep their existing relative-path metadata."""
+    storage_root = tmp_path / "objects"
+    external_locator = ArtifactLocator.from_path(
+        tmp_path / "external" / "artifact.nc",
+        relative_path="external/artifact.nc",
+    )
+    url_locator = ArtifactLocator.from_urlpath(
+        "s3://bucket/prefix/artifact.nc",
+        relative_path="prefix/artifact.nc",
+    )
+
+    assert (
+        storage_planning._storage_relative_path_for_locator(
+            external_locator,
+            storage_root=storage_root,
+        )
+        == "external/artifact.nc"
+    )
+    assert storage_planning._storage_relative_path_for_locator(url_locator, storage_root=storage_root) == (
+        "prefix/artifact.nc"
+    )
 
 
 def test_plan_artifact_storage_uses_uuid_primary_without_writing(tmp_path: Path) -> None:
@@ -216,7 +283,7 @@ def test_urlpath_storage_root_does_not_populate_stored_relpath(
             ),
         ),
     )
-    monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", lambda _urlpath: False)
+    monkeypatch.setattr(storage_planning, "_urlpath_exists_if_supported", lambda _urlpath: False)
 
     plan = catalog.plan_artifact_storage(
         source,
@@ -271,7 +338,7 @@ def test_plan_artifact_storage_urlpath_root_uses_available_collision_check(
         seen.append(urlpath)
         return urlpath.endswith("/fixed.nc")
 
-    monkeypatch.setattr(catalog_module, "_urlpath_exists_if_supported", fake_exists)
+    monkeypatch.setattr(storage_planning, "_urlpath_exists_if_supported", fake_exists)
 
     plan = catalog.plan_artifact_storage(
         source,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,7 @@ import ogcat.storage_planning as storage_planning
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
 from ogcat.hooks import OperationContext, OperationSource
 from ogcat.models import MetadataDict
+from ogcat.reference_planning import plan_reference_locator
 from ogcat.storage import (
     LocalStorageAdapter,
     adapter_for_locator,
@@ -29,21 +30,21 @@ def test_storage_planning_uuid_path_preserves_catalog_and_storage_relative_paths
     """UUID path planning keeps catalog-relative and objects-relative metadata distinct."""
     catalog_root = tmp_path / "catalog"
     objects_root = catalog_root / "data" / "objects"
-    target, catalog_relative_path, storage_relative_path = storage_planning._uuid_storage_path(
+    planned = storage_planning.uuid_storage_path(
         catalog_root=catalog_root,
         objects_root=objects_root,
         artifact_uuid="abcdef123456",
         original_path=tmp_path / "archive.tar.gz",
     )
 
-    assert target == objects_root / "ab" / "abcdef123456.tar.gz"
-    assert catalog_relative_path == "data/objects/ab/abcdef123456.tar.gz"
-    assert storage_relative_path == "ab/abcdef123456.tar.gz"
+    assert planned.target == objects_root / "ab" / "abcdef123456.tar.gz"
+    assert planned.catalog_relative_path == "data/objects/ab/abcdef123456.tar.gz"
+    assert planned.storage_relative_path == "ab/abcdef123456.tar.gz"
 
 
 def test_storage_planning_joins_urlpath_roots_without_path_coercion() -> None:
     """URL path joins should preserve the protocol while normalizing boundary slashes."""
-    assert storage_planning._join_urlpath("s3://bucket/prefix/", "/nested/file.nc") == (
+    assert storage_planning.join_urlpath("s3://bucket/prefix/", "/nested/file.nc") == (
         "s3://bucket/prefix/nested/file.nc"
     )
 
@@ -58,7 +59,7 @@ def test_storage_planning_relative_path_prefers_local_storage_root(
         relative_path="data/objects/ab/artifact.nc",
     )
 
-    assert storage_planning._storage_relative_path_for_locator(locator, storage_root=storage_root) == (
+    assert storage_planning.storage_relative_path_for_locator(locator, storage_root=storage_root) == (
         "ab/artifact.nc"
     )
 
@@ -78,15 +79,37 @@ def test_storage_planning_relative_path_falls_back_to_locator_metadata(
     )
 
     assert (
-        storage_planning._storage_relative_path_for_locator(
+        storage_planning.storage_relative_path_for_locator(
             external_locator,
             storage_root=storage_root,
         )
         == "external/artifact.nc"
     )
-    assert storage_planning._storage_relative_path_for_locator(url_locator, storage_root=storage_root) == (
+    assert storage_planning.storage_relative_path_for_locator(url_locator, storage_root=storage_root) == (
         "prefix/artifact.nc"
     )
+
+
+def test_reference_planning_resolves_local_path_reference(tmp_path: Path) -> None:
+    """Reference planning resolves path-backed references and preserves local path metadata."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+
+    plan = plan_reference_locator(source, uri=None, urlpath=None)
+
+    assert plan.locator == ArtifactLocator.from_path(source.resolve())
+    assert plan.local_path == source.resolve()
+
+
+def test_reference_planning_resolves_uri_and_urlpath_references() -> None:
+    """Reference planning keeps URI and URL-path references path-free."""
+    uri_plan = plan_reference_locator(None, uri="https://example.org/data.nc", urlpath=None)
+    urlpath_plan = plan_reference_locator(None, uri=None, urlpath="s3://bucket/data.nc")
+
+    assert uri_plan.locator == ArtifactLocator(kind="uri", value="https://example.org/data.nc")
+    assert uri_plan.local_path is None
+    assert urlpath_plan.locator == ArtifactLocator.from_urlpath("s3://bucket/data.nc")
+    assert urlpath_plan.local_path is None
 
 
 def test_plan_artifact_storage_uses_uuid_primary_without_writing(tmp_path: Path) -> None:
@@ -283,7 +306,7 @@ def test_urlpath_storage_root_does_not_populate_stored_relpath(
             ),
         ),
     )
-    monkeypatch.setattr(storage_planning, "_urlpath_exists_if_supported", lambda _urlpath: False)
+    monkeypatch.setattr(storage_planning, "urlpath_exists_if_supported", lambda _urlpath: False)
 
     plan = catalog.plan_artifact_storage(
         source,
@@ -338,7 +361,7 @@ def test_plan_artifact_storage_urlpath_root_uses_available_collision_check(
         seen.append(urlpath)
         return urlpath.endswith("/fixed.nc")
 
-    monkeypatch.setattr(storage_planning, "_urlpath_exists_if_supported", fake_exists)
+    monkeypatch.setattr(storage_planning, "urlpath_exists_if_supported", fake_exists)
 
     plan = catalog.plan_artifact_storage(
         source,


### PR DESCRIPTION
## Summary

This is PR 1 in the #84 architecture train.

- Promotes the storage-planning helpers used outside their module to deliberate package-internal interfaces with non-underscore names.
- Replaces planned-locator tuple results with small dataclasses.
- Moves reference locator coercion out of `Catalog` into `reference_planning`.
- Promotes narrow naming helpers used by other modules and updates replica code to stop importing naming privates.
- Updates storage/reference planning tests to target the owning interfaces.

## Architecture Checkpoint

Moved out of `Catalog`:

- reference locator coercion for `add_reference()`;
- private storage-planning helper dependencies.

Still intentionally in `Catalog` for the next PRs:

- add-file primary planning orchestration, to be removed by #86;
- template-link replica post-processing, to be replaced by secondary artifact operations in #88;
- operation request construction, to be moved under #87.

## Checks

- `uv run ruff check src/ogcat/catalog.py src/ogcat/naming.py src/ogcat/reference_planning.py src/ogcat/replicas.py src/ogcat/storage_planning.py tests/test_storage.py`
- `uv run ruff format --check src/ogcat/catalog.py src/ogcat/naming.py src/ogcat/reference_planning.py src/ogcat/replicas.py src/ogcat/storage_planning.py tests/test_storage.py`
- `uv run pyright`
- `uv run pytest tests/test_storage.py tests/test_add.py tests/test_hooks.py tests/test_replicas.py -q`
- `uv run pytest`