### PR TITLE
Document API internals layout

### DIFF
--- a/docs/api/catalog.rst
+++ b/docs/api/catalog.rst
@@ -1,6 +1,11 @@
 Catalog API
 ===========
 
+``Catalog`` is the main public Python facade. It owns user-facing argument
+handling, schema selection, and delegation into internal application services.
+Search results are returned as :class:`ogcat.CatalogRecordSet` by default; the
+record-set helpers are documented with search.
+
 .. autoclass:: ogcat.Catalog
    :members:
    :member-order: bysource

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,6 +1,16 @@
 API reference
 =============
 
+The public API pages document interfaces intended for normal users. Some public
+pages, especially hooks, writers, validation, and models, also describe the
+stable extension points plugin authors can use. The internals page documents
+package-internal boundaries used by maintainers and architecture work; those
+names are not a public stability promise unless a public page says so
+explicitly.
+
+Public API
+----------
+
 .. toctree::
    :maxdepth: 1
 
@@ -13,3 +23,11 @@ API reference
    hooks
    validation
    writers-transactions
+
+Internals
+---------
+
+.. toctree::
+   :maxdepth: 1
+
+   internals

--- a/docs/api/internals.rst
+++ b/docs/api/internals.rst
@@ -1,0 +1,55 @@
+Internal architecture reference
+===============================
+
+These modules describe maintainer-facing seams below the public Python API.
+They are documented so refactors and plugin-boundary discussions have concrete
+interfaces to point at. They should not be treated as stable public API unless
+a public concept page or release note promotes a specific name.
+
+Application orchestration
+-------------------------
+
+``Catalog`` delegates add-operation setup into an internal application service,
+which in turn builds operation-runner requests.
+
+.. automodule:: ogcat.catalog_application
+   :members:
+   :member-order: bysource
+
+.. automodule:: ogcat.operation_runner
+   :members:
+   :member-order: bysource
+
+Materialisation and storage planning
+------------------------------------
+
+Storage planning answers where the primary artifact belongs. Materialisation
+answers how data reaches that target, or whether the operation is record-only.
+
+.. automodule:: ogcat.materialization
+   :members:
+   :member-order: bysource
+
+.. automodule:: ogcat.storage_planning
+   :members:
+   :member-order: bysource
+
+Secondary artifacts
+-------------------
+
+Secondary artifacts are ordered follow-up operations, such as the required
+template-link symlink created after a UUID-primary file record is staged.
+
+.. automodule:: ogcat.secondary_artifacts
+   :members:
+   :member-order: bysource
+
+Repository boundary
+-------------------
+
+Repository implementations own persistence. Catalog and operation services
+depend on the protocol rather than a concrete backend.
+
+.. automodule:: ogcat.repository
+   :members:
+   :member-order: bysource

--- a/docs/api/replicas.rst
+++ b/docs/api/replicas.rst
@@ -1,6 +1,29 @@
 Replica views
 =============
 
+Replica views are user-requested generated link trees derived from catalog
+records. They are separate from required secondary artifacts, such as the
+default template-link created during UUID-primary ``add_file()`` operations.
+Secondary artifact internals are documented on the internals page.
+
 .. automodule:: ogcat.replicas
+   :no-members:
+
+.. autofunction:: ogcat.replicas.plan_replica_view
+
+.. autofunction:: ogcat.replicas.replica_template_context
+
+.. autoclass:: ogcat.ReplicaViewPlan
    :members:
    :member-order: bysource
+
+.. autoclass:: ogcat.ReplicaPlanItem
+   :members:
+   :member-order: bysource
+
+.. autoclass:: ogcat.ReplicaApplyResult
+   :members:
+   :member-order: bysource
+
+.. autoclass:: ogcat.ReplicaState
+   :members:

--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -1,5 +1,9 @@
-Storage planning
+Storage adapters
 ================
+
+This page documents storage adapter primitives and concrete storage plans used
+by writers and public planning helpers. The lower-level primary-storage planner
+and materialisation target types are package internals documented separately.
 
 .. automodule:: ogcat.storage
    :members:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,17 +7,50 @@ metadata when possible, and exposes search through both Python and CLI.
 
 ## Current Architecture
 
-The main pieces are:
+The main pieces now sit in four rough layers. These are working boundaries, not
+a formal framework:
+
+- **Presentation/API:** `Catalog`, `CatalogRecordSet`, and the CLI expose user
+  workflows. They should keep public argument handling and user-facing
+  compatibility behavior visible, while delegating operation choreography.
+- **Application/orchestration:** `CatalogApplication`, `AddOperationRunner`,
+  operation request objects, hooks, audit emission, and units of work coordinate
+  complete operations. This layer owns sequencing, rollback boundaries, and
+  runner dependencies.
+- **Domain/policy:** storage planning, materialisation targets, naming,
+  validation, cheap classification, replica-view planning, secondary artifact
+  policy, and future collection-artifact policy own catalog rules.
+- **Data/infrastructure:** `CatalogRepository`, `TinyDbCatalogRepository`,
+  storage adapters, filesystem/fsspec helpers, and bundled writers own
+  persistence and side effects.
+
+The most important responsibility split is that `Catalog` is the public facade,
+not the operation engine. `Catalog` selects the public operation and validates
+public inputs. Application services and runners decide how to execute the
+operation. Domain planning modules decide where artifacts and secondary
+artifacts belong. Repositories and storage adapters perform persistence and
+filesystem-like effects.
+
+Key concrete types are:
 
 - `CatalogSpec`: the serialisable catalog definition stored in `catalog.json`
-- `Catalog`: the user-facing API for creating, opening, adding, searching, and resolving record paths
+- `Catalog`: the public API facade for creating, opening, adding, searching, and resolving record paths
+- `CatalogApplication`: the internal application service that builds add-operation requests
+- `AddOperationRunner`: the current lifecycle runner for `add_file()` and `add_artifact()`
+- `StoragePlan` and materialisation targets: explicit storage/write decisions for primary artifacts
+- `SecondaryArtifactOperation`: ordered follow-up operations such as template-link symlinks
 - `CatalogRepository`: a protocol for record storage
 - `TinyDbCatalogRepository`: the current repository implementation
 - `CatalogRecord`: the stored record model
-- naming helpers: template rendering for managed storage paths
-- extractors: optional post-ingest metadata extraction
-- operation runners: internal coordinators for validated catalog operation lifecycles
-- CLI: a thin wrapper around the catalog API
+
+Related refactor tracking:
+
+- [#84](https://github.com/openghg/ogcat/issues/84): umbrella `Catalog` facade and operation-boundary refactor
+- [#87](https://github.com/openghg/ogcat/issues/87): application orchestration extraction
+- [#88](https://github.com/openghg/ogcat/issues/88): template symlinks as secondary artifact operations
+- [#89](https://github.com/openghg/ogcat/issues/89): replica module and interface-test cleanup
+- [#92](https://github.com/openghg/ogcat/issues/92): naming-template protected fields and internal identifiers
+- [#70](https://github.com/openghg/ogcat/issues/70): collection artifacts for directory-backed datasets
 
 The catalog root is self-describing:
 
@@ -116,6 +149,25 @@ Required secondary artifacts, such as the default human-readable template symlin
 storage, are modeled as ordered secondary operations. They run after the primary record is staged
 and has an id, but before commit, so their filesystem effects and record metadata updates remain
 part of the same rollback boundary.
+
+## Collection Artifacts And Directory Targets
+
+Collection artifacts are logical records for directory-backed datasets, such as a directory of
+NetCDF files or a future generated `.zarr` store. Architecturally, collection-ness should not be a
+third physical storage target kind. Physical targets remain file-like or directory-like; collection
+semantics live in domain policy and derived classification metadata.
+
+That means the existing operation model should still apply:
+
+- the primary artifact plan chooses the canonical file or directory locator
+- the materialisation intent decides whether a writer produces that target, skips writing for a
+  record-only reference, or delegates to a future directory writer
+- collection policy records cheap metadata such as member pattern, member format, and reader hints
+- secondary artifact operations remain separate follow-up work after the primary record is staged
+
+Keeping collection semantics above storage adapters avoids making `Catalog` branch on special
+directory cases and keeps remote or user-managed collections possible without scanning member files
+by default.
 
 ## Why Templates and Metadata Live in `catalog.json`
 


### PR DESCRIPTION
## Summary

Closes #98.

This PR updates the documentation layout for the #84 architecture train:

- separates the API reference into public API and internals sections;
- adds an internal architecture reference for application orchestration, operation runners, materialization, storage planning, secondary artifacts, and repositories;
- clarifies `Catalog` as the public Python facade;
- narrows the replica API page to generated view concepts and points secondary-artifact internals to the internals page;
- renames the storage API page framing from storage planning to storage adapters;
- updates `docs/architecture.md` with the presentation/application/domain/data responsibility map, related refactor issue links, and how collection artifacts fit the target/materialization model.

## Architecture Checkpoint

This is documentation-only. It does not promote internal modules to stable public API; it gives maintainers and future PRs a named place to discuss the internal seams created by #90, #91, #93, #94, and #95.

## Validation

- `uv run sphinx-build -b html docs docs/_build/html`
- `uv run ruff check docs`