### PR TITLE
[codex] Add materialization target model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,11 +104,12 @@ passed through `OperationServices`. Operation-specific data lives in request dat
 contract explicit enough for future runners, such as an artifact update runner, to reuse the same
 services without sharing add-only request fields.
 
-The next refinement is to make writer materialisation explicit below the public API. A primary
-artifact plan should answer where the artifact belongs, while a writer or materialiser plan should
-answer how bytes or directories are produced there. That distinction is important for future
-directory-backed collection artifacts and `.zarr`-style outputs because `Catalog` should not branch
-on file versus directory versus collection.
+Writer materialisation is represented explicitly by an internal materialisation intent and target.
+A primary artifact plan answers where the artifact belongs, and exposes that decision as a
+materialisation target. The materialisation intent answers how bytes or directories are produced
+there, if at all. That distinction is important for future directory-backed collection artifacts
+and `.zarr`-style outputs because `Catalog` should not branch on file versus directory versus
+collection.
 
 ## Why Templates and Metadata Live in `catalog.json`
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -28,6 +28,7 @@ from ogcat.hooks import (
     coerce_hook_iterable,
     validate_hook_objects,
 )
+from ogcat.materialization import reference_intent, writer_intent
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.operation_helpers import (
     artifact_locator_from_context,
@@ -1328,8 +1329,10 @@ class Catalog:
             time_added=time_added,
             source=source,
             locator_factory=locator_factory,
+            materialization_intent=(
+                reference_intent() if artifact_writer is None else writer_intent(artifact_writer)
+            ),
             storage_plan_factory=storage_plan_factory,
-            artifact_writer=artifact_writer,
             derived_metadata_collector=derived_metadata_collector,
             record_post_processor=record_post_processor,
         )

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from ogcat.extractors import extract_derived_metadata
 from ogcat.hooks import ArtifactWriter, OperationContext, OperationSource
+from ogcat.materialization import (
+    MaterializationIntent,
+    MaterializationPlan,
+    reference_intent,
+    storage_plan_intent,
+    writer_intent,
+)
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataDict
 from ogcat.operation_helpers import storage_plan_with_locator
 from ogcat.operation_runner import (
@@ -18,7 +25,7 @@ from ogcat.operation_runner import (
     StoragePlanFactory,
 )
 from ogcat.spec import RecordSchema
-from ogcat.storage import StoragePlan, WriteMode
+from ogcat.storage import StoragePlan
 from ogcat.storage_planning import (
     PrimaryLocation,
     PrimaryStoragePlanningContext,
@@ -96,13 +103,15 @@ class CatalogApplication:
             """Build the storage plan for a managed local file."""
             primary = planned_primary or plan_primary(context)
             artifact_uuid = context.operation_id if primary_location == "template" else None
-            return primary.to_storage_plan(
+            primary_target = primary.to_materialization_target(
                 locator=locator,
-                target_kind="file",
-                write_mode=cast(WriteMode, operation),
-                ogcat_owned=True,
+                target_kind=materialization_intent.target_kind,
                 artifact_uuid=artifact_uuid,
             )
+            return MaterializationPlan(
+                primary_target=primary_target,
+                intent=materialization_intent,
+            ).to_storage_plan()
 
         def collect_file_metadata(context: OperationContext, locator: ArtifactLocator) -> None:
             """Collect generic derived metadata from the written file."""
@@ -114,6 +123,7 @@ class CatalogApplication:
         artifact_writer: ArtifactWriter = (
             CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()
         )
+        materialization_intent = writer_intent(artifact_writer)
         record_post_processor = self._template_replica_post_processor(
             primary_location=primary_location,
             directory_template=directory_template,
@@ -138,8 +148,8 @@ class CatalogApplication:
                 time_added=time_added,
                 source=source_description,
                 locator_factory=resolve_local_file_locator,
+                materialization_intent=materialization_intent,
                 storage_plan_factory=plan_local_file_storage,
-                artifact_writer=artifact_writer,
                 derived_metadata_collector=collect_file_metadata,
                 record_post_processor=record_post_processor,
             )
@@ -170,6 +180,12 @@ class CatalogApplication:
             path=locator.as_path(),
             descriptor=locator.value,
         )
+        if storage_plan is not None:
+            materialization_intent = storage_plan_intent(storage_plan, writer=artifact_writer)
+        else:
+            materialization_intent = (
+                reference_intent() if artifact_writer is None else writer_intent(artifact_writer)
+            )
         return self.run_add_operation(
             transaction=transaction,
             commit=commit,
@@ -187,7 +203,7 @@ class CatalogApplication:
             time_added=time_added,
             source=operation_source,
             locator_factory=lambda context: locator,
-            artifact_writer=artifact_writer,
+            materialization_intent=materialization_intent,
             storage_plan_factory=(
                 None
                 if storage_plan is None
@@ -217,8 +233,8 @@ class CatalogApplication:
         time_added: str | None,
         source: OperationSource,
         locator_factory: ArtifactLocatorFactory,
+        materialization_intent: MaterializationIntent,
         storage_plan_factory: StoragePlanFactory | None = None,
-        artifact_writer: ArtifactWriter | None = None,
         derived_metadata_collector: DerivedMetadataCollector | None = None,
         record_post_processor: RecordPostProcessor | None = None,
     ) -> CatalogRecord:
@@ -240,8 +256,8 @@ class CatalogApplication:
             time_added=time_added,
             source=source,
             locator_factory=locator_factory,
+            materialization_intent=materialization_intent,
             storage_plan_factory=storage_plan_factory,
-            artifact_writer=artifact_writer,
             derived_metadata_collector=derived_metadata_collector,
             record_post_processor=record_post_processor,
         )

--- a/src/ogcat/materialization.py
+++ b/src/ogcat/materialization.py
@@ -1,0 +1,205 @@
+"""Internal artifact materialization planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from ogcat.hooks import ArtifactWriter
+from ogcat.models import ArtifactLocator
+from ogcat.operation_helpers import adapter_name, directory_from_locator, filename_from_locator
+from ogcat.storage import (
+    ChecksumPolicy,
+    StoragePlan,
+    StoragePrimaryLocation,
+    TargetKind,
+    WriteMode,
+    plan_storage,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializationIntent:
+    """Operation intent for artifact materialization.
+
+    Args:
+        writer: Optional writer used to materialize artifact data.
+        target_kind: Whether the materialized target is file-like or
+            directory-like.
+        write_mode: How the target is materialized, or ``"reference"`` when no
+            write should occur.
+        ogcat_owned: Whether ogcat should treat the materialized target as
+            owned for storage-plan metadata.
+    """
+
+    writer: ArtifactWriter | None
+    target_kind: TargetKind
+    write_mode: WriteMode
+    ogcat_owned: bool
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializationTarget:
+    """Resolved primary target for artifact materialization.
+
+    Args:
+        locator: Canonical artifact locator to store on the record.
+        target_kind: Whether the target is file-like or directory-like.
+        adapter: Optional storage adapter identifier.
+        storage_relative_path: Optional target path relative to the relevant
+            storage root.
+        resolved_directory: Optional rendered directory metadata.
+        resolved_filename: Optional rendered final path component.
+        artifact_uuid: Optional UUID-style primary storage identifier.
+        primary_location: Optional primary placement policy used for the plan.
+    """
+
+    locator: ArtifactLocator
+    target_kind: TargetKind
+    adapter: str | None = None
+    storage_relative_path: str | None = None
+    resolved_directory: str | None = None
+    resolved_filename: str | None = None
+    artifact_uuid: str | None = None
+    primary_location: StoragePrimaryLocation | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializationPlan:
+    """Resolved primary target paired with materialization intent."""
+
+    primary_target: MaterializationTarget
+    intent: MaterializationIntent
+
+    def to_storage_plan(
+        self,
+        *,
+        checksum: ChecksumPolicy = "none",
+        profile: str | None = None,
+        time_added: str | None = None,
+    ) -> StoragePlan:
+        """Build the concrete storage plan for the primary target."""
+        target = self.primary_target
+        return plan_storage(
+            target.locator,
+            target_kind=target.target_kind,
+            write_mode=self.intent.write_mode,
+            checksum=checksum,
+            ogcat_owned=self.intent.ogcat_owned,
+            profile=profile,
+            adapter=target.adapter,
+            time_added=time_added,
+            storage_relative_path=target.storage_relative_path,
+            resolved_directory=target.resolved_directory,
+            resolved_filename=target.resolved_filename,
+            artifact_uuid=target.artifact_uuid,
+            primary_location=target.primary_location,
+        )
+
+
+def reference_intent() -> MaterializationIntent:
+    """Return the materialization intent for record-only references."""
+    return MaterializationIntent(
+        writer=None,
+        target_kind="file",
+        write_mode="reference",
+        ogcat_owned=False,
+    )
+
+
+def writer_intent(writer: ArtifactWriter) -> MaterializationIntent:
+    """Return the materialization intent declared by a writer."""
+    return MaterializationIntent(
+        writer=writer,
+        target_kind=target_kind_from_writer(writer),
+        write_mode=write_mode_from_writer(writer),
+        ogcat_owned=True,
+    )
+
+
+def storage_plan_intent(
+    plan: StoragePlan,
+    *,
+    writer: ArtifactWriter | None = None,
+) -> MaterializationIntent:
+    """Return materialization intent with an explicit storage plan as authority."""
+    return MaterializationIntent(
+        writer=None if plan.write_mode == "reference" else writer,
+        target_kind=plan.target_kind,
+        write_mode=plan.write_mode,
+        ogcat_owned=plan.ogcat_owned,
+    )
+
+
+def target_from_locator(locator: ArtifactLocator, *, target_kind: TargetKind) -> MaterializationTarget:
+    """Build a materialization target directly from a canonical locator."""
+    return MaterializationTarget(
+        locator=locator,
+        target_kind=target_kind,
+        adapter=adapter_name(locator),
+        storage_relative_path=locator.relative_path,
+        resolved_directory=directory_from_locator(locator),
+        resolved_filename=filename_from_locator(locator),
+    )
+
+
+def materialization_plan_from_locator(
+    locator: ArtifactLocator,
+    *,
+    intent: MaterializationIntent,
+) -> MaterializationPlan:
+    """Build a materialization plan directly from a canonical locator."""
+    return MaterializationPlan(
+        primary_target=target_from_locator(locator, target_kind=intent.target_kind),
+        intent=intent,
+    )
+
+
+def validate_writer_matches_storage_plan(writer: ArtifactWriter, plan: StoragePlan) -> None:
+    """Raise when a writer declares target semantics that conflict with a plan."""
+    declared_target_kind = getattr(writer, "target_kind", plan.target_kind)
+    if declared_target_kind in {"file", "directory"} and declared_target_kind != plan.target_kind:
+        raise ValueError(
+            f"Artifact writer target_kind {declared_target_kind!r} does not match "
+            f"storage plan target_kind {plan.target_kind!r}."
+        )
+    declared_write_mode = getattr(writer, "write_mode", plan.write_mode)
+    if (
+        declared_write_mode in {"copy", "move", "write", "reference"}
+        and declared_write_mode != plan.write_mode
+    ):
+        raise ValueError(
+            f"Artifact writer write_mode {declared_write_mode!r} does not match "
+            f"storage plan write_mode {plan.write_mode!r}."
+        )
+
+
+def target_kind_from_writer(writer: ArtifactWriter) -> TargetKind:
+    """Infer a storage target kind from a writer when it declares one."""
+    target_kind = getattr(writer, "target_kind", "file")
+    if target_kind in {"file", "directory"}:
+        return cast(TargetKind, target_kind)
+    return "file"
+
+
+def write_mode_from_writer(writer: ArtifactWriter) -> WriteMode:
+    """Infer a storage write mode from a writer when it declares one."""
+    write_mode = getattr(writer, "write_mode", "write")
+    if write_mode in {"copy", "move", "write", "reference"}:
+        return cast(WriteMode, write_mode)
+    return "write"
+
+
+__all__ = [
+    "MaterializationIntent",
+    "MaterializationPlan",
+    "MaterializationTarget",
+    "materialization_plan_from_locator",
+    "reference_intent",
+    "storage_plan_intent",
+    "target_from_locator",
+    "target_kind_from_writer",
+    "validate_writer_matches_storage_plan",
+    "write_mode_from_writer",
+    "writer_intent",
+]

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -19,30 +19,31 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 from ogcat.audit import add_operation_note
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.hooks import (
     HOOK_PHASES,
-    ArtifactWriter,
     HookDispatcher,
     HookLifecycleCallback,
     HookManager,
     OperationContext,
     OperationSource,
 )
+from ogcat.materialization import (
+    MaterializationIntent,
+    materialization_plan_from_locator,
+    validate_writer_matches_storage_plan,
+)
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.operation_helpers import (
-    adapter_name,
     artifact_locator_from_context,
-    directory_from_locator,
-    filename_from_locator,
     naming_metadata_from_storage_plan,
     normalize_metadata_for_schema,
 )
 from ogcat.spec import RecordSchema
-from ogcat.storage import StoragePlan, TargetKind, WriteMode, plan_storage
+from ogcat.storage import StoragePlan
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import ValidationReport
 
@@ -140,8 +141,8 @@ class AddOperationRequest:
     time_added: str | None
     source: OperationSource
     locator_factory: ArtifactLocatorFactory
+    materialization_intent: MaterializationIntent
     storage_plan_factory: StoragePlanFactory | None = None
-    artifact_writer: ArtifactWriter | None = None
     derived_metadata_collector: DerivedMetadataCollector | None = None
     record_post_processor: RecordPostProcessor | None = None
 
@@ -312,16 +313,10 @@ class AddOperationRunner(OperationRunner):
         context.storage_plan = (
             self.request.storage_plan_factory(context, locator)
             if self.request.storage_plan_factory is not None
-            else plan_storage(
+            else materialization_plan_from_locator(
                 locator,
-                target_kind=_target_kind_from_writer(self.request.artifact_writer),
-                write_mode=_write_mode_from_writer(self.request.artifact_writer),
-                ogcat_owned=self.request.artifact_writer is not None,
-                adapter=adapter_name(locator),
-                storage_relative_path=locator.relative_path,
-                resolved_directory=directory_from_locator(locator),
-                resolved_filename=filename_from_locator(locator),
-            )
+                intent=self.request.materialization_intent,
+            ).to_storage_plan()
         )
         storage_plan = context.storage_plan
         if storage_plan is None:
@@ -352,12 +347,8 @@ class AddOperationRunner(OperationRunner):
         set_phase: _PhaseSetter,
     ) -> None:
         """Materialise or skip the artifact write for an add operation."""
-        if self.request.artifact_writer is None:
-            if add_plan.storage_plan.write_mode != "reference":
-                raise ValueError(
-                    f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
-                    "requires an artifact_writer."
-                )
+        writer = self.request.materialization_intent.writer
+        if add_plan.storage_plan.write_mode == "reference":
             self.dependencies.emit_operation_audit(
                 add_plan.context,
                 event_type="write",
@@ -369,16 +360,22 @@ class AddOperationRunner(OperationRunner):
                 locator=add_plan.locator,
             )
             return
+        if writer is None:
+            raise ValueError(
+                f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
+                "requires an artifact_writer."
+            )
+        validate_writer_matches_storage_plan(writer, add_plan.storage_plan)
 
         set_phase("artifact-write")
-        self.request.artifact_writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
+        writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
         self.dependencies.emit_operation_audit(
             add_plan.context,
             event_type="write",
             message="Artifact write completed.",
             details={
                 "write_phase": "artifact-write",
-                "writer_type": type(self.request.artifact_writer).__name__,
+                "writer_type": type(writer).__name__,
                 "write_mode": add_plan.storage_plan.write_mode,
             },
             locator=add_plan.locator,
@@ -572,26 +569,6 @@ def _add_classification_metadata(context: OperationContext, locator: ArtifactLoc
         }
     elif existing is None:
         context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
-
-
-def _target_kind_from_writer(artifact_writer: ArtifactWriter | None) -> TargetKind:
-    """Infer a storage target kind from a writer when it declares one."""
-    if artifact_writer is None:
-        return "file"
-    target_kind = getattr(artifact_writer, "target_kind", "file")
-    if target_kind in {"file", "directory"}:
-        return cast(TargetKind, target_kind)
-    return "file"
-
-
-def _write_mode_from_writer(artifact_writer: ArtifactWriter | None) -> WriteMode:
-    """Infer a storage write mode from a writer when it declares one."""
-    if artifact_writer is None:
-        return "reference"
-    write_mode = getattr(artifact_writer, "write_mode", "write")
-    if write_mode in {"copy", "move", "write", "reference"}:
-        return cast(WriteMode, write_mode)
-    return "write"
 
 
 def _validation_audit_level(report: ValidationReport) -> str:

--- a/src/ogcat/storage_planning.py
+++ b/src/ogcat/storage_planning.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias
 
+from ogcat.materialization import (
+    MaterializationIntent,
+    MaterializationPlan,
+    MaterializationTarget,
+)
 from ogcat.models import ArtifactLocator
 from ogcat.naming import build_naming_context, render_storage_location, split_name_and_suffixes
 from ogcat.operation_helpers import (
@@ -27,7 +32,6 @@ from ogcat.storage import (
     StoragePlan,
     TargetKind,
     WriteMode,
-    plan_storage,
 )
 
 PrimaryLocation: TypeAlias = Literal["uuid", "template"]
@@ -123,6 +127,48 @@ class PrimaryStoragePlanResult:
         Returns:
             Storage plan carrying the primary storage planning metadata.
         """
+        intent = MaterializationIntent(
+            writer=None,
+            target_kind=target_kind,
+            write_mode=write_mode,
+            ogcat_owned=ogcat_owned,
+        )
+        return MaterializationPlan(
+            primary_target=self.to_materialization_target(
+                locator=locator,
+                target_kind=target_kind,
+                adapter=adapter,
+                artifact_uuid=artifact_uuid,
+            ),
+            intent=intent,
+        ).to_storage_plan(
+            checksum=checksum,
+            profile=profile,
+            time_added=time_added,
+        )
+
+    def to_materialization_target(
+        self,
+        *,
+        locator: ArtifactLocator | None = None,
+        target_kind: TargetKind = "file",
+        adapter: str | None = None,
+        artifact_uuid: str | None = None,
+    ) -> MaterializationTarget:
+        """Build the resolved primary target for a materialization plan.
+
+        Args:
+            locator: Optional hook-resolved canonical locator.
+            target_kind: Whether the target is file-like or directory-like.
+            adapter: Optional adapter identifier. When omitted, it is inferred
+                from the planned locator.
+            artifact_uuid: Optional artifact UUID override for compatibility
+                with operations that record the operation id separately from
+                primary storage identity.
+
+        Returns:
+            Materialization target carrying primary storage planning metadata.
+        """
         canonical_locator = self.locator if locator is None else locator
         if canonical_locator == self.locator:
             storage_relative_path = self.storage_relative_path
@@ -136,15 +182,10 @@ class PrimaryStoragePlanResult:
                 else directory_from_relative_path(storage_relative_path)
             )
             resolved_filename = filename_from_locator(canonical_locator)
-        return plan_storage(
-            canonical_locator,
+        return MaterializationTarget(
+            locator=canonical_locator,
             target_kind=target_kind,
-            write_mode=write_mode,
-            checksum=checksum,
-            ogcat_owned=ogcat_owned,
-            profile=profile,
             adapter=adapter_name(canonical_locator) if adapter is None else adapter,
-            time_added=time_added,
             storage_relative_path=storage_relative_path,
             resolved_directory=resolved_directory,
             resolved_filename=resolved_filename,

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -19,6 +19,7 @@ from ogcat import (
 )
 from ogcat.catalog_application import CatalogApplication
 from ogcat.operation_runner import AddOperationRequest, OperationRunner
+from ogcat.storage import StoragePlan
 
 
 def test_add_file_facade_delegates_to_application_service(
@@ -100,7 +101,104 @@ def test_run_add_operation_delegates_to_operation_runner(
     assert request.operation_type == "add_artifact"
     assert request.record_type == "external_reference"
     assert request.metadata == {"title": "Delegated"}
+    assert request.materialization_intent.writer is None
+    assert request.materialization_intent.write_mode == "reference"
+    assert request.materialization_intent.ogcat_owned is False
     assert record.id == "runner"
+
+
+def test_add_file_application_request_uses_copy_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed file requests carry explicit copy materialization intent."""
+    requests: list[AddOperationRequest] = []
+
+    class FakeRunner(OperationRunner):
+        def __init__(self, request: AddOperationRequest) -> None:
+            self.request = request
+
+        def run(self) -> CatalogRecord:
+            return CatalogRecord(
+                catalog="files",
+                time_added="2026-05-15T00:00:00Z",
+                id="runner",
+                record_type=self.request.record_type,
+                locator=ArtifactLocator.path(tmp_path / "stored.nc"),
+            )
+
+    def build_fake_runner(self: Catalog, request: AddOperationRequest) -> OperationRunner:
+        requests.append(request)
+        return FakeRunner(request)
+
+    monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    catalog.add_file(source, operation="copy")
+
+    request = requests[0]
+    assert request.operation_type == "add_file"
+    assert request.materialization_intent.target_kind == "file"
+    assert request.materialization_intent.write_mode == "copy"
+    assert request.materialization_intent.ogcat_owned is True
+    assert type(request.materialization_intent.writer).__name__ == "CopyArtifactWriter"
+
+
+def test_add_artifact_application_request_uses_writer_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Writer-backed artifact requests carry target kind and write mode intent."""
+    requests: list[AddOperationRequest] = []
+
+    class DirectoryWriter:
+        target_kind = "directory"
+        write_mode = "write"
+
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            raise AssertionError("fake runner should not invoke writer")
+
+    class FakeRunner(OperationRunner):
+        def __init__(self, request: AddOperationRequest) -> None:
+            self.request = request
+
+        def run(self) -> CatalogRecord:
+            return CatalogRecord(
+                catalog="artifacts",
+                time_added="2026-05-15T00:00:00Z",
+                id="runner",
+                record_type=self.request.record_type,
+                locator=ArtifactLocator.path(tmp_path / "stored.zarr"),
+            )
+
+    def build_fake_runner(self: Catalog, request: AddOperationRequest) -> OperationRunner:
+        requests.append(request)
+        return FakeRunner(request)
+
+    writer = DirectoryWriter()
+    monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    catalog.add_artifact(
+        record_type="zarr_store",
+        locator=ArtifactLocator.path(tmp_path / "store.zarr"),
+        source=OperationSource(kind="memory", descriptor="generated"),
+        artifact_writer=writer,
+    )
+
+    request = requests[0]
+    assert request.operation_type == "add_artifact"
+    assert request.materialization_intent.writer is writer
+    assert request.materialization_intent.target_kind == "directory"
+    assert request.materialization_intent.write_mode == "write"
+    assert request.materialization_intent.ogcat_owned is True
 
 
 def test_add_file_lifecycle_preserves_hook_order_and_file_storage(tmp_path: Path) -> None:
@@ -173,6 +271,71 @@ def test_record_only_add_artifact_skips_artifact_write(tmp_path: Path) -> None:
     assert record.stored_abspath == str(target)
     assert not target.exists()
     assert catalog.repository.all() == [record]
+
+
+def test_explicit_reference_storage_plan_skips_artifact_writer(tmp_path: Path) -> None:
+    """Explicit reference plans are authoritative and do not run supplied writers."""
+
+    class ExplodingWriter:
+        target_kind = "file"
+        write_mode = "write"
+
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            raise AssertionError("reference storage plan should skip the writer")
+
+    target = tmp_path / "planned.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="planned_reference",
+        storage_plan=StoragePlan(locator=ArtifactLocator.path(target), write_mode="reference"),
+        source=OperationSource(kind="text", descriptor="record only"),
+        artifact_writer=ExplodingWriter(),
+    )
+
+    assert record.locator == ArtifactLocator.path(target)
+    assert not target.exists()
+
+
+def test_explicit_storage_plan_rejects_writer_write_mode_mismatch(tmp_path: Path) -> None:
+    """Writer-declared write modes must match authoritative explicit plans."""
+
+    class CopyDeclaredWriter:
+        target_kind = "file"
+        write_mode = "copy"
+
+        def write(
+            self,
+            context: OperationContext,
+            source: OperationSource,
+            target: ArtifactLocator,
+        ) -> None:
+            raise AssertionError("mismatched writer should fail before writing")
+
+    target = tmp_path / "planned.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(
+        ValueError,
+        match="Artifact writer write_mode 'copy' does not match storage plan write_mode 'move'",
+    ):
+        catalog.add_artifact(
+            record_type="planned_move",
+            storage_plan=StoragePlan(
+                locator=ArtifactLocator.path(target),
+                write_mode="move",
+                ogcat_owned=True,
+            ),
+            source=OperationSource(kind="text", descriptor="planned move"),
+            artifact_writer=CopyDeclaredWriter(),
+        )
+
+    assert not target.exists()
 
 
 def test_writer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,6 +10,11 @@ import ogcat.catalog_application as catalog_application_module
 import ogcat.storage_planning as storage_planning
 from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
 from ogcat.hooks import OperationContext, OperationSource
+from ogcat.materialization import (
+    MaterializationIntent,
+    MaterializationPlan,
+    materialization_plan_from_locator,
+)
 from ogcat.models import MetadataDict
 from ogcat.reference_planning import plan_reference_locator
 from ogcat.storage import (
@@ -128,6 +133,46 @@ def test_primary_storage_planner_uuid_location_builds_storage_plan(tmp_path: Pat
     assert plan.ogcat_owned
 
 
+def test_primary_storage_planner_builds_materialization_target(tmp_path: Path) -> None:
+    """Primary planner exposes a target interface before storage-plan conversion."""
+    catalog_root = tmp_path / "catalog"
+    result = storage_planning.plan_primary_storage(
+        storage_planning.PrimaryStoragePlanningContext(
+            catalog_root=catalog_root,
+            files_root=catalog_root / "data" / "files",
+            objects_root=catalog_root / "data" / "objects",
+            operation_id="abcdef1234567890",
+            metadata={},
+            directory_template="{year_added}/{original_stem}",
+            filename_template="{original_filename}",
+            source_path=tmp_path / "source.zarr",
+            storage_root=None,
+            date_added="2026-05-15",
+            primary_location="uuid",
+        )
+    )
+
+    target = result.to_materialization_target(target_kind="directory")
+    plan = MaterializationPlan(
+        primary_target=target,
+        intent=MaterializationIntent(
+            writer=None,
+            target_kind="directory",
+            write_mode="write",
+            ogcat_owned=True,
+        ),
+    ).to_storage_plan()
+
+    assert target.target_kind == "directory"
+    assert target.adapter == "local"
+    assert target.storage_relative_path == "ab/abcdef1234567890.zarr"
+    assert target.resolved_directory == "ab"
+    assert target.resolved_filename == "abcdef1234567890.zarr"
+    assert plan.target_kind == "directory"
+    assert plan.write_mode == "write"
+    assert plan.ogcat_owned
+
+
 def test_primary_storage_planner_template_location_uses_schema_naming(tmp_path: Path) -> None:
     """Primary planner owns template placement without assigning an artifact UUID."""
     catalog_root = tmp_path / "catalog"
@@ -216,6 +261,29 @@ def test_primary_storage_planner_uuid_urlpath_root_has_remote_plan_metadata(tmp_
     assert plan.adapter == "fsspec"
     assert plan.artifact_uuid == "abcdef1234567890"
     assert plan.primary_location == "uuid"
+
+
+def test_locator_materialization_plan_supports_directory_writer_intent() -> None:
+    """Locator-backed writer materialization preserves target kind and adapter metadata."""
+    intent = MaterializationIntent(
+        writer=None,
+        target_kind="directory",
+        write_mode="write",
+        ogcat_owned=True,
+    )
+
+    plan = materialization_plan_from_locator(
+        ArtifactLocator.from_urlpath("s3://bucket/stores/example.zarr"),
+        intent=intent,
+    ).to_storage_plan()
+
+    assert plan.target_kind == "directory"
+    assert plan.write_mode == "write"
+    assert plan.ogcat_owned
+    assert plan.adapter == "fsspec"
+    assert plan.storage_relative_path is None
+    assert plan.resolved_directory == "s3://bucket/stores"
+    assert plan.resolved_filename == "example.zarr"
 
 
 def test_primary_storage_plan_uses_locator_directory_when_hook_target_has_no_relative_path(


### PR DESCRIPTION
## Summary
- Add an internal materialization module that separates writer intent, resolved primary targets, and storage-plan conversion.
- Route default add-operation planning through the materialization target model while preserving explicit `StoragePlan` authority.
- Expose `PrimaryStoragePlanResult.to_materialization_target(...)` so primary planning can feed file, directory, and future collection-like targets without `Catalog` branching on target shape.
- Add regression coverage for writer-backed requests, directory target intent, hook-resolved target metadata, explicit reference plans skipping writers, and explicit plan/writer mismatch validation.

## Architecture Checkpoint
- `Catalog` remains a public facade and transitional wrapper.
- `CatalogApplication` now prepares materialization intent, while `AddOperationRunner` converts locator-backed operations into storage plans through the new target model.
- Writer target/write-mode inference no longer lives as private runner helpers.
- Remaining follow-up: template-link replicas still need to become ordered secondary artifact operations, and issue #70 collection artifacts should build on this target contract.

## Tests
- `uv run ruff check src/ogcat/materialization.py src/ogcat/storage_planning.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py tests/test_storage.py tests/test_add_operation_lifecycle.py`
- `uv run ruff format --check src/ogcat/materialization.py src/ogcat/storage_planning.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py tests/test_storage.py tests/test_add_operation_lifecycle.py`
- `uv run pyright src/ogcat/materialization.py src/ogcat/storage_planning.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py`
- `uv run pytest tests/test_add_operation_lifecycle.py tests/test_storage.py tests/test_writers.py -q`
- `uv run pytest`