### PR TITLE
[codex] Model template links as secondary artifacts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,10 @@ contract rather than the add lifecycle details.
 
 The current concrete runner is `AddOperationRunner`. It implements the add lifecycle for
 `add_file()` and `add_artifact()`: validation, hook dispatch, locator resolution, storage planning,
-artifact writing or reference skipping, derived metadata collection, record staging, commit, audit,
-and rollback. `OperationRunner` is the generic internal command interface with a single `run()`
-method, so future operation families can be represented without overloading add-specific names.
+artifact writing or reference skipping, derived metadata collection, record staging, required
+secondary artifact operations, commit, audit, and rollback. `OperationRunner` is the generic
+internal command interface with a single `run()` method, so future operation families can be
+represented without overloading add-specific names.
 
 Shared catalog services such as hook management, audit emission, validation, and record building are
 passed through `OperationServices`. Operation-specific data lives in request dataclasses such as
@@ -110,6 +111,11 @@ materialisation target. The materialisation intent answers how bytes or director
 there, if at all. That distinction is important for future directory-backed collection artifacts
 and `.zarr`-style outputs because `Catalog` should not branch on file versus directory versus
 collection.
+
+Required secondary artifacts, such as the default human-readable template symlink for UUID primary
+storage, are modeled as ordered secondary operations. They run after the primary record is staged
+and has an id, but before commit, so their filesystem effects and record metadata updates remain
+part of the same rollback boundary.
 
 ## Why Templates and Metadata Live in `catalog.json`
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -28,7 +28,6 @@ from ogcat.hooks import (
     coerce_hook_iterable,
     validate_hook_objects,
 )
-from ogcat.materialization import reference_intent, writer_intent
 from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
 from ogcat.operation_helpers import (
     artifact_locator_from_context,
@@ -38,12 +37,8 @@ from ogcat.operation_helpers import (
 from ogcat.operation_runner import (
     AddOperationRequest,
     AddOperationRunner,
-    ArtifactLocatorFactory,
-    DerivedMetadataCollector,
     OperationRunner,
     OperationServices,
-    RecordPostProcessor,
-    StoragePlanFactory,
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
@@ -51,7 +46,6 @@ from ogcat.reference_planning import plan_reference_locator
 from ogcat.replicas import (
     ReplicaMode,
     ReplicaViewPlan,
-    materialize_template_link_replica,
     plan_replica_view,
 )
 from ogcat.repository import CatalogRepository
@@ -1108,45 +1102,6 @@ class Catalog:
             naming_metadata=normalized_naming_metadata,
         )
 
-    def _create_template_link_replica(
-        self,
-        *,
-        transaction: UnitOfWork,
-        context: OperationContext,
-        record: CatalogRecord,
-        directory_template: str,
-        filename_template: str,
-    ) -> CatalogRecord:
-        """Create and record the default template symlink replica."""
-        materialized = materialize_template_link_replica(
-            catalog_root=self.root,
-            files_root=self.root / self.spec.files_root,
-            record=record,
-            directory_template=directory_template,
-            filename_template=filename_template,
-            register_rollback=lambda action, description: transaction.register_rollback(
-                action,
-                description=description,
-            ),
-        )
-        if materialized is None:
-            return record
-        updated_record = replace(record, naming_metadata=materialized.naming_metadata)
-        updated_record = transaction.update_staged_record(updated_record)
-        self._emit_operation_audit(
-            context,
-            event_type="replica",
-            message="Template symlink replica created.",
-            details={
-                "replica_role": "template_link",
-                "replica_mode": "symlink",
-                "replica_path": str(materialized.target_path),
-                "primary_path": str(materialized.primary_path),
-            },
-            locator=record.locator,
-        )
-        return updated_record
-
     def _add_artifact_in_transaction(
         self,
         *,
@@ -1285,56 +1240,6 @@ class Catalog:
                 else f"{event.phase.label} hooks completed."
             ),
             details=details,
-        )
-
-    def _run_add_operation(
-        self,
-        *,
-        transaction: UnitOfWork,
-        commit: bool,
-        operation_type: str,
-        record_type: str,
-        schema: RecordSchema,
-        schema_record_type: str | None,
-        metadata: MetadataDict,
-        storage_mode: str | None,
-        original_path: str | Path | None,
-        original_filename: str | None,
-        suffixes: list[str] | None,
-        derived_metadata: MetadataDict,
-        naming_metadata: MetadataDict | None,
-        time_added: str | None,
-        source: OperationSource,
-        locator_factory: ArtifactLocatorFactory,
-        storage_plan_factory: StoragePlanFactory | None = None,
-        artifact_writer: ArtifactWriter | None = None,
-        derived_metadata_collector: DerivedMetadataCollector | None = None,
-        record_post_processor: RecordPostProcessor | None = None,
-    ) -> CatalogRecord:
-        """Run the shared add operation lifecycle for file and record-only adds."""
-        return self._application().run_add_operation(
-            transaction=transaction,
-            commit=commit,
-            operation_type=operation_type,
-            record_type=record_type,
-            schema=schema,
-            schema_record_type=schema_record_type,
-            metadata=metadata,
-            storage_mode=storage_mode,
-            original_path=original_path,
-            original_filename=original_filename,
-            suffixes=suffixes,
-            derived_metadata=derived_metadata,
-            naming_metadata=naming_metadata,
-            time_added=time_added,
-            source=source,
-            locator_factory=locator_factory,
-            materialization_intent=(
-                reference_intent() if artifact_writer is None else writer_intent(artifact_writer)
-            ),
-            storage_plan_factory=storage_plan_factory,
-            derived_metadata_collector=derived_metadata_collector,
-            record_post_processor=record_post_processor,
         )
 
     def _application(self) -> CatalogApplication:

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -21,9 +21,9 @@ from ogcat.operation_runner import (
     AddOperationRequest,
     ArtifactLocatorFactory,
     DerivedMetadataCollector,
-    RecordPostProcessor,
     StoragePlanFactory,
 )
+from ogcat.secondary_artifacts import SecondaryArtifactOperation, TemplateLinkSecondaryArtifact
 from ogcat.spec import RecordSchema
 from ogcat.storage import StoragePlan
 from ogcat.storage_planning import (
@@ -124,7 +124,7 @@ class CatalogApplication:
             CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()
         )
         materialization_intent = writer_intent(artifact_writer)
-        record_post_processor = self._template_replica_post_processor(
+        secondary_artifact_operations = self._template_link_secondary_artifacts(
             primary_location=primary_location,
             directory_template=directory_template,
             filename_template=filename_template,
@@ -151,7 +151,7 @@ class CatalogApplication:
                 materialization_intent=materialization_intent,
                 storage_plan_factory=plan_local_file_storage,
                 derived_metadata_collector=collect_file_metadata,
-                record_post_processor=record_post_processor,
+                secondary_artifact_operations=secondary_artifact_operations,
             )
 
     def add_artifact(
@@ -236,7 +236,7 @@ class CatalogApplication:
         materialization_intent: MaterializationIntent,
         storage_plan_factory: StoragePlanFactory | None = None,
         derived_metadata_collector: DerivedMetadataCollector | None = None,
-        record_post_processor: RecordPostProcessor | None = None,
+        secondary_artifact_operations: tuple[SecondaryArtifactOperation, ...] = (),
     ) -> CatalogRecord:
         """Build and run a shared add-operation request."""
         request = AddOperationRequest(
@@ -259,36 +259,28 @@ class CatalogApplication:
             materialization_intent=materialization_intent,
             storage_plan_factory=storage_plan_factory,
             derived_metadata_collector=derived_metadata_collector,
-            record_post_processor=record_post_processor,
+            secondary_artifact_operations=secondary_artifact_operations,
         )
         return self.catalog._build_add_operation_runner(request).run()
 
-    def _template_replica_post_processor(
+    def _template_link_secondary_artifacts(
         self,
         *,
         primary_location: PrimaryLocation,
         directory_template: str,
         filename_template: str,
-    ) -> RecordPostProcessor | None:
-        """Return the default template-link post processor when required."""
+    ) -> tuple[SecondaryArtifactOperation, ...]:
+        """Return default secondary artifacts for UUID primary file adds."""
         if primary_location != "uuid":
-            return None
-
-        def create_default_template_replica(
-            transaction: UnitOfWork,
-            context: OperationContext,
-            record: CatalogRecord,
-        ) -> CatalogRecord:
-            """Create the default template symlink replica for a UUID primary."""
-            return self.catalog._create_template_link_replica(
-                transaction=transaction,
-                context=context,
-                record=record,
+            return ()
+        return (
+            TemplateLinkSecondaryArtifact(
+                catalog_root=self.catalog.root,
+                files_root=self.catalog.root / self.catalog.spec.files_root,
                 directory_template=directory_template,
                 filename_template=filename_template,
-            )
-
-        return create_default_template_replica
+            ),
+        )
 
 
 __all__ = ["CatalogApplication"]

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -42,6 +42,7 @@ from ogcat.operation_helpers import (
     naming_metadata_from_storage_plan,
     normalize_metadata_for_schema,
 )
+from ogcat.secondary_artifacts import SecondaryArtifactOperation, SecondaryArtifactResult
 from ogcat.spec import RecordSchema
 from ogcat.storage import StoragePlan
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
@@ -50,7 +51,6 @@ from ogcat.validation import ValidationReport
 ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
-RecordPostProcessor = Callable[[UnitOfWork, OperationContext, CatalogRecord], CatalogRecord]
 _PhaseSetter = Callable[[str], None]
 
 
@@ -144,7 +144,7 @@ class AddOperationRequest:
     materialization_intent: MaterializationIntent
     storage_plan_factory: StoragePlanFactory | None = None
     derived_metadata_collector: DerivedMetadataCollector | None = None
-    record_post_processor: RecordPostProcessor | None = None
+    secondary_artifact_operations: tuple[SecondaryArtifactOperation, ...] = ()
 
 
 @dataclass(slots=True)
@@ -443,15 +443,62 @@ class AddOperationRunner(OperationRunner):
             },
             locator=add_plan.locator,
         )
-        if self.request.record_post_processor is not None:
-            set_phase("record-post-processing")
-            persisted = self.request.record_post_processor(
+        persisted = self._run_secondary_artifacts(
+            add_plan=add_plan,
+            record=persisted,
+            set_phase=set_phase,
+        )
+        set_phase(HOOK_PHASES["after_record_write"].name)
+        hook_dispatcher.after_record_write(add_plan.context)
+        return persisted
+
+    def _run_secondary_artifacts(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        record: CatalogRecord,
+        set_phase: _PhaseSetter,
+    ) -> CatalogRecord:
+        """Run required secondary artifact operations for the staged record."""
+        persisted = record
+        for operation in self.request.secondary_artifact_operations:
+            set_phase(f"secondary-artifact:{operation.role}")
+            result = operation.run(
                 self.request.transaction,
                 add_plan.context,
                 persisted,
             )
-        set_phase(HOOK_PHASES["after_record_write"].name)
-        hook_dispatcher.after_record_write(add_plan.context)
+            if result is None:
+                continue
+            persisted = self._apply_secondary_artifact_result(
+                add_plan=add_plan,
+                record=persisted,
+                result=result,
+            )
+        return persisted
+
+    def _apply_secondary_artifact_result(
+        self,
+        *,
+        add_plan: _AddOperationPlan,
+        record: CatalogRecord,
+        result: SecondaryArtifactResult,
+    ) -> CatalogRecord:
+        """Persist secondary artifact metadata and emit its audit event."""
+        persisted = record
+        if result.naming_metadata_updates:
+            naming_metadata = dict(record.naming_metadata)
+            naming_metadata.update(result.naming_metadata_updates)
+            persisted = self.request.transaction.update_staged_record(
+                replace(record, naming_metadata=naming_metadata)
+            )
+        self.dependencies.emit_operation_audit(
+            add_plan.context,
+            event_type=result.event_type,
+            message=result.message,
+            details=dict(result.audit_details),
+            locator=record.locator,
+        )
         return persisted
 
     def _commit_if_owned(

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -1,0 +1,130 @@
+"""Secondary artifact operations coordinated by add-operation runners."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Protocol
+
+from ogcat.hooks import OperationContext
+from ogcat.models import CatalogRecord, MetadataDict
+from ogcat.replicas import ReplicaMode, materialize_template_link_replica
+from ogcat.transactions import UnitOfWork
+
+SecondaryArtifactRole = Literal["template_link"]
+
+
+@dataclass(frozen=True, slots=True)
+class SecondaryArtifactResult:
+    """Result from a materialized secondary artifact operation.
+
+    Args:
+        role: Semantic role of the secondary artifact.
+        mode: Materialization mode used for the secondary artifact.
+        message: Audit message to emit after successful materialization.
+        event_type: Audit event type to emit after successful materialization.
+        naming_metadata_updates: Metadata fields to merge onto the staged
+            catalog record.
+        audit_details: Structured audit details for the operation.
+    """
+
+    role: SecondaryArtifactRole
+    mode: ReplicaMode
+    message: str
+    event_type: str = "secondary_artifact"
+    naming_metadata_updates: MetadataDict = field(default_factory=dict)
+    audit_details: Mapping[str, object] = field(default_factory=dict)
+
+
+class SecondaryArtifactOperation(Protocol):
+    """Required secondary artifact operation run after primary record staging."""
+
+    @property
+    def role(self) -> SecondaryArtifactRole:
+        """Semantic role of the secondary artifact."""
+        ...
+
+    @property
+    def required(self) -> bool:
+        """Whether operation failure should fail the add operation."""
+        ...
+
+    def run(
+        self,
+        transaction: UnitOfWork,
+        context: OperationContext,
+        record: CatalogRecord,
+    ) -> SecondaryArtifactResult | None:
+        """Materialize the secondary artifact for the staged record."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateLinkSecondaryArtifact:
+    """Required template-link symlink secondary for UUID primary artifacts."""
+
+    catalog_root: Path
+    files_root: Path
+    directory_template: str
+    filename_template: str
+    role: SecondaryArtifactRole = "template_link"
+    mode: ReplicaMode = "symlink"
+    required: bool = True
+
+    def run(
+        self,
+        transaction: UnitOfWork,
+        context: OperationContext,
+        record: CatalogRecord,
+    ) -> SecondaryArtifactResult | None:
+        """Create the template-link replica and return record metadata updates."""
+        materialized = materialize_template_link_replica(
+            catalog_root=self.catalog_root,
+            files_root=self.files_root,
+            record=record,
+            directory_template=self.directory_template,
+            filename_template=self.filename_template,
+            register_rollback=_rollback_registrar(transaction),
+        )
+        if materialized is None:
+            return None
+        return SecondaryArtifactResult(
+            role=self.role,
+            mode=self.mode,
+            message="Template symlink replica created.",
+            event_type="replica",
+            naming_metadata_updates={
+                "template_replica_path": str(materialized.target_path),
+                "template_replica_relative_path": materialized.catalog_relative_path,
+                "template_replica_storage_relative_path": materialized.storage_relative_path,
+                "template_resolved_directory": materialized.resolved_directory,
+                "template_resolved_filename": materialized.resolved_filename,
+            },
+            audit_details={
+                "replica_role": self.role,
+                "replica_mode": self.mode,
+                "replica_path": str(materialized.target_path),
+                "primary_path": str(materialized.primary_path),
+            },
+        )
+
+
+def _rollback_registrar(
+    transaction: UnitOfWork,
+) -> Callable[[Callable[[], None], str], object]:
+    """Return the rollback callback shape expected by replica materializers."""
+
+    def register_rollback(action: Callable[[], None], description: str) -> object:
+        """Register one secondary artifact rollback action."""
+        return transaction.register_rollback(action, description=description)
+
+    return register_rollback
+
+
+__all__ = [
+    "SecondaryArtifactOperation",
+    "SecondaryArtifactResult",
+    "SecondaryArtifactRole",
+    "TemplateLinkSecondaryArtifact",
+]

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -38,16 +38,11 @@ class SecondaryArtifactResult:
 
 
 class SecondaryArtifactOperation(Protocol):
-    """Required secondary artifact operation run after primary record staging."""
+    """Secondary artifact operation run after primary record staging."""
 
     @property
     def role(self) -> SecondaryArtifactRole:
         """Semantic role of the secondary artifact."""
-        ...
-
-    @property
-    def required(self) -> bool:
-        """Whether operation failure should fail the add operation."""
         ...
 
     def run(
@@ -70,7 +65,6 @@ class TemplateLinkSecondaryArtifact:
     filename_template: str
     role: SecondaryArtifactRole = "template_link"
     mode: ReplicaMode = "symlink"
-    required: bool = True
 
     def run(
         self,
@@ -94,13 +88,7 @@ class TemplateLinkSecondaryArtifact:
             mode=self.mode,
             message="Template symlink replica created.",
             event_type="replica",
-            naming_metadata_updates={
-                "template_replica_path": str(materialized.target_path),
-                "template_replica_relative_path": materialized.catalog_relative_path,
-                "template_replica_storage_relative_path": materialized.storage_relative_path,
-                "template_resolved_directory": materialized.resolved_directory,
-                "template_resolved_filename": materialized.resolved_filename,
-            },
+            naming_metadata_updates=materialized.naming_metadata,
             audit_details={
                 "replica_role": self.role,
                 "replica_mode": self.mode,

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -294,6 +294,27 @@ def test_add_file_lifecycle_preserves_hook_order_and_file_storage(tmp_path: Path
     assert record.derived_metadata["extract_hook"] == "add_file"
 
 
+def test_add_file_template_secondary_emits_replica_audit(tmp_path: Path) -> None:
+    """Template-link secondaries keep the existing replica audit contract."""
+    source = tmp_path / "audited.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source)
+
+    replica_path = Path(str(record.naming_metadata["template_replica_path"]))
+    primary_path = Path(str(record.stored_abspath))
+    replica_events = catalog.audit_events(event_type="replica")
+    assert len(replica_events) == 1
+    event = replica_events[0]
+    assert event.message == "Template symlink replica created."
+    assert event.record_id == record.id
+    assert event.details["replica_role"] == "template_link"
+    assert event.details["replica_mode"] == "symlink"
+    assert event.details["replica_path"] == str(replica_path)
+    assert event.details["primary_path"] == str(primary_path)
+
+
 def test_record_only_add_artifact_skips_artifact_write(tmp_path: Path) -> None:
     """Record-only add_artifact stores the locator without creating the target."""
     target = tmp_path / "generated.txt"

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -18,8 +18,11 @@ from ogcat import (
     ValidationReport,
 )
 from ogcat.catalog_application import CatalogApplication
+from ogcat.materialization import reference_intent
 from ogcat.operation_runner import AddOperationRequest, OperationRunner
+from ogcat.secondary_artifacts import SecondaryArtifactResult, SecondaryArtifactRole
 from ogcat.storage import StoragePlan
+from ogcat.transactions import UnitOfWork
 
 
 def test_add_file_facade_delegates_to_application_service(
@@ -313,6 +316,82 @@ def test_add_file_template_secondary_emits_replica_audit(tmp_path: Path) -> None
     assert event.details["replica_mode"] == "symlink"
     assert event.details["replica_path"] == str(replica_path)
     assert event.details["primary_path"] == str(primary_path)
+
+
+def test_secondary_artifacts_run_in_order_and_share_metadata(tmp_path: Path) -> None:
+    """Later secondary operations see metadata updates from earlier operations."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class FirstSecondaryArtifact:
+        role: SecondaryArtifactRole = "template_link"
+
+        def run(
+            self,
+            transaction: UnitOfWork,
+            context: OperationContext,
+            record: CatalogRecord,
+        ) -> SecondaryArtifactResult:
+            calls.append(("first", dict(record.naming_metadata)))
+            return SecondaryArtifactResult(
+                role=self.role,
+                mode="symlink",
+                message="First secondary applied.",
+                naming_metadata_updates={"first_secondary": "done"},
+            )
+
+    class SecondSecondaryArtifact:
+        role: SecondaryArtifactRole = "template_link"
+
+        def run(
+            self,
+            transaction: UnitOfWork,
+            context: OperationContext,
+            record: CatalogRecord,
+        ) -> SecondaryArtifactResult:
+            calls.append(("second", dict(record.naming_metadata)))
+            assert record.naming_metadata["first_secondary"] == "done"
+            return SecondaryArtifactResult(
+                role=self.role,
+                mode="symlink",
+                message="Second secondary applied.",
+                naming_metadata_updates={"second_secondary": "saw-first"},
+            )
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+    locator = ArtifactLocator.path(tmp_path / "external.txt")
+
+    with catalog.transaction() as transaction:
+        record = catalog._application().run_add_operation(
+            transaction=transaction,
+            commit=True,
+            operation_type="add_artifact",
+            record_type="ordered_secondary",
+            schema=RecordSchema(),
+            schema_record_type="ordered_secondary",
+            metadata={},
+            storage_mode=None,
+            original_path=None,
+            original_filename=None,
+            suffixes=None,
+            derived_metadata={},
+            naming_metadata={"initial": "metadata"},
+            time_added="2026-05-17T00:00:00Z",
+            source=OperationSource(kind="test", descriptor="secondary order"),
+            locator_factory=lambda context: locator,
+            materialization_intent=reference_intent(),
+            secondary_artifact_operations=(
+                FirstSecondaryArtifact(),
+                SecondSecondaryArtifact(),
+            ),
+        )
+
+    assert [call[0] for call in calls] == ["first", "second"]
+    assert calls[0][1]["initial"] == "metadata"
+    assert "first_secondary" not in calls[0][1]
+    assert calls[1][1]["first_secondary"] == "done"
+    assert record.naming_metadata["first_secondary"] == "done"
+    assert record.naming_metadata["second_secondary"] == "saw-first"
+    assert catalog.repository.all()[0].naming_metadata == record.naming_metadata
 
 
 def test_record_only_add_artifact_skips_artifact_write(tmp_path: Path) -> None:

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -452,6 +452,36 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
     assert catalog.repository.all() == []
 
 
+def test_after_record_hook_failure_rolls_back_template_secondary(
+    tmp_path: Path,
+) -> None:
+    """Failures after template-link creation roll back the symlink, primary, and record."""
+    root = tmp_path / "catalog"
+    source = tmp_path / "secondary.nc"
+    source.write_text("payload", encoding="utf-8")
+    files_root = root / "data" / "files"
+    objects_root = root / "data" / "objects"
+
+    class FailingAfterRecordHook:
+        def after_record_write(self, context: OperationContext) -> None:
+            created_links = [path for path in files_root.rglob("*.nc") if path.is_symlink()]
+            assert created_links, "template secondary should exist before after_record_write"
+            raise RuntimeError("stop after secondary artifact")
+
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(catalog_name="files"),
+        plugins=PluginRegistry([FailingAfterRecordHook()]),
+    )
+
+    with pytest.raises(RuntimeError, match="stop after secondary artifact"):
+        catalog.add_file(source)
+
+    assert catalog.repository.all() == []
+    assert list(files_root.rglob("*.nc")) == []
+    assert list(objects_root.rglob("*.nc")) == []
+
+
 def test_operation_runner_preserves_failure_audit_phase_and_rollback(tmp_path: Path) -> None:
     """Runner-owned failures keep the existing failure phase and rollback audit."""
 

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -144,6 +144,44 @@ def test_add_file_application_request_uses_copy_materialization(
     assert request.materialization_intent.write_mode == "copy"
     assert request.materialization_intent.ogcat_owned is True
     assert type(request.materialization_intent.writer).__name__ == "CopyArtifactWriter"
+    assert len(request.secondary_artifact_operations) == 1
+    assert request.secondary_artifact_operations[0].role == "template_link"
+
+
+def test_add_file_template_primary_request_has_no_template_link_secondary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Template-primary file requests do not schedule a template-link secondary."""
+    requests: list[AddOperationRequest] = []
+
+    class FakeRunner(OperationRunner):
+        def __init__(self, request: AddOperationRequest) -> None:
+            self.request = request
+
+        def run(self) -> CatalogRecord:
+            return CatalogRecord(
+                catalog="files",
+                time_added="2026-05-15T00:00:00Z",
+                id="runner",
+                record_type=self.request.record_type,
+                locator=ArtifactLocator.path(tmp_path / "stored.nc"),
+            )
+
+    def build_fake_runner(self: Catalog, request: AddOperationRequest) -> OperationRunner:
+        requests.append(request)
+        return FakeRunner(request)
+
+    monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    catalog.add_file(source, operation="copy", primary_location="template")
+
+    request = requests[0]
+    assert request.operation_type == "add_file"
+    assert request.secondary_artifact_operations == ()
 
 
 def test_add_artifact_application_request_uses_writer_materialization(

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -19,6 +19,7 @@ from ogcat import (
 )
 from ogcat.catalog_application import CatalogApplication
 from ogcat.materialization import reference_intent
+from ogcat.models import MetadataDict
 from ogcat.operation_runner import AddOperationRequest, OperationRunner
 from ogcat.secondary_artifacts import SecondaryArtifactResult, SecondaryArtifactRole
 from ogcat.storage import StoragePlan
@@ -320,7 +321,7 @@ def test_add_file_template_secondary_emits_replica_audit(tmp_path: Path) -> None
 
 def test_secondary_artifacts_run_in_order_and_share_metadata(tmp_path: Path) -> None:
     """Later secondary operations see metadata updates from earlier operations."""
-    calls: list[tuple[str, dict[str, object]]] = []
+    calls: list[tuple[str, MetadataDict]] = []
 
     class FirstSecondaryArtifact:
         role: SecondaryArtifactRole = "template_link"

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -7,7 +7,16 @@ from pathlib import Path
 
 import pytest
 
-from ogcat import Catalog, CatalogRecord, CatalogSpec, ReplicaState
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogRecord,
+    CatalogSpec,
+    OperationContext,
+    OperationSource,
+    ReplicaState,
+)
+from ogcat.secondary_artifacts import TemplateLinkSecondaryArtifact
 
 
 def _record_id(record: CatalogRecord) -> str:
@@ -22,6 +31,60 @@ def _source_file(tmp_path: Path, name: str, text: str = "payload") -> Path:
     source.parent.mkdir(parents=True, exist_ok=True)
     source.write_text(text, encoding="utf-8")
     return source
+
+
+def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
+    tmp_path: Path,
+) -> None:
+    """Template-link secondary operations create relative symlinks with rollback."""
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+    primary_path = root / "data" / "objects" / "ab" / "abcdef.nc"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("payload", encoding="utf-8")
+    record = CatalogRecord(
+        catalog="files",
+        time_added="2026-05-15T00:00:00Z",
+        id="record-1",
+        record_type="managed_file",
+        locator=ArtifactLocator.path(
+            primary_path,
+            relative_path="data/objects/ab/abcdef.nc",
+        ),
+        original_filename="alpha.nc",
+        suffixes=[".nc"],
+        naming_metadata={"artifact_uuid": "abcdef"},
+    )
+    operation = TemplateLinkSecondaryArtifact(
+        catalog_root=root,
+        files_root=root / "data" / "files",
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+    )
+    link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
+
+    with catalog.transaction() as transaction:
+        context = OperationContext(
+            catalog_root=root,
+            operation_id="operation-1",
+            operation_type="add_file",
+            record_type="managed_file",
+            user_metadata={},
+            derived_metadata={},
+            register_rollback=transaction.register_rollback,
+            source=OperationSource(kind="test"),
+        )
+        result = operation.run(transaction, context, record)
+        assert result is not None
+        link_path = Path(str(result.naming_metadata_updates["template_replica_path"]))
+        assert result.role == "template_link"
+        assert result.mode == "symlink"
+        assert link_path.is_symlink()
+        assert not Path(os.readlink(link_path)).is_absolute()
+        assert link_path.resolve() == primary_path
+
+    assert not link_path.exists()
+    assert not link_path.is_symlink()
 
 
 def test_plan_view_does_not_create_links(tmp_path: Path) -> None:

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -61,7 +61,7 @@ def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
         directory_template="{year_added}/{original_stem}",
         filename_template="{original_filename}",
     )
-    link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
+    expected_link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
 
     with catalog.transaction() as transaction:
         context = OperationContext(
@@ -77,14 +77,15 @@ def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
         result = operation.run(transaction, context, record)
         assert result is not None
         link_path = Path(str(result.naming_metadata_updates["template_replica_path"]))
+        assert link_path == expected_link_path
         assert result.role == "template_link"
         assert result.mode == "symlink"
         assert link_path.is_symlink()
         assert not Path(os.readlink(link_path)).is_absolute()
         assert link_path.resolve() == primary_path
 
-    assert not link_path.exists()
-    assert not link_path.is_symlink()
+    assert not expected_link_path.exists()
+    assert not expected_link_path.is_symlink()
 
 
 def test_plan_view_does_not_create_links(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add an internal secondary artifact operation interface and a concrete template-link secondary artifact.
- Replace the add-operation `record_post_processor` callback with ordered secondary artifact operations coordinated by `AddOperationRunner`.
- Move template symlink record updates and audit emission into the runner path, while keeping the existing low-level replica materializer behavior.
- Remove `Catalog._create_template_link_replica` and the unused private `_run_add_operation` wrapper.

Closes #88 

## Architecture Checkpoint
- `Catalog` no longer materializes template links directly.
- `CatalogApplication` decides which required secondary operations are needed for UUID-primary managed files.
- `AddOperationRunner` owns the order: primary record staging, secondary artifact operations, `after_record_write`, then commit.
- Template symlink metadata remains backward compatible via the existing `template_replica_*` and `template_resolved_*` fields.

## Tests
- `uv run ruff check src/ogcat/secondary_artifacts.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py tests/test_add_operation_lifecycle.py tests/test_replicas.py`
- `uv run ruff format --check src/ogcat/secondary_artifacts.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py tests/test_add_operation_lifecycle.py tests/test_replicas.py`
- `uv run pyright src/ogcat/secondary_artifacts.py src/ogcat/operation_runner.py src/ogcat/catalog_application.py src/ogcat/catalog.py`
- `uv run pytest tests/test_add_operation_lifecycle.py tests/test_replicas.py tests/test_add.py tests/test_hooks.py -q`
- `uv run pytest`

Review agent also inspected rollback/order risks and found no issues.