### PR TITLE
[codex] Extract catalog application add service

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,9 +86,11 @@ native transaction support later.
 
 ## Operation Runners
 
-`Catalog` remains the public API and setup layer: it validates user inputs, selects schemas, opens
-transactions, and prepares operation-specific request objects. Internal operation runners own the
-ordered lifecycle after that setup.
+`Catalog` remains the public API facade: it validates user inputs, selects schemas, and delegates
+add-operation orchestration to the internal `CatalogApplication` service. The application service
+prepares operation-specific request objects, wires managed-file storage planning to copy/move
+writers, and invokes the operation runner. This keeps the public API methods focused on the API
+contract rather than the add lifecycle details.
 
 The current concrete runner is `AddOperationRunner`. It implements the add lifecycle for
 `add_file()` and `add_artifact()`: validation, hook dispatch, locator resolution, storage planning,
@@ -101,6 +103,12 @@ passed through `OperationServices`. Operation-specific data lives in request dat
 `AddOperationRequest`. This keeps the public catalog surface narrow while making the internal
 contract explicit enough for future runners, such as an artifact update runner, to reuse the same
 services without sharing add-only request fields.
+
+The next refinement is to make writer materialisation explicit below the public API. A primary
+artifact plan should answer where the artifact belongs, while a writer or materialiser plan should
+answer how bytes or directories are produced there. That distinction is important for future
+directory-backed collection artifacts and `.zarr`-style outputs because `Catalog` should not branch
+on file versus directory versus collection.
 
 ## Why Templates and Metadata Live in `catalog.json`
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import getpass
 import os
 import warnings
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -18,7 +18,7 @@ from ogcat.audit import (
     AuditSink,
     JsonlAuditSink,
 )
-from ogcat.extractors import extract_derived_metadata
+from ogcat.catalog_application import CatalogApplication
 from ogcat.hooks import (
     ArtifactWriter,
     HookLifecycleEvent,
@@ -33,13 +33,16 @@ from ogcat.operation_helpers import (
     artifact_locator_from_context,
     naming_metadata_from_storage_plan,
     normalize_metadata_for_schema,
-    storage_plan_with_locator,
 )
 from ogcat.operation_runner import (
     AddOperationRequest,
     AddOperationRunner,
+    ArtifactLocatorFactory,
+    DerivedMetadataCollector,
     OperationRunner,
     OperationServices,
+    RecordPostProcessor,
+    StoragePlanFactory,
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
@@ -61,21 +64,15 @@ from ogcat.storage import (
 from ogcat.storage_planning import (
     PrimaryLocation,
     PrimaryStoragePlanningContext,
-    PrimaryStoragePlanResult,
     plan_primary_storage,
 )
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 from ogcat.transactions import UnitOfWork
 from ogcat.validation import ValidationReport, validate_metadata, validate_spec
-from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
 
-ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
-StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
-DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 PluginInput = PluginRegistry | Iterable[object] | None
 HookInput = HookManager | Iterable[object] | None
 MetadataUpdateMode = Literal["replace", "shallow_merge"]
-RecordPostProcessor = Callable[[UnitOfWork, OperationContext, CatalogRecord], CatalogRecord]
 
 
 @dataclass(slots=True)
@@ -230,109 +227,18 @@ class Catalog:
         resolved_primary_location = _coerce_primary_location(primary_location)
 
         timestamp = _utc_timestamp()
-        files_root = self.root / self.spec.files_root
-        objects_root = self.root / self.spec.objects_root
-        naming_metadata: MetadataDict = {
-            "record_schema": "default" if record_type is None else record_type,
-            "directory_template": directory_template,
-            "filename_template": filename_template,
-            "primary_location": resolved_primary_location,
-        }
-        planned_primary: PrimaryStoragePlanResult | None = None
-
-        def plan_primary(context: OperationContext) -> PrimaryStoragePlanResult:
-            """Plan the managed-file primary location for this operation."""
-            return plan_primary_storage(
-                PrimaryStoragePlanningContext(
-                    catalog_root=self.root,
-                    files_root=files_root,
-                    objects_root=objects_root,
-                    operation_id=context.operation_id,
-                    metadata=context.user_metadata,
-                    directory_template=directory_template,
-                    filename_template=filename_template,
-                    source_path=source,
-                    storage_root=None,
-                    date_added=timestamp[:10],
-                    primary_location=resolved_primary_location,
-                )
-            )
-
-        def resolve_local_file_locator(context: OperationContext) -> ArtifactLocator:
-            """Resolve the managed-file storage path for this operation."""
-            nonlocal planned_primary
-            planned_primary = plan_primary(context)
-            if resolved_primary_location == "template":
-                naming_metadata["artifact_uuid"] = context.operation_id
-            return planned_primary.locator
-
-        def plan_local_file_storage(
-            context: OperationContext,
-            locator: ArtifactLocator,
-        ) -> StoragePlan:
-            """Build the storage plan for a managed local file."""
-            primary = planned_primary or plan_primary(context)
-            artifact_uuid = context.operation_id if resolved_primary_location == "template" else None
-            return primary.to_storage_plan(
-                locator=locator,
-                target_kind="file",
-                write_mode=cast(WriteMode, chosen_operation),
-                ogcat_owned=True,
-                artifact_uuid=artifact_uuid,
-            )
-
-        def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
-            """Collect generic derived metadata from the written file."""
-            locator_path = locator.as_path()
-            if locator_path is not None:
-                context.derived_metadata.update(extract_derived_metadata(locator_path))
-
-        source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
-        artifact_writer: ArtifactWriter = (
-            CopyArtifactWriter() if chosen_operation == "copy" else MoveArtifactWriter()
+        return self._application().add_file(
+            source=source,
+            metadata=metadata,
+            schema=schema,
+            schema_record_type=record_type,
+            record_type=resolved_record_type,
+            directory_template=directory_template,
+            filename_template=filename_template,
+            operation=chosen_operation,
+            primary_location=resolved_primary_location,
+            time_added=timestamp,
         )
-        record_post_processor: RecordPostProcessor | None = None
-        if resolved_primary_location == "uuid":
-
-            def create_default_template_replica(
-                transaction: UnitOfWork,
-                context: OperationContext,
-                record: CatalogRecord,
-            ) -> CatalogRecord:
-                """Create the default template symlink replica for a UUID primary."""
-                return self._create_template_link_replica(
-                    transaction=transaction,
-                    context=context,
-                    record=record,
-                    directory_template=directory_template,
-                    filename_template=filename_template,
-                )
-
-            record_post_processor = create_default_template_replica
-
-        with self.transaction() as transaction:
-            return self._run_add_operation(
-                transaction=transaction,
-                commit=True,
-                operation_type="add_file",
-                record_type=resolved_record_type,
-                schema=schema,
-                schema_record_type=record_type,
-                metadata=metadata,
-                storage_mode=chosen_operation,
-                original_path=source,
-                original_filename=source.name,
-                suffixes=source.suffixes,
-                derived_metadata={},
-                naming_metadata=naming_metadata,
-                time_added=timestamp,
-                source=source_description,
-                locator_factory=resolve_local_file_locator,
-                storage_plan_factory=plan_local_file_storage,
-                artifact_writer=artifact_writer,
-                derived_metadata_collector=collect_file_metadata,
-                record_post_processor=record_post_processor,
-            )
 
     def plan_artifact_storage(
         self,
@@ -533,10 +439,11 @@ class Catalog:
         metadata = _coerce_metadata_input(metadata_input, schema_name=schema_name)
         validated_source = _optional_operation_source(source)
         validated_artifact_writer = _validate_artifact_writer(artifact_writer)
+        application = self._application()
         if transaction is not None:
             if transaction.repository is not self.repository:
                 raise ValueError("Transaction is bound to a different catalog repository.")
-            return self._add_artifact_in_transaction(
+            return application.add_artifact(
                 transaction=transaction,
                 commit=False,
                 record_type=record_type,
@@ -555,7 +462,7 @@ class Catalog:
                 schema=schema,
             )
         with self.transaction() as unit_of_work:
-            return self._add_artifact_in_transaction(
+            return application.add_artifact(
                 transaction=unit_of_work,
                 commit=True,
                 record_type=record_type,
@@ -1260,18 +1167,11 @@ class Catalog:
         schema: RecordSchema,
     ) -> CatalogRecord:
         """Add an artifact record within an active transaction."""
-        operation_source = source or OperationSource(
-            kind="external",
-            path=locator.as_path(),
-            descriptor=locator.value,
-        )
-        return self._run_add_operation(
+        return self._application().add_artifact(
             transaction=transaction,
             commit=commit,
-            operation_type="add_artifact",
             record_type=record_type,
-            schema=schema,
-            schema_record_type=record_type,
+            locator=locator,
             metadata=metadata,
             storage_mode=storage_mode,
             original_path=original_path,
@@ -1280,17 +1180,10 @@ class Catalog:
             derived_metadata=derived_metadata,
             naming_metadata=naming_metadata,
             time_added=time_added,
-            source=operation_source,
-            locator_factory=lambda context: locator,
+            source=source,
             artifact_writer=artifact_writer,
-            storage_plan_factory=(
-                None
-                if storage_plan is None
-                else lambda context, canonical_locator: storage_plan_with_locator(
-                    storage_plan,
-                    canonical_locator,
-                )
-            ),
+            storage_plan=storage_plan,
+            schema=schema,
         )
 
     def _emit_audit(self, event: AuditEvent) -> None:
@@ -1418,7 +1311,7 @@ class Catalog:
         record_post_processor: RecordPostProcessor | None = None,
     ) -> CatalogRecord:
         """Run the shared add operation lifecycle for file and record-only adds."""
-        request = AddOperationRequest(
+        return self._application().run_add_operation(
             transaction=transaction,
             commit=commit,
             operation_type=operation_type,
@@ -1440,7 +1333,10 @@ class Catalog:
             derived_metadata_collector=derived_metadata_collector,
             record_post_processor=record_post_processor,
         )
-        return self._build_add_operation_runner(request).run()
+
+    def _application(self) -> CatalogApplication:
+        """Build the internal application service for catalog operations."""
+        return CatalogApplication(self)
 
     def _build_add_operation_runner(self, request: AddOperationRequest) -> OperationRunner:
         """Build the runner used for one internal add operation."""

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -1,0 +1,278 @@
+"""Application services below the public catalog facade."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from ogcat.extractors import extract_derived_metadata
+from ogcat.hooks import ArtifactWriter, OperationContext, OperationSource
+from ogcat.models import ArtifactLocator, CatalogRecord, MetadataDict
+from ogcat.operation_helpers import storage_plan_with_locator
+from ogcat.operation_runner import (
+    AddOperationRequest,
+    ArtifactLocatorFactory,
+    DerivedMetadataCollector,
+    RecordPostProcessor,
+    StoragePlanFactory,
+)
+from ogcat.spec import RecordSchema
+from ogcat.storage import StoragePlan, WriteMode
+from ogcat.storage_planning import (
+    PrimaryLocation,
+    PrimaryStoragePlanningContext,
+    PrimaryStoragePlanResult,
+    plan_primary_storage,
+)
+from ogcat.transactions import UnitOfWork
+from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
+
+if TYPE_CHECKING:
+    from ogcat.catalog import Catalog
+
+
+@dataclass(slots=True)
+class CatalogApplication:
+    """Coordinate catalog operations below the public Python API."""
+
+    catalog: Catalog
+
+    def add_file(
+        self,
+        *,
+        source: Path,
+        metadata: MetadataDict,
+        schema: RecordSchema,
+        schema_record_type: str | None,
+        record_type: str,
+        directory_template: str,
+        filename_template: str,
+        operation: str,
+        primary_location: PrimaryLocation,
+        time_added: str,
+    ) -> CatalogRecord:
+        """Run the managed local-file add operation."""
+        files_root = self.catalog.root / self.catalog.spec.files_root
+        objects_root = self.catalog.root / self.catalog.spec.objects_root
+        naming_metadata: MetadataDict = {
+            "record_schema": "default" if schema_record_type is None else schema_record_type,
+            "directory_template": directory_template,
+            "filename_template": filename_template,
+            "primary_location": primary_location,
+        }
+        planned_primary: PrimaryStoragePlanResult | None = None
+
+        def plan_primary(context: OperationContext) -> PrimaryStoragePlanResult:
+            """Plan the managed-file primary location for this operation."""
+            return plan_primary_storage(
+                PrimaryStoragePlanningContext(
+                    catalog_root=self.catalog.root,
+                    files_root=files_root,
+                    objects_root=objects_root,
+                    operation_id=context.operation_id,
+                    metadata=context.user_metadata,
+                    directory_template=directory_template,
+                    filename_template=filename_template,
+                    source_path=source,
+                    storage_root=None,
+                    date_added=time_added[:10],
+                    primary_location=primary_location,
+                )
+            )
+
+        def resolve_local_file_locator(context: OperationContext) -> ArtifactLocator:
+            """Resolve the managed-file storage path for this operation."""
+            nonlocal planned_primary
+            planned_primary = plan_primary(context)
+            if primary_location == "template":
+                naming_metadata["artifact_uuid"] = context.operation_id
+            return planned_primary.locator
+
+        def plan_local_file_storage(
+            context: OperationContext,
+            locator: ArtifactLocator,
+        ) -> StoragePlan:
+            """Build the storage plan for a managed local file."""
+            primary = planned_primary or plan_primary(context)
+            artifact_uuid = context.operation_id if primary_location == "template" else None
+            return primary.to_storage_plan(
+                locator=locator,
+                target_kind="file",
+                write_mode=cast(WriteMode, operation),
+                ogcat_owned=True,
+                artifact_uuid=artifact_uuid,
+            )
+
+        def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
+            """Collect generic derived metadata from the written file."""
+            locator_path = locator.as_path()
+            if locator_path is not None:
+                context.derived_metadata.update(extract_derived_metadata(locator_path))
+
+        source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
+        artifact_writer: ArtifactWriter = (
+            CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()
+        )
+        record_post_processor = self._template_replica_post_processor(
+            primary_location=primary_location,
+            directory_template=directory_template,
+            filename_template=filename_template,
+        )
+
+        with self.catalog.transaction() as transaction:
+            return self.run_add_operation(
+                transaction=transaction,
+                commit=True,
+                operation_type="add_file",
+                record_type=record_type,
+                schema=schema,
+                schema_record_type=schema_record_type,
+                metadata=metadata,
+                storage_mode=operation,
+                original_path=source,
+                original_filename=source.name,
+                suffixes=source.suffixes,
+                derived_metadata={},
+                naming_metadata=naming_metadata,
+                time_added=time_added,
+                source=source_description,
+                locator_factory=resolve_local_file_locator,
+                storage_plan_factory=plan_local_file_storage,
+                artifact_writer=artifact_writer,
+                derived_metadata_collector=collect_file_metadata,
+                record_post_processor=record_post_processor,
+            )
+
+    def add_artifact(
+        self,
+        *,
+        transaction: UnitOfWork,
+        commit: bool,
+        record_type: str,
+        locator: ArtifactLocator,
+        metadata: MetadataDict,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        derived_metadata: MetadataDict,
+        naming_metadata: MetadataDict | None,
+        time_added: str | None,
+        source: OperationSource | None,
+        artifact_writer: ArtifactWriter | None,
+        storage_plan: StoragePlan | None,
+        schema: RecordSchema,
+    ) -> CatalogRecord:
+        """Run the general add-artifact operation."""
+        operation_source = source or OperationSource(
+            kind="external",
+            path=locator.as_path(),
+            descriptor=locator.value,
+        )
+        return self.run_add_operation(
+            transaction=transaction,
+            commit=commit,
+            operation_type="add_artifact",
+            record_type=record_type,
+            schema=schema,
+            schema_record_type=record_type,
+            metadata=metadata,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=suffixes,
+            derived_metadata=derived_metadata,
+            naming_metadata=naming_metadata,
+            time_added=time_added,
+            source=operation_source,
+            locator_factory=lambda context: locator,
+            artifact_writer=artifact_writer,
+            storage_plan_factory=(
+                None
+                if storage_plan is None
+                else lambda context, canonical_locator: storage_plan_with_locator(
+                    storage_plan,
+                    canonical_locator,
+                )
+            ),
+        )
+
+    def run_add_operation(
+        self,
+        *,
+        transaction: UnitOfWork,
+        commit: bool,
+        operation_type: str,
+        record_type: str,
+        schema: RecordSchema,
+        schema_record_type: str | None,
+        metadata: MetadataDict,
+        storage_mode: str | None,
+        original_path: str | Path | None,
+        original_filename: str | None,
+        suffixes: list[str] | None,
+        derived_metadata: MetadataDict,
+        naming_metadata: MetadataDict | None,
+        time_added: str | None,
+        source: OperationSource,
+        locator_factory: ArtifactLocatorFactory,
+        storage_plan_factory: StoragePlanFactory | None = None,
+        artifact_writer: ArtifactWriter | None = None,
+        derived_metadata_collector: DerivedMetadataCollector | None = None,
+        record_post_processor: RecordPostProcessor | None = None,
+    ) -> CatalogRecord:
+        """Build and run a shared add-operation request."""
+        request = AddOperationRequest(
+            transaction=transaction,
+            commit=commit,
+            operation_type=operation_type,
+            record_type=record_type,
+            schema=schema,
+            schema_record_type=schema_record_type,
+            metadata=metadata,
+            storage_mode=storage_mode,
+            original_path=original_path,
+            original_filename=original_filename,
+            suffixes=suffixes,
+            derived_metadata=derived_metadata,
+            naming_metadata=naming_metadata,
+            time_added=time_added,
+            source=source,
+            locator_factory=locator_factory,
+            storage_plan_factory=storage_plan_factory,
+            artifact_writer=artifact_writer,
+            derived_metadata_collector=derived_metadata_collector,
+            record_post_processor=record_post_processor,
+        )
+        return self.catalog._build_add_operation_runner(request).run()
+
+    def _template_replica_post_processor(
+        self,
+        *,
+        primary_location: PrimaryLocation,
+        directory_template: str,
+        filename_template: str,
+    ) -> RecordPostProcessor | None:
+        """Return the default template-link post processor when required."""
+        if primary_location != "uuid":
+            return None
+
+        def create_default_template_replica(
+            transaction: UnitOfWork,
+            context: OperationContext,
+            record: CatalogRecord,
+        ) -> CatalogRecord:
+            """Create the default template symlink replica for a UUID primary."""
+            return self.catalog._create_template_link_replica(
+                transaction=transaction,
+                context=context,
+                record=record,
+                directory_template=directory_template,
+                filename_template=filename_template,
+            )
+
+        return create_default_template_replica
+
+
+__all__ = ["CatalogApplication"]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -790,7 +790,7 @@ def test_add_file_removes_copied_target_when_metadata_extraction_fails(
     def fail_extract(path: Path) -> dict[str, object]:
         raise ValueError("simulated metadata failure")
 
-    monkeypatch.setattr("ogcat.catalog.extract_derived_metadata", fail_extract)
+    monkeypatch.setattr("ogcat.catalog_application.extract_derived_metadata", fail_extract)
 
     with pytest.raises(ValueError, match="simulated metadata failure"):
         catalog.add_file(source)

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -17,7 +17,42 @@ from ogcat import (
     RecordSchema,
     ValidationReport,
 )
+from ogcat.catalog_application import CatalogApplication
 from ogcat.operation_runner import AddOperationRequest, OperationRunner
+
+
+def test_add_file_facade_delegates_to_application_service(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog.add_file keeps API coercion while delegating operation orchestration."""
+    captured: dict[str, object] = {}
+
+    def fake_add_file(self: CatalogApplication, **kwargs: object) -> CatalogRecord:
+        captured.update(kwargs)
+        source = kwargs["source"]
+        assert isinstance(source, Path)
+        return CatalogRecord(
+            catalog=self.catalog.spec.catalog_name,
+            time_added="2026-05-15T00:00:00Z",
+            id="delegated",
+            record_type=str(kwargs["record_type"]),
+            locator=ArtifactLocator.path(source),
+        )
+
+    monkeypatch.setattr(CatalogApplication, "add_file", fake_add_file)
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source, metadata={"title": "Example"}, operation="copy")
+
+    assert record.id == "delegated"
+    assert captured["source"] == source.resolve()
+    assert captured["metadata"] == {"title": "Example"}
+    assert captured["record_type"] == "managed_file"
+    assert captured["operation"] == "copy"
+    assert captured["primary_location"] == "uuid"
 
 
 def test_run_add_operation_delegates_to_operation_runner(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-import ogcat.catalog as catalog_module
+import ogcat.catalog_application as catalog_application_module
 import ogcat.storage_planning as storage_planning
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
 from ogcat.hooks import OperationContext, OperationSource
@@ -701,8 +701,8 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
         CatalogSpec(catalog_name="files"),
         plugins=PluginRegistry([RedirectHook()]),
     )
-    monkeypatch.setattr(catalog_module.CopyArtifactWriter, "write", fake_write)
-    monkeypatch.setattr(catalog_module, "extract_derived_metadata", fail_extract)
+    monkeypatch.setattr(catalog_application_module.CopyArtifactWriter, "write", fake_write)
+    monkeypatch.setattr(catalog_application_module, "extract_derived_metadata", fail_extract)
 
     record = catalog.add_file(source_file, operation="copy")
 


### PR DESCRIPTION
## Summary
- add an internal `CatalogApplication` service below the public `Catalog` facade
- move managed-file add orchestration, primary planning closures, copy/move writer setup, and add request construction out of `Catalog.add_file()`
- route `Catalog.add_artifact()` through the application service after preserving public argument coercion and validation
- update tests and architecture docs for the new application/orchestration boundary

## Architecture Checkpoint
This is the first #87 extraction slice. `Catalog` still owns public API coercion, schema selection, and some transitional private helpers. `CatalogApplication` now owns add-operation request construction and the managed-file operation setup that previously made `add_file()` much heavier than `add_artifact()`.

Deliberately left for later #87/#70/#88 slices:
- introduce an explicit materialization/target model for writer-backed artifacts
- make writer-backed `add_artifact()` and `add_file()` share that model more directly
- use the target/materialization boundary to support collection artifacts (#70)
- turn template symlinks into secondary artifact operations (#88)

Refs #87.

## Validation
- `uv run ruff check src/ogcat/catalog.py src/ogcat/catalog_application.py tests/test_add_operation_lifecycle.py tests/test_add.py tests/test_storage.py`
- `uv run ruff format --check src/ogcat/catalog.py src/ogcat/catalog_application.py tests/test_add_operation_lifecycle.py tests/test_add.py tests/test_storage.py`
- `uv run pyright`
- `uv run pytest tests/test_add_operation_lifecycle.py tests/test_add.py tests/test_storage.py tests/test_writers.py -q`
- `uv run pytest`