### PR TITLE
[codex] Introduce shared primary storage planner

### DIFF
--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -29,13 +29,8 @@ from ogcat.hooks import (
     validate_hook_objects,
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
-from ogcat.naming import build_naming_context, render_storage_location
 from ogcat.operation_helpers import (
-    adapter_name,
     artifact_locator_from_context,
-    directory_from_locator,
-    directory_from_relative_path,
-    filename_from_locator,
     naming_metadata_from_storage_plan,
     normalize_metadata_for_schema,
     storage_plan_with_locator,
@@ -59,17 +54,15 @@ from ogcat.repository import CatalogRepository
 from ogcat.search import SearchQuery
 from ogcat.spec import CatalogSpec, RecordSchema
 from ogcat.storage import (
-    LocalStorageAdapter,
     StoragePlan,
     TargetKind,
     WriteMode,
-    plan_storage,
 )
 from ogcat.storage_planning import (
     PrimaryLocation,
-    render_planned_locator,
-    storage_relative_path_for_locator,
-    uuid_storage_path,
+    PrimaryStoragePlanningContext,
+    PrimaryStoragePlanResult,
+    plan_primary_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import UnitOfWork
@@ -245,71 +238,47 @@ class Catalog:
             "filename_template": filename_template,
             "primary_location": resolved_primary_location,
         }
+        planned_primary: PrimaryStoragePlanResult | None = None
+
+        def plan_primary(context: OperationContext) -> PrimaryStoragePlanResult:
+            """Plan the managed-file primary location for this operation."""
+            return plan_primary_storage(
+                PrimaryStoragePlanningContext(
+                    catalog_root=self.root,
+                    files_root=files_root,
+                    objects_root=objects_root,
+                    operation_id=context.operation_id,
+                    metadata=context.user_metadata,
+                    directory_template=directory_template,
+                    filename_template=filename_template,
+                    source_path=source,
+                    storage_root=None,
+                    date_added=timestamp[:10],
+                    primary_location=resolved_primary_location,
+                )
+            )
 
         def resolve_local_file_locator(context: OperationContext) -> ArtifactLocator:
             """Resolve the managed-file storage path for this operation."""
-            artifact_uuid = context.operation_id
-            naming_metadata["artifact_uuid"] = artifact_uuid
-            naming_context = build_naming_context(
-                record_id=artifact_uuid,
-                operation_id=artifact_uuid,
-                original_path=source,
-                metadata=context.user_metadata,
-                date_added=timestamp[:10],
-            )
-            if resolved_primary_location == "uuid":
-                uuid_path = uuid_storage_path(
-                    catalog_root=self.root,
-                    objects_root=objects_root,
-                    artifact_uuid=artifact_uuid,
-                    original_path=source,
-                )
-                naming_metadata["primary_storage_relative_path"] = uuid_path.storage_relative_path
-                naming_metadata["primary_resolved_directory"] = directory_from_relative_path(
-                    uuid_path.storage_relative_path
-                )
-                naming_metadata["primary_resolved_filename"] = uuid_path.target.name
-                return ArtifactLocator.from_path(
-                    uuid_path.target,
-                    relative_path=uuid_path.catalog_relative_path,
-                )
-
-            storage_adapter = LocalStorageAdapter()
-            target, _catalog_relative_path, _resolved_filename = render_storage_location(
-                files_root=files_root,
-                directory_template=directory_template,
-                filename_template=filename_template,
-                context=naming_context,
-                exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
-            )
-            catalog_relative_path = target.relative_to(self.root).as_posix()
-            storage_relative_path = target.relative_to(files_root).as_posix()
-            naming_metadata["resolved_filename"] = _resolved_filename
-            naming_metadata["primary_storage_relative_path"] = storage_relative_path
-            naming_metadata["primary_resolved_directory"] = directory_from_relative_path(
-                storage_relative_path
-            )
-            naming_metadata["primary_resolved_filename"] = _resolved_filename
-            return ArtifactLocator.from_path(target, relative_path=catalog_relative_path)
+            nonlocal planned_primary
+            planned_primary = plan_primary(context)
+            if resolved_primary_location == "template":
+                naming_metadata["artifact_uuid"] = context.operation_id
+            return planned_primary.locator
 
         def plan_local_file_storage(
             context: OperationContext,
             locator: ArtifactLocator,
         ) -> StoragePlan:
             """Build the storage plan for a managed local file."""
-            storage_root = objects_root if resolved_primary_location == "uuid" else files_root
-            storage_relative_path = storage_relative_path_for_locator(locator, storage_root=storage_root)
-            return plan_storage(
-                locator,
+            primary = planned_primary or plan_primary(context)
+            artifact_uuid = context.operation_id if resolved_primary_location == "template" else None
+            return primary.to_storage_plan(
+                locator=locator,
                 target_kind="file",
                 write_mode=cast(WriteMode, chosen_operation),
                 ogcat_owned=True,
-                adapter=adapter_name(locator),
-                storage_relative_path=storage_relative_path,
-                resolved_directory=directory_from_relative_path(storage_relative_path),
-                resolved_filename=filename_from_locator(locator),
-                artifact_uuid=context.operation_id,
-                primary_location=resolved_primary_location,
+                artifact_uuid=artifact_uuid,
             )
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
@@ -444,10 +413,18 @@ class Catalog:
         hook_dispatcher.after_validate_metadata(context, validation_report)
         validation_report.raise_for_errors()
 
-        if locator is None:
-            directory_template = _require_template(schema.directory_template, field_name="directory_template")
-            filename_template = _require_template(schema.filename_template, field_name="filename_template")
-            planned = render_planned_locator(
+        directory_template = (
+            _require_template(schema.directory_template, field_name="directory_template")
+            if locator is None
+            else schema.directory_template or ""
+        )
+        filename_template = (
+            _require_template(schema.filename_template, field_name="filename_template")
+            if locator is None
+            else schema.filename_template or ""
+        )
+        primary = plan_primary_storage(
+            PrimaryStoragePlanningContext(
                 catalog_root=self.root,
                 files_root=self.root / self.spec.files_root,
                 objects_root=self.root / self.spec.objects_root,
@@ -458,36 +435,20 @@ class Catalog:
                 source_path=source_path,
                 storage_root=storage_root,
                 date_added=timestamp[:10],
-                primary_location=resolved_primary_location,
+                primary_location="user_provided" if locator is not None else resolved_primary_location,
+                locator=locator,
             )
-            planned_locator = planned.locator
-            storage_relative_path = planned.storage_relative_path
-            resolved_directory = planned.resolved_directory
-            resolved_filename = planned.resolved_filename
-        else:
-            planned_locator = locator
-            storage_relative_path = locator.relative_path
-            resolved_directory = directory_from_locator(locator)
-            resolved_filename = filename_from_locator(locator)
+        )
+        planned_locator = primary.locator
         context.planned_locators = [planned_locator]
         hook_dispatcher.resolve_artifact_locator(context)
         canonical_locator = artifact_locator_from_context(context)
-        if canonical_locator != planned_locator:
-            storage_relative_path = canonical_locator.relative_path
-            resolved_directory = directory_from_locator(canonical_locator)
-            resolved_filename = filename_from_locator(canonical_locator)
-        plan = plan_storage(
-            canonical_locator,
+        plan = primary.to_storage_plan(
+            locator=canonical_locator,
             target_kind=target_kind,
             write_mode=resolved_write_mode,
             ogcat_owned=ogcat_owned,
-            adapter=adapter_name(canonical_locator),
             time_added=timestamp,
-            storage_relative_path=storage_relative_path,
-            resolved_directory=resolved_directory,
-            resolved_filename=resolved_filename,
-            artifact_uuid=operation_id if locator is None and resolved_primary_location == "uuid" else None,
-            primary_location="user_provided" if locator is not None else resolved_primary_location,
         )
         context.storage_plan = plan
         return plan

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -13,6 +13,7 @@ _COMPRESSED_SUFFIXES = {".gz", ".bz2", ".xz", ".zip", ".zst"}
 _RESERVED_TEMPLATE_FIELDS = frozenset(
     {
         "date_added",
+        "artifact_uuid",
         "id",
         "operation_id",
         "original_filename",

--- a/src/ogcat/storage_planning.py
+++ b/src/ogcat/storage_planning.py
@@ -15,10 +15,164 @@ from typing import Literal, TypeAlias
 
 from ogcat.models import ArtifactLocator
 from ogcat.naming import build_naming_context, render_storage_location, split_name_and_suffixes
-from ogcat.operation_helpers import directory_from_relative_path
-from ogcat.storage import LocalStorageAdapter
+from ogcat.operation_helpers import (
+    adapter_name,
+    directory_from_locator,
+    directory_from_relative_path,
+    filename_from_locator,
+)
+from ogcat.storage import (
+    ChecksumPolicy,
+    LocalStorageAdapter,
+    StoragePlan,
+    TargetKind,
+    WriteMode,
+    plan_storage,
+)
 
 PrimaryLocation: TypeAlias = Literal["uuid", "template"]
+StoragePrimaryLocation: TypeAlias = Literal["uuid", "template", "user_provided"]
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryStoragePlanningContext:
+    """Inputs required to plan a primary artifact storage location.
+
+    Args:
+        catalog_root: Catalog root used for catalog-local relative paths.
+        files_root: Catalog template-managed files root.
+        objects_root: Catalog UUID-managed object root.
+        operation_id: Operation id used as the planned artifact UUID.
+        metadata: Normalized metadata available to naming templates.
+        directory_template: Directory naming template from the record schema.
+        filename_template: Filename naming template from the record schema.
+        source_path: Optional source path used for naming context.
+        storage_root: Optional external local root or fsspec URL root.
+        date_added: ISO date string used by date-based templates.
+        primary_location: Primary placement policy to render.
+        locator: User-provided locator when ``primary_location`` is
+            ``"user_provided"``.
+    """
+
+    catalog_root: Path
+    files_root: Path
+    objects_root: Path
+    operation_id: str
+    metadata: Mapping[str, object]
+    directory_template: str
+    filename_template: str
+    source_path: Path | None
+    storage_root: str | Path | None
+    date_added: str
+    primary_location: StoragePrimaryLocation
+    locator: ArtifactLocator | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryStoragePlanResult:
+    """Planned primary storage locator and derived metadata.
+
+    Args:
+        locator: Target artifact locator.
+        storage_relative_path: Path relative to the relevant storage root.
+        resolved_directory: Rendered storage directory, when available.
+        resolved_filename: Rendered final path component, when available.
+        artifact_uuid: UUID-style artifact storage identifier, when generated.
+        primary_location: Primary placement policy used for the plan.
+        storage_root: Local storage root used to recalculate path metadata when
+            hooks replace the planned locator.
+    """
+
+    locator: ArtifactLocator
+    storage_relative_path: str | None
+    resolved_directory: str | None
+    resolved_filename: str | None
+    artifact_uuid: str | None
+    primary_location: StoragePrimaryLocation
+    storage_root: Path | None = None
+
+    def to_storage_plan(
+        self,
+        *,
+        locator: ArtifactLocator | None = None,
+        target_kind: TargetKind = "file",
+        write_mode: WriteMode = "reference",
+        checksum: ChecksumPolicy = "none",
+        ogcat_owned: bool = False,
+        profile: str | None = None,
+        adapter: str | None = None,
+        time_added: str | None = None,
+        artifact_uuid: str | None = None,
+    ) -> StoragePlan:
+        """Build a concrete :class:`~ogcat.storage.StoragePlan`.
+
+        Args:
+            locator: Optional hook-resolved canonical locator.
+            target_kind: Whether the target is file-like or directory-like.
+            write_mode: Intended materialisation mode.
+            checksum: Checksum policy requested for the write.
+            ogcat_owned: Whether ogcat should treat the target as managed.
+            profile: Optional storage profile name or hint.
+            adapter: Optional adapter identifier. When omitted, it is inferred
+                from the planned locator.
+            time_added: Optional timestamp used for the storage plan.
+            artifact_uuid: Optional artifact UUID override for compatibility
+                with operations that record the operation id separately from
+                primary storage identity.
+
+        Returns:
+            Storage plan carrying the primary storage planning metadata.
+        """
+        canonical_locator = self.locator if locator is None else locator
+        if canonical_locator == self.locator:
+            storage_relative_path = self.storage_relative_path
+            resolved_directory = self.resolved_directory
+            resolved_filename = self.resolved_filename
+        else:
+            storage_relative_path = self._storage_relative_path_for(canonical_locator)
+            resolved_directory = (
+                directory_from_locator(canonical_locator)
+                if storage_relative_path is None
+                else directory_from_relative_path(storage_relative_path)
+            )
+            resolved_filename = filename_from_locator(canonical_locator)
+        return plan_storage(
+            canonical_locator,
+            target_kind=target_kind,
+            write_mode=write_mode,
+            checksum=checksum,
+            ogcat_owned=ogcat_owned,
+            profile=profile,
+            adapter=adapter_name(canonical_locator) if adapter is None else adapter,
+            time_added=time_added,
+            storage_relative_path=storage_relative_path,
+            resolved_directory=resolved_directory,
+            resolved_filename=resolved_filename,
+            artifact_uuid=self.artifact_uuid if artifact_uuid is None else artifact_uuid,
+            primary_location=self.primary_location,
+        )
+
+    def naming_metadata(self) -> dict[str, object]:
+        """Build record naming metadata from the planned primary storage."""
+        metadata: dict[str, object] = {"primary_location": self.primary_location}
+        if self.artifact_uuid is not None:
+            metadata["artifact_uuid"] = self.artifact_uuid
+        if self.storage_relative_path is not None:
+            metadata["storage_relative_path"] = self.storage_relative_path
+            metadata["primary_storage_relative_path"] = self.storage_relative_path
+        if self.resolved_directory is not None:
+            metadata["resolved_directory"] = self.resolved_directory
+            metadata["primary_resolved_directory"] = self.resolved_directory
+        if self.resolved_filename is not None:
+            metadata["resolved_filename"] = self.resolved_filename
+            metadata["primary_resolved_filename"] = self.resolved_filename
+        return metadata
+
+    def _storage_relative_path_for(self, locator: ArtifactLocator) -> str | None:
+        """Return storage-relative metadata for a hook-resolved locator."""
+        if self.storage_root is None:
+            return locator.relative_path
+        return storage_relative_path_for_locator(locator, storage_root=self.storage_root)
 
 
 @dataclass(frozen=True, slots=True)
@@ -134,6 +288,106 @@ def render_uuid_planned_locator(
     )
 
 
+def plan_primary_storage(context: PrimaryStoragePlanningContext) -> PrimaryStoragePlanResult:
+    """Plan the primary storage location for a catalog artifact.
+
+    Args:
+        context: Storage planning inputs including roots, naming templates,
+            metadata, and primary placement policy.
+
+    Returns:
+        Planned primary storage locator and metadata suitable for constructing
+        a storage plan or record naming metadata.
+
+    Raises:
+        ValueError: If ``primary_location`` is ``"user_provided"`` without a
+            locator, or an unsupported primary placement policy is supplied.
+    """
+    if context.primary_location == "user_provided":
+        if context.locator is None:
+            raise ValueError("locator is required when primary_location is 'user_provided'.")
+        return PrimaryStoragePlanResult(
+            locator=context.locator,
+            storage_relative_path=context.locator.relative_path,
+            resolved_directory=directory_from_locator(context.locator),
+            resolved_filename=filename_from_locator(context.locator),
+            artifact_uuid=None,
+            primary_location="user_provided",
+            storage_root=None,
+        )
+
+    if context.locator is not None:
+        raise ValueError("locator can only be provided when primary_location is 'user_provided'.")
+
+    naming_source = context.source_path or Path("artifact")
+    artifact_uuid = context.operation_id
+    naming_context = build_naming_context(
+        record_id=context.operation_id,
+        operation_id=context.operation_id,
+        original_path=naming_source,
+        metadata=context.metadata,
+        date_added=context.date_added,
+    )
+    naming_context["artifact_uuid"] = artifact_uuid
+    if context.primary_location == "uuid":
+        planned = render_uuid_planned_locator(
+            catalog_root=context.catalog_root,
+            objects_root=context.objects_root,
+            storage_root=context.storage_root,
+            artifact_uuid=artifact_uuid,
+            original_path=naming_source,
+        )
+        return _primary_result_from_planned_locator(
+            planned,
+            artifact_uuid=artifact_uuid,
+            primary_location="uuid",
+            storage_root=_primary_storage_root(context),
+        )
+
+    if context.primary_location != "template":
+        raise ValueError("primary_location must be 'uuid', 'template', or 'user_provided'.")
+    if context.storage_root is not None and _is_urlpath_root(context.storage_root):
+        planned = _render_urlpath_template_locator(
+            root_url=str(context.storage_root),
+            directory_template=context.directory_template,
+            filename_template=context.filename_template,
+            naming_context=naming_context,
+        )
+        return _primary_result_from_planned_locator(
+            planned,
+            artifact_uuid=None,
+            primary_location="template",
+            storage_root=_primary_storage_root(context),
+        )
+
+    local_files_root = (
+        context.files_root
+        if context.storage_root is None
+        else Path(context.storage_root).expanduser().resolve()
+    )
+    storage_adapter = LocalStorageAdapter()
+    target, _catalog_relative_path, resolved_filename = render_storage_location(
+        files_root=local_files_root,
+        directory_template=context.directory_template,
+        filename_template=context.filename_template,
+        context=naming_context,
+        exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
+    )
+    relative_path = (
+        target.relative_to(context.catalog_root).as_posix() if context.storage_root is None else None
+    )
+    storage_relative_path = target.relative_to(local_files_root).as_posix()
+    return PrimaryStoragePlanResult(
+        locator=ArtifactLocator.from_path(target, relative_path=relative_path),
+        storage_relative_path=storage_relative_path,
+        resolved_directory=directory_from_relative_path(storage_relative_path),
+        resolved_filename=resolved_filename,
+        artifact_uuid=None,
+        primary_location="template",
+        storage_root=_primary_storage_root(context),
+    )
+
+
 def render_planned_locator(
     *,
     catalog_root: Path,
@@ -166,49 +420,26 @@ def render_planned_locator(
     Returns:
         Rendered locator and path metadata.
     """
-    naming_source = source_path or Path("artifact")
-    naming_context = build_naming_context(
-        record_id=operation_id,
-        operation_id=operation_id,
-        original_path=naming_source,
-        metadata=metadata,
-        date_added=date_added,
-    )
-    artifact_uuid = operation_id
-    naming_context["artifact_uuid"] = artifact_uuid
-    if primary_location == "uuid":
-        return render_uuid_planned_locator(
+    planned = plan_primary_storage(
+        PrimaryStoragePlanningContext(
             catalog_root=catalog_root,
+            files_root=files_root,
             objects_root=objects_root,
-            storage_root=storage_root,
-            artifact_uuid=artifact_uuid,
-            original_path=naming_source,
-        )
-
-    if storage_root is not None and _is_urlpath_root(storage_root):
-        return _render_urlpath_template_locator(
-            root_url=str(storage_root),
+            operation_id=operation_id,
+            metadata=metadata,
             directory_template=directory_template,
             filename_template=filename_template,
-            naming_context=naming_context,
+            source_path=source_path,
+            storage_root=storage_root,
+            date_added=date_added,
+            primary_location=primary_location,
         )
-
-    local_files_root = files_root if storage_root is None else Path(storage_root).expanduser().resolve()
-    storage_adapter = LocalStorageAdapter()
-    target, _catalog_relative_path, resolved_filename = render_storage_location(
-        files_root=local_files_root,
-        directory_template=directory_template,
-        filename_template=filename_template,
-        context=naming_context,
-        exists=lambda candidate: storage_adapter.exists(ArtifactLocator.from_path(candidate)),
     )
-    relative_path = target.relative_to(catalog_root).as_posix() if storage_root is None else None
-    storage_relative_path = target.relative_to(local_files_root).as_posix()
     return PlannedLocator(
-        locator=ArtifactLocator.from_path(target, relative_path=relative_path),
-        storage_relative_path=storage_relative_path,
-        resolved_directory=directory_from_relative_path(storage_relative_path),
-        resolved_filename=resolved_filename,
+        locator=planned.locator,
+        storage_relative_path=planned.storage_relative_path,
+        resolved_directory=planned.resolved_directory,
+        resolved_filename=planned.resolved_filename,
     )
 
 
@@ -304,6 +535,38 @@ def _render_urlpath_template_locator(
     )
 
 
+def _primary_result_from_planned_locator(
+    planned: PlannedLocator,
+    *,
+    artifact_uuid: str | None,
+    primary_location: StoragePrimaryLocation,
+    storage_root: Path | None,
+) -> PrimaryStoragePlanResult:
+    """Return a primary storage planning result from locator metadata."""
+    return PrimaryStoragePlanResult(
+        locator=planned.locator,
+        storage_relative_path=planned.storage_relative_path,
+        resolved_directory=planned.resolved_directory,
+        resolved_filename=planned.resolved_filename,
+        artifact_uuid=artifact_uuid,
+        primary_location=primary_location,
+        storage_root=storage_root,
+    )
+
+
+def _primary_storage_root(context: PrimaryStoragePlanningContext) -> Path | None:
+    """Return the local root used for storage-relative metadata."""
+    if context.storage_root is not None:
+        if _is_urlpath_root(context.storage_root):
+            return None
+        return Path(context.storage_root).expanduser().resolve()
+    if context.primary_location == "uuid":
+        return context.objects_root
+    if context.primary_location == "template":
+        return context.files_root
+    return None
+
+
 def _uuid_storage_relative_path(*, artifact_uuid: str, original_path: Path) -> str:
     """Return the objects-root-relative path for a UUID primary artifact."""
     _stem, suffix = split_name_and_suffixes(original_path.name)
@@ -313,8 +576,12 @@ def _uuid_storage_relative_path(*, artifact_uuid: str, original_path: Path) -> s
 __all__ = [
     "PlannedLocator",
     "PrimaryLocation",
+    "PrimaryStoragePlanningContext",
+    "PrimaryStoragePlanResult",
+    "StoragePrimaryLocation",
     "UuidStoragePath",
     "join_urlpath",
+    "plan_primary_storage",
     "render_planned_locator",
     "render_uuid_planned_locator",
     "storage_relative_path_for_locator",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -86,6 +86,10 @@ def test_add_file_can_store_primary_at_template_path(tmp_path: Path) -> None:
     assert expected.exists()
     assert not expected.is_symlink()
     assert "template_replica_path" not in record.naming_metadata
+    artifact_uuid = str(record.naming_metadata["artifact_uuid"])
+    assert len(artifact_uuid) == 32
+    int(artifact_uuid, 16)
+    assert artifact_uuid != _record_id(record)
     assert record.naming_metadata["primary_location"] == "template"
 
 
@@ -513,7 +517,7 @@ def test_metadata_normalization_accepts_numpy_scalars_when_available(tmp_path: P
     assert type(record.user_metadata["count"]) is int
 
 
-@pytest.mark.parametrize("field_name", ["id", "uuid", "operation_id"])
+@pytest.mark.parametrize("field_name", ["artifact_uuid", "id", "uuid", "operation_id"])
 def test_add_file_rejects_metadata_that_clobbers_reserved_template_fields(
     tmp_path: Path,
     field_name: str,
@@ -532,6 +536,22 @@ def test_add_file_rejects_metadata_that_clobbers_reserved_template_fields(
     assert catalog.repository.all() == []
     assert list((root / "data" / "files").rglob("reserved.nc")) == []
     assert list((root / "data" / "objects").rglob("reserved.nc")) == []
+
+
+def test_add_file_template_primary_rejects_artifact_uuid_metadata(tmp_path: Path) -> None:
+    """Template-primary ingest rejects metadata that would shadow planner fields."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "reserved.nc"
+    source.write_text("dummy", encoding="utf-8")
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(ValueError, match="Metadata cannot use reserved template field\\(s\\): artifact_uuid"):
+        catalog.add_file(source, metadata={"artifact_uuid": "user-value"}, primary_location="template")
+
+    assert catalog.repository.all() == []
+    assert list((root / "data" / "files").rglob("reserved.nc")) == []
 
 
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -90,6 +90,164 @@ def test_storage_planning_relative_path_falls_back_to_locator_metadata(
     )
 
 
+def test_primary_storage_planner_uuid_location_builds_storage_plan(tmp_path: Path) -> None:
+    """Primary planner owns UUID placement and storage-plan metadata."""
+    catalog_root = tmp_path / "catalog"
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=catalog_root,
+            files_root=catalog_root / "data" / "files",
+            objects_root=catalog_root / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={},
+            directory_template="{year_added}/{original_stem}",
+            filename_template="{original_filename}",
+            source_path=tmp_path / "source.nc",
+            storage_root=None,
+            date_added="2026-05-15",
+            primary_location="uuid",
+        )
+    )
+    plan = result.to_storage_plan(write_mode="copy", ogcat_owned=True)
+
+    expected = catalog_root / "data" / "objects" / "ab" / "abcdef1234567890.nc"
+    assert result.locator == ArtifactLocator.from_path(
+        expected,
+        relative_path="data/objects/ab/abcdef1234567890.nc",
+    )
+    assert result.storage_relative_path == "ab/abcdef1234567890.nc"
+    assert result.resolved_directory == "ab"
+    assert result.resolved_filename == "abcdef1234567890.nc"
+    assert result.artifact_uuid == "abcdef1234567890"
+    assert result.primary_location == "uuid"
+    assert plan.locator == result.locator
+    assert plan.storage_relative_path == "ab/abcdef1234567890.nc"
+    assert plan.artifact_uuid == "abcdef1234567890"
+    assert plan.primary_location == "uuid"
+    assert plan.write_mode == "copy"
+    assert plan.ogcat_owned
+
+
+def test_primary_storage_planner_template_location_uses_schema_naming(tmp_path: Path) -> None:
+    """Primary planner owns template placement without assigning an artifact UUID."""
+    catalog_root = tmp_path / "catalog"
+
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=catalog_root,
+            files_root=catalog_root / "data" / "files",
+            objects_root=catalog_root / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={"species": "CO2", "year": 2026, "title": "paris"},
+            directory_template="{species}/{year}",
+            filename_template="{title}{original_suffix}",
+            source_path=tmp_path / "source.nc",
+            storage_root=None,
+            date_added="2026-05-15",
+            primary_location="template",
+        )
+    )
+
+    expected = catalog_root / "data" / "files" / "CO2" / "2026" / "paris.nc"
+    assert result.locator == ArtifactLocator.from_path(expected, relative_path="data/files/CO2/2026/paris.nc")
+    assert result.storage_relative_path == "CO2/2026/paris.nc"
+    assert result.resolved_directory == "CO2/2026"
+    assert result.resolved_filename == "paris.nc"
+    assert result.artifact_uuid is None
+    assert result.primary_location == "template"
+
+
+def test_primary_storage_planner_user_provided_location_keeps_explicit_locator(
+    tmp_path: Path,
+) -> None:
+    """Primary planner treats explicit locators as caller-selected storage."""
+    target = tmp_path / "chosen" / "artifact.nc"
+    locator = ArtifactLocator.from_path(target)
+
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=tmp_path / "catalog",
+            files_root=tmp_path / "catalog" / "data" / "files",
+            objects_root=tmp_path / "catalog" / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={},
+            directory_template="",
+            filename_template="",
+            source_path=tmp_path / "source.nc",
+            storage_root=None,
+            date_added="2026-05-15",
+            primary_location="user_provided",
+            locator=locator,
+        )
+    )
+
+    assert result.locator == locator
+    assert result.storage_relative_path is None
+    assert result.resolved_directory == str(target.parent)
+    assert result.resolved_filename == "artifact.nc"
+    assert result.artifact_uuid is None
+    assert result.primary_location == "user_provided"
+
+
+def test_primary_storage_planner_uuid_urlpath_root_has_remote_plan_metadata(tmp_path: Path) -> None:
+    """Primary planner supports UUID placement under fsspec URL roots."""
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=tmp_path / "catalog",
+            files_root=tmp_path / "catalog" / "data" / "files",
+            objects_root=tmp_path / "catalog" / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={},
+            directory_template="{year_added}/{original_stem}",
+            filename_template="{original_filename}",
+            source_path=tmp_path / "source.nc",
+            storage_root="s3://bucket/prefix",
+            date_added="2026-05-15",
+            primary_location="uuid",
+        )
+    )
+    plan = result.to_storage_plan(write_mode="copy", ogcat_owned=True)
+
+    assert result.locator == ArtifactLocator.from_urlpath("s3://bucket/prefix/ab/abcdef1234567890.nc")
+    assert result.locator.relative_path is None
+    assert result.storage_relative_path == "ab/abcdef1234567890.nc"
+    assert result.resolved_directory == "ab"
+    assert result.resolved_filename == "abcdef1234567890.nc"
+    assert plan.adapter == "fsspec"
+    assert plan.artifact_uuid == "abcdef1234567890"
+    assert plan.primary_location == "uuid"
+
+
+def test_primary_storage_plan_uses_locator_directory_when_hook_target_has_no_relative_path(
+    tmp_path: Path,
+) -> None:
+    """Hook replacement keeps locator-derived directory metadata when no relative path exists."""
+    catalog_root = tmp_path / "catalog"
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=catalog_root,
+            files_root=catalog_root / "data" / "files",
+            objects_root=catalog_root / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={},
+            directory_template="{year_added}/{original_stem}",
+            filename_template="{original_filename}",
+            source_path=tmp_path / "source.nc",
+            storage_root=None,
+            date_added="2026-05-15",
+            primary_location="uuid",
+        )
+    )
+    hook_target = ArtifactLocator.from_urlpath("memory://bucket/redirected/copied.nc")
+
+    plan = result.to_storage_plan(locator=hook_target)
+
+    assert plan.locator == hook_target
+    assert plan.storage_relative_path is None
+    assert plan.resolved_directory == "memory://bucket/redirected"
+    assert plan.resolved_filename == "copied.nc"
+
+
 def test_reference_planning_resolves_local_path_reference(tmp_path: Path) -> None:
     """Reference planning resolves path-backed references and preserves local path metadata."""
     source = tmp_path / "source.nc"
@@ -181,6 +339,22 @@ def test_plan_artifact_storage_can_use_template_primary(tmp_path: Path) -> None:
     assert plan.resolved_filename == "paris.nc"
     assert plan.primary_location == "template"
     assert not expected.exists()
+
+
+def test_plan_artifact_storage_template_primary_rejects_artifact_uuid_metadata(
+    tmp_path: Path,
+) -> None:
+    """Dry-run template planning rejects metadata that would shadow planner fields."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(ValueError, match="Metadata cannot use reserved template field\\(s\\): artifact_uuid"):
+        catalog.plan_artifact_storage(
+            source,
+            metadata={"artifact_uuid": "user-value"},
+            primary_location="template",
+        )
 
 
 def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path) -> None:
@@ -288,6 +462,32 @@ def test_plan_artifact_storage_urlpath_root_does_not_import_fsspec(
     assert plan.storage_relative_path == "CO2/remote.nc"
     assert plan.resolved_directory == "CO2"
     assert plan.resolved_filename == "remote.nc"
+
+
+def test_plan_artifact_storage_uuid_urlpath_root_uses_root_relative_metadata(
+    tmp_path: Path,
+) -> None:
+    """UUID primary URL roots produce fsspec plans with root-relative metadata."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    plan = catalog.plan_artifact_storage(
+        source,
+        storage_root="s3://bucket/prefix",
+        write_mode="copy",
+    )
+
+    assert plan.artifact_uuid is not None
+    assert plan.locator == ArtifactLocator.from_urlpath(
+        f"s3://bucket/prefix/{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    )
+    assert plan.locator.relative_path is None
+    assert plan.adapter == "fsspec"
+    assert plan.storage_relative_path == f"{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.resolved_directory == plan.artifact_uuid[:2]
+    assert plan.resolved_filename == f"{plan.artifact_uuid}.nc"
+    assert plan.primary_location == "uuid"
 
 
 def test_urlpath_storage_root_does_not_populate_stored_relpath(
@@ -417,6 +617,33 @@ def test_plan_artifact_storage_custom_local_root_has_no_catalog_relative_path(tm
     assert plan.resolved_filename == "external.nc"
     assert record.stored_relpath is None
     assert record.locator.relative_path is None
+
+
+def test_plan_artifact_storage_uuid_custom_local_root_has_no_catalog_relative_path(
+    tmp_path: Path,
+) -> None:
+    """UUID primary custom local roots keep storage metadata root-relative."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    external_root = tmp_path / "external-root"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    plan = catalog.plan_artifact_storage(
+        source,
+        storage_root=external_root,
+        write_mode="reference",
+        ogcat_owned=False,
+    )
+
+    assert plan.artifact_uuid is not None
+    assert plan.locator == ArtifactLocator.from_path(
+        external_root / plan.artifact_uuid[:2] / f"{plan.artifact_uuid}.nc"
+    )
+    assert plan.locator.relative_path is None
+    assert plan.storage_relative_path == f"{plan.artifact_uuid[:2]}/{plan.artifact_uuid}.nc"
+    assert plan.resolved_directory == plan.artifact_uuid[:2]
+    assert plan.resolved_filename == f"{plan.artifact_uuid}.nc"
+    assert plan.primary_location == "uuid"
 
 
 def test_plan_artifact_storage_explicit_locator_overrides_primary_location(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a shared `plan_primary_storage()` interface with typed context/result dataclasses
- route `Catalog.add_file()` and `Catalog.plan_artifact_storage()` through that planner for UUID, template, external-root, URL-root, and explicit locator cases
- reserve `artifact_uuid` in naming context inputs and preserve hook-resolved locator metadata consistently

## Architecture Checkpoint
`Catalog` still owns operation orchestration in this PR, but primary storage placement policy now lives behind `storage_planning.plan_primary_storage()`. `Catalog` no longer decides UUID/template path metadata directly; it delegates to the planner and converts the result into storage plans.

What remains for later PRs:
- extracting an application/orchestration layer below `Catalog`
- modeling template symlinks as secondary artifact operations
- further moving tests from facade behavior toward operation/service interfaces

Closes #86.

## Validation
- `uv run ruff check src/ogcat/catalog.py src/ogcat/naming.py src/ogcat/storage_planning.py tests/test_storage.py tests/test_add.py`
- `uv run ruff format --check src/ogcat/catalog.py src/ogcat/naming.py src/ogcat/storage_planning.py tests/test_storage.py tests/test_add.py`
- `uv run pyright`
- `uv run pytest`