### PR TITLE
Clarify replica module boundaries

### DIFF
--- a/docs/api/internals.rst
+++ b/docs/api/internals.rst
@@ -44,6 +44,18 @@ template-link symlink created after a UUID-primary file record is staged.
    :members:
    :member-order: bysource
 
+.. automodule:: ogcat.template_replicas
+   :members:
+   :member-order: bysource
+
+.. automodule:: ogcat.replica_context
+   :members:
+   :member-order: bysource
+
+.. automodule:: ogcat.replica_links
+   :members:
+   :member-order: bysource
+
 Repository boundary
 -------------------
 

--- a/docs/api/replicas.rst
+++ b/docs/api/replicas.rst
@@ -11,8 +11,6 @@ Secondary artifact internals are documented on the internals page.
 
 .. autofunction:: ogcat.replicas.plan_replica_view
 
-.. autofunction:: ogcat.replicas.replica_template_context
-
 .. autoclass:: ogcat.ReplicaViewPlan
    :members:
    :member-order: bysource

--- a/src/ogcat/replica_context.py
+++ b/src/ogcat/replica_context.py
@@ -1,0 +1,79 @@
+"""Template context helpers shared by replica planners and materializers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ogcat.models import CatalogRecord
+from ogcat.naming import (
+    RESERVED_TEMPLATE_FIELDS,
+    build_naming_context,
+    normalise_segment,
+    split_name_and_suffixes,
+)
+
+
+def replica_template_context(record: CatalogRecord) -> dict[str, object]:
+    """Build a template context from record metadata and locator fields."""
+    context: dict[str, object] = {}
+    context.update(record.derived_metadata)
+    context.update(record.user_metadata)
+
+    artifact_uuid = record.naming_metadata.get("artifact_uuid")
+    record_id = "" if record.id is None else str(record.id)
+    uuid_value = str(artifact_uuid or record_id)
+    original_name = _record_original_name(record)
+    naming_metadata = {
+        key: value for key, value in record.user_metadata.items() if key not in RESERVED_TEMPLATE_FIELDS
+    }
+    context.update(
+        build_naming_context(
+            record_id=record_id,
+            operation_id=uuid_value,
+            original_path=Path(original_name),
+            metadata=naming_metadata,
+            date_added=record.time_added[:10],
+        )
+    )
+    locator_path = record.path()
+    locator_name = "" if locator_path is None else locator_path.name
+    locator_stem, locator_suffix = split_name_and_suffixes(locator_name)
+
+    context.update(
+        {
+            "id": record_id,
+            "uuid": uuid_value,
+            "artifact_uuid": uuid_value,
+            "operation_id": uuid_value,
+            "date_added": record.time_added[:10],
+            "year_added": record.time_added[:4],
+            "record_type": record.record_type,
+            "storage_mode": record.storage_mode or "",
+            "locator_kind": record.locator.kind,
+            "locator_value": record.locator.value,
+            "locator_filename": locator_name,
+            "locator_stem": normalise_segment(locator_stem) if locator_stem else "",
+            "locator_suffix": locator_suffix,
+            "stored_relpath": record.stored_relpath or "",
+            "path": "" if locator_path is None else str(locator_path),
+        }
+    )
+    return context
+
+
+def _record_original_name(record: CatalogRecord) -> str:
+    """Return the best filename-like value available for a record."""
+    if record.original_filename:
+        return record.original_filename
+    locator_path = record.path()
+    if locator_path is not None:
+        return locator_path.name
+    locator_value = record.locator.value.rstrip("/")
+    if locator_value:
+        return locator_value.rsplit("/", 1)[-1]
+    return "artifact"
+
+
+__all__ = [
+    "replica_template_context",
+]

--- a/src/ogcat/replica_links.py
+++ b/src/ogcat/replica_links.py
@@ -1,0 +1,33 @@
+"""Shared local symlink helpers for replica materialization."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def relative_symlink_target(source_path: Path, *, link_path: Path) -> str | Path:
+    """Return a relative symlink target when the platform can represent one."""
+    try:
+        return os.path.relpath(source_path, start=link_path.parent)
+    except ValueError:
+        return source_path
+
+
+def symlink_points_to(link_path: Path, source_path: Path) -> bool:
+    """Return whether a symlink points at a source path."""
+    try:
+        link_target = Path(os.readlink(link_path))
+    except OSError:
+        return False
+    if not link_target.is_absolute():
+        link_target = (link_path.parent / link_target).resolve()
+    else:
+        link_target = link_target.resolve()
+    return link_target == source_path.resolve()
+
+
+__all__ = [
+    "relative_symlink_target",
+    "symlink_points_to",
+]

--- a/src/ogcat/replica_types.py
+++ b/src/ogcat/replica_types.py
@@ -1,0 +1,13 @@
+"""Shared replica type aliases."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ReplicaMode = Literal["symlink"]
+ReplicaRole = Literal["template_link", "view_link"]
+
+__all__ = [
+    "ReplicaMode",
+    "ReplicaRole",
+]

--- a/src/ogcat/replicas.py
+++ b/src/ogcat/replicas.py
@@ -6,27 +6,20 @@ artifacts but do not change catalog records.
 
 from __future__ import annotations
 
-import os
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Literal
 
-from ogcat.models import CatalogRecord, MetadataDict
-from ogcat.naming import (
-    RESERVED_TEMPLATE_FIELDS,
-    build_naming_context,
-    normalise_segment,
-    render_storage_location,
-    render_template,
-    split_name_and_suffixes,
+from ogcat.models import CatalogRecord
+from ogcat.naming import normalise_segment, render_template
+from ogcat.replica_context import replica_template_context
+from ogcat.replica_links import (
+    relative_symlink_target,
+    symlink_points_to,
 )
-from ogcat.operation_helpers import directory_from_relative_path
-
-ReplicaMode = Literal["symlink"]
-ReplicaRole = Literal["template_link", "view_link"]
+from ogcat.replica_types import ReplicaMode, ReplicaRole
 
 
 class ReplicaState(StrEnum):
@@ -110,29 +103,6 @@ class ReplicaApplyResult:
             ReplicaState.ERROR,
         }
         return [item for item in self.items if item.state in error_states]
-
-
-@dataclass(frozen=True, slots=True)
-class TemplateLinkReplicaMaterialization:
-    """Materialized default template replica details.
-
-    Args:
-        primary_path: Local primary path the symlink points at.
-        target_path: Local template replica symlink path.
-        catalog_relative_path: Replica path relative to the catalog root.
-        storage_relative_path: Replica path relative to the readable files root.
-        resolved_directory: Rendered template replica directory.
-        resolved_filename: Rendered template replica filename.
-        naming_metadata: Naming metadata to merge onto the catalog record.
-    """
-
-    primary_path: Path
-    target_path: Path
-    catalog_relative_path: str
-    storage_relative_path: str
-    resolved_directory: str
-    resolved_filename: str
-    naming_metadata: MetadataDict
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,120 +208,6 @@ def plan_replica_view(
     )
 
 
-def replica_template_context(record: CatalogRecord) -> dict[str, object]:
-    """Build a template context from record metadata and locator fields."""
-    context: dict[str, object] = {}
-    context.update(record.derived_metadata)
-    context.update(record.user_metadata)
-
-    artifact_uuid = record.naming_metadata.get("artifact_uuid")
-    record_id = "" if record.id is None else str(record.id)
-    uuid_value = str(artifact_uuid or record_id)
-    original_name = _record_original_name(record)
-    naming_metadata = {
-        key: value for key, value in record.user_metadata.items() if key not in RESERVED_TEMPLATE_FIELDS
-    }
-    context.update(
-        build_naming_context(
-            record_id=record_id,
-            operation_id=uuid_value,
-            original_path=Path(original_name),
-            metadata=naming_metadata,
-            date_added=record.time_added[:10],
-        )
-    )
-    locator_path = record.path()
-    locator_name = "" if locator_path is None else locator_path.name
-    locator_stem, locator_suffix = split_name_and_suffixes(locator_name)
-
-    context.update(
-        {
-            "id": record_id,
-            "uuid": uuid_value,
-            "artifact_uuid": uuid_value,
-            "operation_id": uuid_value,
-            "date_added": record.time_added[:10],
-            "year_added": record.time_added[:4],
-            "record_type": record.record_type,
-            "storage_mode": record.storage_mode or "",
-            "locator_kind": record.locator.kind,
-            "locator_value": record.locator.value,
-            "locator_filename": locator_name,
-            "locator_stem": normalise_segment(locator_stem) if locator_stem else "",
-            "locator_suffix": locator_suffix,
-            "stored_relpath": record.stored_relpath or "",
-            "path": "" if locator_path is None else str(locator_path),
-        }
-    )
-    return context
-
-
-def materialize_template_link_replica(
-    *,
-    catalog_root: Path,
-    files_root: Path,
-    record: CatalogRecord,
-    directory_template: str,
-    filename_template: str,
-    register_rollback: Callable[[Callable[[], None], str], object] | None = None,
-) -> TemplateLinkReplicaMaterialization | None:
-    """Create the default template symlink replica for a path-backed record.
-
-    Args:
-        catalog_root: Catalog root used for catalog-relative path metadata.
-        files_root: Human-readable template replica root.
-        record: Record whose primary path should be linked.
-        directory_template: Directory template to render.
-        filename_template: Filename template to render.
-        register_rollback: Optional rollback registration callback accepting an
-            action and a human-readable description.
-
-    Returns:
-        Materialized replica details, or ``None`` if the record is not
-        path-backed.
-    """
-    primary_path = record.path()
-    if primary_path is None:
-        return None
-    target, _catalog_relative_path, resolved_filename = render_storage_location(
-        files_root=files_root,
-        directory_template=directory_template,
-        filename_template=filename_template,
-        context=replica_template_context(record),
-        exists=lambda candidate: candidate.exists() or candidate.is_symlink(),
-    )
-    catalog_relative_path = target.relative_to(catalog_root).as_posix()
-    storage_relative_path = target.relative_to(files_root).as_posix()
-    resolved_directory = directory_from_relative_path(storage_relative_path) or ""
-    target.parent.mkdir(parents=True, exist_ok=True)
-    if register_rollback is not None:
-        register_rollback(
-            lambda path=target: path.unlink(missing_ok=True),
-            f"remove template symlink replica {target}",
-        )
-    target.symlink_to(_relative_symlink_target(primary_path, link_path=target))
-
-    naming_metadata = dict(record.naming_metadata)
-    naming_metadata.update(
-        {
-            "template_replica_path": str(target),
-            "template_replica_relative_path": catalog_relative_path,
-            "template_replica_storage_relative_path": storage_relative_path,
-            "template_resolved_directory": resolved_directory,
-            "template_resolved_filename": resolved_filename,
-        }
-    )
-    return TemplateLinkReplicaMaterialization(
-        primary_path=primary_path,
-        target_path=target,
-        catalog_relative_path=catalog_relative_path,
-        storage_relative_path=storage_relative_path,
-        resolved_directory=resolved_directory,
-        resolved_filename=resolved_filename,
-        naming_metadata=naming_metadata,
-    )
-
-
 def _plan_record_replica(
     *,
     root: Path,
@@ -441,7 +297,7 @@ def _apply_symlink_item(item: ReplicaPlanItem) -> ReplicaPlanItem:
     if existing_state is not None:
         return replace(item, state=existing_state[0], message=existing_state[1])
     item.target_path.parent.mkdir(parents=True, exist_ok=True)
-    item.target_path.symlink_to(_relative_symlink_target(item.source_path, link_path=item.target_path))
+    item.target_path.symlink_to(relative_symlink_target(item.source_path, link_path=item.target_path))
     return replace(item, state=ReplicaState.CREATED)
 
 
@@ -449,30 +305,9 @@ def _existing_target_state(target_path: Path, source_path: Path) -> tuple[Replic
     """Return the state implied by an existing target path."""
     if not target_path.exists() and not target_path.is_symlink():
         return None
-    if target_path.is_symlink() and _symlink_points_to(target_path, source_path):
+    if target_path.is_symlink() and symlink_points_to(target_path, source_path):
         return ReplicaState.UP_TO_DATE, f"Replica already points at {source_path}"
     return ReplicaState.COLLISION, f"Replica path already exists: {target_path}"
-
-
-def _symlink_points_to(link_path: Path, source_path: Path) -> bool:
-    """Return whether a symlink points at a source path."""
-    try:
-        link_target = Path(os.readlink(link_path))
-    except OSError:
-        return False
-    if not link_target.is_absolute():
-        link_target = (link_path.parent / link_target).resolve()
-    else:
-        link_target = link_target.resolve()
-    return link_target == source_path.resolve()
-
-
-def _relative_symlink_target(source_path: Path, *, link_path: Path) -> str | Path:
-    """Return a relative symlink target when the platform can represent one."""
-    try:
-        return os.path.relpath(source_path, start=link_path.parent)
-    except ValueError:
-        return source_path
 
 
 def _render_replica_path(root: Path, template: str, context: dict[str, object]) -> Path:
@@ -485,19 +320,6 @@ def _render_replica_path(root: Path, template: str, context: dict[str, object]) 
     if any(part in {".", ".."} for part in normalised_parts) or Path(rendered).is_absolute():
         raise ValueError(f"Replica template must render a relative path below the view root: {rendered}")
     return root.joinpath(*normalised_parts)
-
-
-def _record_original_name(record: CatalogRecord) -> str:
-    """Return the best filename-like value available for a record."""
-    if record.original_filename:
-        return record.original_filename
-    locator_path = record.path()
-    if locator_path is not None:
-        return locator_path.name
-    locator_value = record.locator.value.rstrip("/")
-    if locator_value:
-        return locator_value.rsplit("/", 1)[-1]
-    return "artifact"
 
 
 def _format_blocking_items(items: Sequence[ReplicaPlanItem]) -> str:
@@ -513,8 +335,5 @@ __all__ = [
     "ReplicaRole",
     "ReplicaState",
     "ReplicaViewPlan",
-    "TemplateLinkReplicaMaterialization",
-    "materialize_template_link_replica",
     "plan_replica_view",
-    "replica_template_context",
 ]

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -9,7 +9,8 @@ from typing import Literal, Protocol
 
 from ogcat.hooks import OperationContext
 from ogcat.models import CatalogRecord, MetadataDict
-from ogcat.replicas import ReplicaMode, materialize_template_link_replica
+from ogcat.replica_types import ReplicaMode
+from ogcat.template_replicas import materialize_template_link_replica
 from ogcat.transactions import UnitOfWork
 
 SecondaryArtifactRole = Literal["template_link"]

--- a/src/ogcat/template_replicas.py
+++ b/src/ogcat/template_replicas.py
@@ -1,0 +1,108 @@
+"""Default template-link replica materialization."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ogcat.models import CatalogRecord, MetadataDict
+from ogcat.naming import render_storage_location
+from ogcat.operation_helpers import directory_from_relative_path
+from ogcat.replica_context import replica_template_context
+from ogcat.replica_links import relative_symlink_target
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateLinkReplicaMaterialization:
+    """Materialized default template replica details.
+
+    Args:
+        primary_path: Local primary path the symlink points at.
+        target_path: Local template replica symlink path.
+        catalog_relative_path: Replica path relative to the catalog root.
+        storage_relative_path: Replica path relative to the readable files root.
+        resolved_directory: Rendered template replica directory.
+        resolved_filename: Rendered template replica filename.
+        naming_metadata: Naming metadata to merge onto the catalog record.
+    """
+
+    primary_path: Path
+    target_path: Path
+    catalog_relative_path: str
+    storage_relative_path: str
+    resolved_directory: str
+    resolved_filename: str
+    naming_metadata: MetadataDict
+
+
+def materialize_template_link_replica(
+    *,
+    catalog_root: Path,
+    files_root: Path,
+    record: CatalogRecord,
+    directory_template: str,
+    filename_template: str,
+    register_rollback: Callable[[Callable[[], None], str], object] | None = None,
+) -> TemplateLinkReplicaMaterialization | None:
+    """Create the default template symlink replica for a path-backed record.
+
+    Args:
+        catalog_root: Catalog root used for catalog-relative path metadata.
+        files_root: Human-readable template replica root.
+        record: Record whose primary path should be linked.
+        directory_template: Directory template to render.
+        filename_template: Filename template to render.
+        register_rollback: Optional rollback registration callback accepting an
+            action and a human-readable description.
+
+    Returns:
+        Materialized replica details, or ``None`` if the record is not
+        path-backed.
+    """
+    primary_path = record.path()
+    if primary_path is None:
+        return None
+    target, _catalog_relative_path, resolved_filename = render_storage_location(
+        files_root=files_root,
+        directory_template=directory_template,
+        filename_template=filename_template,
+        context=replica_template_context(record),
+        exists=lambda candidate: candidate.exists() or candidate.is_symlink(),
+    )
+    catalog_relative_path = target.relative_to(catalog_root).as_posix()
+    storage_relative_path = target.relative_to(files_root).as_posix()
+    resolved_directory = directory_from_relative_path(storage_relative_path) or ""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if register_rollback is not None:
+        register_rollback(
+            lambda path=target: path.unlink(missing_ok=True),
+            f"remove template symlink replica {target}",
+        )
+    target.symlink_to(relative_symlink_target(primary_path, link_path=target))
+
+    naming_metadata = dict(record.naming_metadata)
+    naming_metadata.update(
+        {
+            "template_replica_path": str(target),
+            "template_replica_relative_path": catalog_relative_path,
+            "template_replica_storage_relative_path": storage_relative_path,
+            "template_resolved_directory": resolved_directory,
+            "template_resolved_filename": resolved_filename,
+        }
+    )
+    return TemplateLinkReplicaMaterialization(
+        primary_path=primary_path,
+        target_path=target,
+        catalog_relative_path=catalog_relative_path,
+        storage_relative_path=storage_relative_path,
+        resolved_directory=resolved_directory,
+        resolved_filename=resolved_filename,
+        naming_metadata=naming_metadata,
+    )
+
+
+__all__ = [
+    "TemplateLinkReplicaMaterialization",
+    "materialize_template_link_replica",
+]

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -689,7 +689,7 @@ def test_add_file_rolls_back_record_when_naming_fails(
     def fail_render_storage_location(*args: object, **kwargs: object) -> None:
         raise ValueError("simulated naming failure")
 
-    monkeypatch.setattr("ogcat.replicas.render_storage_location", fail_render_storage_location)
+    monkeypatch.setattr("ogcat.template_replicas.render_storage_location", fail_render_storage_location)
 
     with pytest.raises(ValueError, match="simulated naming failure"):
         catalog.add_file(source)
@@ -715,7 +715,7 @@ def test_add_file_rolls_back_record_after_staged_insert_before_file_write(
     def fail_before_file_write(*args: object, **kwargs: object) -> None:
         raise RuntimeError("simulated post-insert failure")
 
-    monkeypatch.setattr("ogcat.replicas.render_storage_location", fail_before_file_write)
+    monkeypatch.setattr("ogcat.template_replicas.render_storage_location", fail_before_file_write)
 
     with pytest.raises(RuntimeError, match="simulated post-insert failure"):
         catalog.add_file(source)

--- a/tests/test_replicas.py
+++ b/tests/test_replicas.py
@@ -8,15 +8,12 @@ from pathlib import Path
 import pytest
 
 from ogcat import (
-    ArtifactLocator,
     Catalog,
     CatalogRecord,
     CatalogSpec,
-    OperationContext,
-    OperationSource,
     ReplicaState,
 )
-from ogcat.secondary_artifacts import TemplateLinkSecondaryArtifact
+from ogcat.replicas import plan_replica_view
 
 
 def _record_id(record: CatalogRecord) -> str:
@@ -33,68 +30,17 @@ def _source_file(tmp_path: Path, name: str, text: str = "payload") -> Path:
     return source
 
 
-def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
-    tmp_path: Path,
-) -> None:
-    """Template-link secondary operations create relative symlinks with rollback."""
-    root = tmp_path / "catalog"
-    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
-    primary_path = root / "data" / "objects" / "ab" / "abcdef.nc"
-    primary_path.parent.mkdir(parents=True, exist_ok=True)
-    primary_path.write_text("payload", encoding="utf-8")
-    record = CatalogRecord(
-        catalog="files",
-        time_added="2026-05-15T00:00:00Z",
-        id="record-1",
-        record_type="managed_file",
-        locator=ArtifactLocator.path(
-            primary_path,
-            relative_path="data/objects/ab/abcdef.nc",
-        ),
-        original_filename="alpha.nc",
-        suffixes=[".nc"],
-        naming_metadata={"artifact_uuid": "abcdef"},
-    )
-    operation = TemplateLinkSecondaryArtifact(
-        catalog_root=root,
-        files_root=root / "data" / "files",
-        directory_template="{year_added}/{original_stem}",
-        filename_template="{original_filename}",
-    )
-    expected_link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
-
-    with catalog.transaction() as transaction:
-        context = OperationContext(
-            catalog_root=root,
-            operation_id="operation-1",
-            operation_type="add_file",
-            record_type="managed_file",
-            user_metadata={},
-            derived_metadata={},
-            register_rollback=transaction.register_rollback,
-            source=OperationSource(kind="test"),
-        )
-        result = operation.run(transaction, context, record)
-        assert result is not None
-        link_path = Path(str(result.naming_metadata_updates["template_replica_path"]))
-        assert link_path == expected_link_path
-        assert result.role == "template_link"
-        assert result.mode == "symlink"
-        assert link_path.is_symlink()
-        assert not Path(os.readlink(link_path)).is_absolute()
-        assert link_path.resolve() == primary_path
-
-    assert not expected_link_path.exists()
-    assert not expected_link_path.is_symlink()
-
-
 def test_plan_view_does_not_create_links(tmp_path: Path) -> None:
     """Planning a view is a dry run with no filesystem side effects."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
     record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
     view_root = tmp_path / "view"
 
-    plan = catalog.plan_view(view_root, "{product}/{id}_{original_filename}")
+    plan = plan_replica_view(
+        root=view_root,
+        template="{product}/{id}_{original_filename}",
+        records=[record],
+    )
 
     assert len(plan.items) == 1
     item = plan.items[0]
@@ -111,7 +57,11 @@ def test_apply_symlink_view_creates_links_and_is_idempotent(tmp_path: Path) -> N
     primary_path = record.path()
     assert primary_path is not None
 
-    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+    plan = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}_{original_filename}",
+        records=[record],
+    )
     result = plan.apply()
     link_path = result.created[0].target_path
 
@@ -119,9 +69,10 @@ def test_apply_symlink_view_creates_links_and_is_idempotent(tmp_path: Path) -> N
     assert not Path(os.readlink(link_path)).is_absolute()
     assert link_path.resolve() == primary_path
 
-    second_result = catalog.plan_view(
-        tmp_path / "view",
-        "{product}/{id}_{original_filename}",
+    second_result = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}_{original_filename}",
+        records=[record],
     ).apply()
 
     assert second_result.created == []
@@ -134,8 +85,12 @@ def test_apply_skip_errors_reports_symlink_oserror_as_skipped(
 ) -> None:
     """skip_errors=True reports symlink failures in both skipped and errors."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
-    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
-    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    plan = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}_{original_filename}",
+        records=[record],
+    )
 
     def fail_symlink_to(
         self: Path,
@@ -157,11 +112,11 @@ def test_apply_skip_errors_reports_symlink_oserror_as_skipped(
 def test_view_reports_template_collisions(tmp_path: Path) -> None:
     """Plans report duplicate rendered paths before creating any links."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
-    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
-    catalog.add_file(_source_file(tmp_path, "beta.nc"), metadata={"product": "flux"})
+    first = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    second = catalog.add_file(_source_file(tmp_path, "beta.nc"), metadata={"product": "flux"})
     view_root = tmp_path / "view"
 
-    plan = catalog.plan_view(view_root, "same-name.nc")
+    plan = plan_replica_view(root=view_root, template="same-name.nc", records=[first, second])
 
     assert len(plan.collisions) == 2
     with pytest.raises(ValueError, match="same-name.nc"):
@@ -172,9 +127,13 @@ def test_view_reports_template_collisions(tmp_path: Path) -> None:
 def test_view_reports_unsupported_non_path_locators(tmp_path: Path) -> None:
     """URI records are reported as unsupported for local symlink views."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
-    catalog.add_reference(uri="https://example.org/data.nc", metadata={"product": "remote"})
+    record = catalog.add_reference(uri="https://example.org/data.nc", metadata={"product": "remote"})
 
-    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+    plan = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}.nc",
+        records=[record],
+    )
 
     assert len(plan.unsupported) == 1
     assert plan.unsupported[0].state == ReplicaState.UNSUPPORTED
@@ -192,7 +151,11 @@ def test_view_reports_missing_primary_targets(tmp_path: Path) -> None:
     assert primary_path is not None
     primary_path.unlink()
 
-    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+    plan = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}.nc",
+        records=[record],
+    )
 
     assert len(plan.missing_targets) == 1
     with pytest.raises(ValueError, match="Primary target does not exist"):
@@ -207,7 +170,11 @@ def test_apply_rechecks_missing_primary_targets_after_planning(tmp_path: Path) -
     record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
     primary_path = record.path()
     assert primary_path is not None
-    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+    plan = plan_replica_view(
+        root=tmp_path / "view",
+        template="{product}/{id}.nc",
+        records=[record],
+    )
     target_path = plan.items[0].target_path
     primary_path.unlink()
 
@@ -226,10 +193,14 @@ def test_apply_rechecks_missing_primary_targets_after_planning(tmp_path: Path) -
 def test_plan_view_rejects_normalized_parent_segments(tmp_path: Path) -> None:
     """Whitespace-padded parent-directory segments must not escape the view root."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
-    catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": " .. "})
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": " .. "})
 
     with pytest.raises(ValueError, match="relative path below the view root"):
-        catalog.plan_view(tmp_path / "view", "{product}/{id}.nc")
+        plan_replica_view(
+            root=tmp_path / "view",
+            template="{product}/{id}.nc",
+            records=[record],
+        )
 
 
 def test_view_regeneration_uses_updated_metadata_without_moving_primary(tmp_path: Path) -> None:

--- a/tests/test_secondary_artifacts.py
+++ b/tests/test_secondary_artifacts.py
@@ -1,0 +1,114 @@
+"""Secondary artifact operation tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ogcat import (
+    ArtifactLocator,
+    Catalog,
+    CatalogRecord,
+    CatalogSpec,
+    OperationContext,
+    OperationSource,
+)
+from ogcat.hooks import RollbackRegistrar
+from ogcat.secondary_artifacts import TemplateLinkSecondaryArtifact
+
+
+def _operation_context(root: Path, transaction_register: RollbackRegistrar) -> OperationContext:
+    """Build a minimal operation context for secondary artifact tests."""
+    return OperationContext(
+        catalog_root=root,
+        operation_id="operation-1",
+        operation_type="add_file",
+        record_type="managed_file",
+        user_metadata={},
+        derived_metadata={},
+        register_rollback=transaction_register,
+        source=OperationSource(kind="test"),
+    )
+
+
+def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
+    tmp_path: Path,
+) -> None:
+    """Template-link secondary operations create relative symlinks with rollback."""
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+    primary_path = root / "data" / "objects" / "ab" / "abcdef.nc"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("payload", encoding="utf-8")
+    record = CatalogRecord(
+        catalog="files",
+        time_added="2026-05-15T00:00:00Z",
+        id="record-1",
+        record_type="managed_file",
+        locator=ArtifactLocator.path(
+            primary_path,
+            relative_path="data/objects/ab/abcdef.nc",
+        ),
+        original_filename="alpha.nc",
+        suffixes=[".nc"],
+        naming_metadata={"artifact_uuid": "abcdef"},
+    )
+    operation = TemplateLinkSecondaryArtifact(
+        catalog_root=root,
+        files_root=root / "data" / "files",
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+    )
+    expected_link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
+
+    with catalog.transaction() as transaction:
+        result = operation.run(
+            transaction,
+            _operation_context(root, transaction.register_rollback),
+            record,
+        )
+        assert result is not None
+        link_path = Path(str(result.naming_metadata_updates["template_replica_path"]))
+        assert link_path == expected_link_path
+        assert result.role == "template_link"
+        assert result.mode == "symlink"
+        assert link_path.is_symlink()
+        assert not Path(os.readlink(link_path)).is_absolute()
+        assert link_path.resolve() == primary_path
+
+    assert not expected_link_path.exists()
+    assert not expected_link_path.is_symlink()
+
+
+def test_template_link_secondary_artifact_skips_non_path_records(tmp_path: Path) -> None:
+    """Template-link secondary operations skip records without local paths."""
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+    record = CatalogRecord(
+        catalog="files",
+        time_added="2026-05-15T00:00:00Z",
+        id="record-1",
+        record_type="managed_file",
+        locator=ArtifactLocator(kind="uri", value="https://example.org/data.nc"),
+        original_filename="alpha.nc",
+        suffixes=[".nc"],
+        naming_metadata={"artifact_uuid": "abcdef"},
+    )
+    operation = TemplateLinkSecondaryArtifact(
+        catalog_root=root,
+        files_root=root / "data" / "files",
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+    )
+    expected_link_path = root / "data" / "files" / "2026" / "alpha" / "alpha.nc"
+
+    with catalog.transaction() as transaction:
+        result = operation.run(
+            transaction,
+            _operation_context(root, transaction.register_rollback),
+            record,
+        )
+
+    assert result is None
+    assert not expected_link_path.exists()
+    assert not expected_link_path.is_symlink()

--- a/tests/test_template_replicas.py
+++ b/tests/test_template_replicas.py
@@ -1,0 +1,130 @@
+"""Template-link replica materialization tests."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from ogcat import ArtifactLocator, CatalogRecord
+from ogcat.template_replicas import materialize_template_link_replica
+
+
+def _path_record(primary_path: Path) -> CatalogRecord:
+    """Build a path-backed record for template-link materializer tests."""
+    return CatalogRecord(
+        catalog="files",
+        time_added="2026-05-15T00:00:00Z",
+        id="record-1",
+        record_type="managed_file",
+        locator=ArtifactLocator.path(
+            primary_path,
+            relative_path="data/objects/ab/abcdef.nc",
+        ),
+        original_filename="alpha.nc",
+        suffixes=[".nc"],
+        naming_metadata={"artifact_uuid": "abcdef"},
+    )
+
+
+def test_materialize_template_link_replica_records_metadata_and_relative_link(
+    tmp_path: Path,
+) -> None:
+    """Template-link materialization returns metadata and a relative symlink."""
+    root = tmp_path / "catalog"
+    files_root = root / "data" / "files"
+    primary_path = root / "data" / "objects" / "ab" / "abcdef.nc"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("payload", encoding="utf-8")
+    record = _path_record(primary_path)
+    expected_link_path = files_root / "2026" / "alpha" / "alpha.nc"
+
+    materialized = materialize_template_link_replica(
+        catalog_root=root,
+        files_root=files_root,
+        record=record,
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+    )
+
+    assert materialized is not None
+    assert materialized.primary_path == primary_path
+    assert materialized.target_path == expected_link_path
+    assert materialized.catalog_relative_path == "data/files/2026/alpha/alpha.nc"
+    assert materialized.storage_relative_path == "2026/alpha/alpha.nc"
+    assert materialized.resolved_directory == "2026/alpha"
+    assert materialized.resolved_filename == "alpha.nc"
+    assert materialized.naming_metadata["template_replica_path"] == str(expected_link_path)
+    assert materialized.naming_metadata["template_replica_relative_path"] == "data/files/2026/alpha/alpha.nc"
+    assert materialized.naming_metadata["template_replica_storage_relative_path"] == "2026/alpha/alpha.nc"
+    assert materialized.naming_metadata["template_resolved_directory"] == "2026/alpha"
+    assert materialized.naming_metadata["template_resolved_filename"] == "alpha.nc"
+    assert expected_link_path.is_symlink()
+    assert not Path(os.readlink(expected_link_path)).is_absolute()
+    assert expected_link_path.resolve() == primary_path
+
+
+def test_materialize_template_link_replica_registers_rollback(tmp_path: Path) -> None:
+    """Template-link materialization registers rollback for the created symlink."""
+    root = tmp_path / "catalog"
+    files_root = root / "data" / "files"
+    primary_path = root / "data" / "objects" / "ab" / "abcdef.nc"
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    primary_path.write_text("payload", encoding="utf-8")
+    record = _path_record(primary_path)
+    rollback_actions: list[Callable[[], None]] = []
+    rollback_descriptions: list[str] = []
+
+    def register_rollback(action: Callable[[], None], description: str) -> object:
+        rollback_actions.append(action)
+        rollback_descriptions.append(description)
+        return action
+
+    materialized = materialize_template_link_replica(
+        catalog_root=root,
+        files_root=files_root,
+        record=record,
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+        register_rollback=register_rollback,
+    )
+
+    assert materialized is not None
+    assert rollback_descriptions == [f"remove template symlink replica {materialized.target_path}"]
+    assert materialized.target_path.is_symlink()
+
+    rollback_actions[0]()
+
+    assert not materialized.target_path.exists()
+    assert not materialized.target_path.is_symlink()
+
+
+def test_materialize_template_link_replica_skips_non_path_records(tmp_path: Path) -> None:
+    """Template-link materialization skips records without local primary paths."""
+    root = tmp_path / "catalog"
+    files_root = root / "data" / "files"
+    record = CatalogRecord(
+        catalog="files",
+        time_added="2026-05-15T00:00:00Z",
+        id="record-1",
+        record_type="managed_file",
+        locator=ArtifactLocator(kind="uri", value="https://example.org/data.nc"),
+        original_filename="alpha.nc",
+        suffixes=[".nc"],
+        naming_metadata={"artifact_uuid": "abcdef"},
+    )
+
+    def register_rollback(action: Callable[[], None], description: str) -> object:
+        raise AssertionError("non-path records should not register rollback")
+
+    materialized = materialize_template_link_replica(
+        catalog_root=root,
+        files_root=files_root,
+        record=record,
+        directory_template="{year_added}/{original_stem}",
+        filename_template="{original_filename}",
+        register_rollback=register_rollback,
+    )
+
+    assert materialized is None
+    assert not (files_root / "2026" / "alpha" / "alpha.nc").exists()


### PR DESCRIPTION
## Summary

- Split generated replica view planning from default template-link materialization.
- Added internal replica context/type/link modules and moved template-link symlink materialization into `ogcat.template_replicas`.
- Moved tests toward owning interfaces: `plan_replica_view`, `TemplateLinkSecondaryArtifact`, and `materialize_template_link_replica`.
- Updated internal API docs to show the secondary-artifact/template-replica boundary.

## Architecture checkpoint

`ogcat.replicas` now focuses on generated replica view planning and application. Required template-link secondary artifacts depend on `ogcat.template_replicas` directly, so secondary materialization no longer hangs off the generated-view module. `Catalog.plan_view()` remains as the public facade smoke path.

Closes #89.

## Checks

- `uv run ruff check src/ogcat/replicas.py src/ogcat/secondary_artifacts.py src/ogcat/replica_context.py src/ogcat/replica_links.py src/ogcat/replica_types.py src/ogcat/template_replicas.py tests/test_add.py tests/test_replicas.py tests/test_secondary_artifacts.py tests/test_template_replicas.py`
- `uv run ruff format --check src/ogcat/replicas.py src/ogcat/secondary_artifacts.py src/ogcat/replica_context.py src/ogcat/replica_links.py src/ogcat/replica_types.py src/ogcat/template_replicas.py tests/test_add.py tests/test_replicas.py tests/test_secondary_artifacts.py tests/test_template_replicas.py`
- `uv run pyright`
- `uv run pytest`
- `uv run sphinx-build -b html docs docs/_build/html`