### PR TITLE
Clarify naming template field policy

### DIFF
--- a/MVP_SPEC.md
+++ b/MVP_SPEC.md
@@ -125,7 +125,11 @@ The context includes:
 - `year_month_or_original_stem`
 - `title_slug` when `title` metadata is present
 - all user metadata fields
-- the generated record id
+
+Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid`
+are reserved for record identity, audit, and storage planning. They are not
+public storage-template inputs. Use explicit metadata names such as
+`dataset_id` when a domain identifier should appear in a human-readable path.
 
 ### Collision handling
 

--- a/MVP_SPEC.md
+++ b/MVP_SPEC.md
@@ -126,12 +126,14 @@ The context includes:
 - `title_slug` when `title` metadata is present
 - user metadata fields that do not collide with generated field names
 
-Generated context names such as `date_added`, `year_added`, `original_stem`,
-and `title_slug` are reserved metadata keys. Internal identifiers such as
-`id`, `uuid`, `operation_id`, and `artifact_uuid` are also reserved for record
-identity, audit, and storage planning. They are not public storage-template
-inputs. Use explicit metadata names such as `dataset_id` when a domain
-identifier should appear in a human-readable path.
+When ogcat builds a storage naming context, generated context names such as
+`date_added`, `year_added`, `original_stem`, and `title_slug` are reserved
+metadata keys. Internal identifiers such as `id`, `uuid`, `operation_id`, and
+`artifact_uuid` are also reserved in template contexts for record identity,
+audit, and storage planning. They are not public storage-template inputs.
+Explicit-locator records that do not render schema naming templates are not
+subject to this template-context restriction. Use explicit metadata names such
+as `dataset_id` when a domain identifier should appear in a human-readable path.
 
 ### Collision handling
 

--- a/MVP_SPEC.md
+++ b/MVP_SPEC.md
@@ -124,12 +124,14 @@ The context includes:
 - `year_added`
 - `year_month_or_original_stem`
 - `title_slug` when `title` metadata is present
-- all user metadata fields
+- user metadata fields that do not collide with generated field names
 
-Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid`
-are reserved for record identity, audit, and storage planning. They are not
-public storage-template inputs. Use explicit metadata names such as
-`dataset_id` when a domain identifier should appear in a human-readable path.
+Generated context names such as `date_added`, `year_added`, `original_stem`,
+and `title_slug` are reserved metadata keys. Internal identifiers such as
+`id`, `uuid`, `operation_id`, and `artifact_uuid` are also reserved for record
+identity, audit, and storage planning. They are not public storage-template
+inputs. Use explicit metadata names such as `dataset_id` when a domain
+identifier should appear in a human-readable path.
 
 ### Collision handling
 

--- a/README.md
+++ b/README.md
@@ -198,10 +198,12 @@ path should be the primary storage location.
 
 Schema naming templates are intended for human-readable paths. They can use user metadata that
 does not collide with generated names, plus fields such as `date_added`, `year_added`,
-`original_stem`, `original_suffix`, and `title_slug`. Those generated names are reserved metadata
-keys. Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid` are also
-reserved for catalog bookkeeping and storage planning; use explicit metadata names such as
-`dataset_id` for domain identifiers that should appear in paths.
+`original_stem`, `original_suffix`, and `title_slug`. When ogcat builds a storage or
+template-link naming context, those generated names are reserved metadata keys. Internal
+identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid` are also reserved in
+template contexts; explicit-locator records that do not render schema naming templates are not
+subject to this template-context restriction. Use explicit metadata names such as `dataset_id`
+for domain identifiers that should appear in paths.
 
 Use `catalog.plan_artifact_storage(...)` to dry-run a planned target before writing. The returned
 `StoragePlan` contains the locator, write intent, and resolved naming outputs; pass record metadata

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ By default, `add_file()` stores the primary artifact under a UUID path and creat
 symlink replica for human-readable browsing. Pass `primary_location="template"` when the template
 path should be the primary storage location.
 
+Schema naming templates are intended for human-readable paths. They can use user metadata plus
+generated fields such as `year_added`, `original_stem`, `original_suffix`, and `title_slug`.
+Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid` are reserved for
+catalog bookkeeping and storage planning; use explicit metadata names such as `dataset_id` for
+domain identifiers that should appear in paths.
+
 Use `catalog.plan_artifact_storage(...)` to dry-run a planned target before writing. The returned
 `StoragePlan` contains the locator, write intent, and resolved naming outputs; pass record metadata
 explicitly when calling `add_artifact(storage_plan=...)`. The plan is available to hooks and artifact

--- a/README.md
+++ b/README.md
@@ -196,11 +196,12 @@ By default, `add_file()` stores the primary artifact under a UUID path and creat
 symlink replica for human-readable browsing. Pass `primary_location="template"` when the template
 path should be the primary storage location.
 
-Schema naming templates are intended for human-readable paths. They can use user metadata plus
-generated fields such as `year_added`, `original_stem`, `original_suffix`, and `title_slug`.
-Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid` are reserved for
-catalog bookkeeping and storage planning; use explicit metadata names such as `dataset_id` for
-domain identifiers that should appear in paths.
+Schema naming templates are intended for human-readable paths. They can use user metadata that
+does not collide with generated names, plus fields such as `date_added`, `year_added`,
+`original_stem`, `original_suffix`, and `title_slug`. Those generated names are reserved metadata
+keys. Internal identifiers such as `id`, `uuid`, `operation_id`, and `artifact_uuid` are also
+reserved for catalog bookkeeping and storage planning; use explicit metadata names such as
+`dataset_id` for domain identifiers that should appear in paths.
 
 Use `catalog.plan_artifact_storage(...)` to dry-run a planned target before writing. The returned
 `StoragePlan` contains the locator, write intent, and resolved naming outputs; pass record metadata

--- a/docs/api/classification.rst
+++ b/docs/api/classification.rst
@@ -1,0 +1,10 @@
+Artifact classification
+=======================
+
+These helpers build cheap, JSON-compatible classification metadata for records.
+They describe artifact shape and reader hints without opening scientific data
+payloads.
+
+.. autofunction:: ogcat.classification.classify_artifact
+
+.. autofunction:: ogcat.classification.collection_classification_metadata

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -17,6 +17,7 @@ Public API
    catalog
    audit
    models
+   classification
    search
    storage
    replicas

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -65,7 +65,10 @@ suffix list.
 
 ``naming_metadata``
 :   Internal metadata used to evaluate directory and filename templates.  You
-    do not normally need to read or set this directly.
+    do not normally need to read or set this directly. Fields such as
+    ``artifact_uuid`` are storage-planning details and are not public naming
+    template inputs; use explicit user metadata such as ``dataset_id`` for
+    domain identifiers that should appear in human-readable paths.
 
 ## Searching across namespaces
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -72,8 +72,8 @@ filename:  {title_slug|original_stem}{original_suffix}
 ### Naming template fields
 
 Storage and template-link naming templates are intended to produce
-human-readable paths. They may use user metadata fields plus these generated
-fields:
+human-readable paths. They may use user metadata fields that do not collide
+with reserved generated names, plus these generated fields:
 
 - ``date_added``: date used for the add operation, in ``YYYY-MM-DD`` form.
 - ``year_added``: year from ``date_added``.
@@ -85,6 +85,11 @@ fields:
   supplied.
 - ``year_month_or_original_stem``: ``YYYYMM`` from integer-like ``year`` and
   ``month`` metadata, ``YYYY`` from ``year`` alone, or ``original_stem``.
+
+The generated field names above are reserved metadata keys. For example,
+metadata cannot define ``date_added``, ``year_added``, ``original_stem``,
+``original_suffix``, or ``title_slug`` because ogcat owns those names when it
+builds the template context.
 
 Internal identifiers are deliberately not part of human-readable storage
 template policy. ``id``, ``uuid``, ``operation_id``, and ``artifact_uuid`` are

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -86,16 +86,19 @@ with reserved generated names, plus these generated fields:
 - ``year_month_or_original_stem``: ``YYYYMM`` from integer-like ``year`` and
   ``month`` metadata, ``YYYY`` from ``year`` alone, or ``original_stem``.
 
-The generated field names above are reserved metadata keys. For example,
+When ogcat builds a storage or template-link naming context, metadata for that
+naming operation cannot define the generated field names above. For example,
 metadata cannot define ``date_added``, ``year_added``, ``original_stem``,
-``original_suffix``, or ``title_slug`` because ogcat owns those names when it
-builds the template context.
+``original_suffix``, or ``title_slug`` because ogcat owns those names while
+rendering the template.
 
 Internal identifiers are deliberately not part of human-readable storage
 template policy. ``id``, ``uuid``, ``operation_id``, and ``artifact_uuid`` are
 reserved for catalog bookkeeping, storage planning, audit, and operation
-correlation. Metadata cannot use those names, and schema naming templates cannot
-reference them. If you need a user-visible identifier in a path, provide it as
+correlation. Schema naming templates cannot reference them, and metadata used
+to render those templates cannot define them. Explicit-locator records that do
+not render schema naming templates are not subject to this template-context
+restriction. If you need a user-visible identifier in a path, provide it as
 ordinary metadata with an explicit domain name such as ``dataset_id``.
 
 Generated replica views are different: they are built from existing

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -69,6 +69,34 @@ directory: {year_added}/{original_stem}
 filename:  {title_slug|original_stem}{original_suffix}
 ```
 
+### Naming template fields
+
+Storage and template-link naming templates are intended to produce
+human-readable paths. They may use user metadata fields plus these generated
+fields:
+
+- ``date_added``: date used for the add operation, in ``YYYY-MM-DD`` form.
+- ``year_added``: year from ``date_added``.
+- ``original_filename``: source filename used for naming.
+- ``original_stem``: normalized source filename without the preserved suffix.
+- ``original_suffix``: preserved source suffix such as ``.nc`` or
+  ``.tar.gz``.
+- ``title_slug``: slugified ``title`` metadata when a non-empty title is
+  supplied.
+- ``year_month_or_original_stem``: ``YYYYMM`` from integer-like ``year`` and
+  ``month`` metadata, ``YYYY`` from ``year`` alone, or ``original_stem``.
+
+Internal identifiers are deliberately not part of human-readable storage
+template policy. ``id``, ``uuid``, ``operation_id``, and ``artifact_uuid`` are
+reserved for catalog bookkeeping, storage planning, audit, and operation
+correlation. Metadata cannot use those names, and schema naming templates cannot
+reference them. If you need a user-visible identifier in a path, provide it as
+ordinary metadata with an explicit domain name such as ``dataset_id``.
+
+Generated replica views are different: they are built from existing
+``CatalogRecord`` objects and may use record fields such as ``id`` when that is
+useful for disambiguating a view.
+
 Pass ``primary_location="template"`` to keep the older template-primary
 behavior:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,14 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    # GitHub renders this snapshot's Mermaid fences. Exclude it from Sphinx
+    # until the generated docs site has Mermaid rendering configured.
+    "current-architecture-report.md",
+]
 
 html_theme = "furo"
 

--- a/docs/current-architecture-report.md
+++ b/docs/current-architecture-report.md
@@ -6,9 +6,13 @@ direction is to keep `Catalog`, `CatalogRecordSet`, and the CLI as public
 presentation surfaces while moving orchestration, domain policy, and persistence
 behind clearer internal interfaces.
 
+The diagrams use GitHub-rendered Mermaid fences. This snapshot is excluded from
+the Sphinx documentation build until the architecture and docs rendering setup
+are stable enough to publish diagrams in the generated docs site.
+
 ## Layer Map
 
-```text
+```mermaid
 flowchart TD
   CLI["CLI presentation"]
   Catalog["Catalog facade"]
@@ -49,7 +53,7 @@ flowchart TD
 
 ## Primary Add Flow
 
-```text
+```mermaid
 sequenceDiagram
   participant User
   participant Catalog
@@ -108,7 +112,7 @@ sequenceDiagram
 
 ## Data Model Sketch
 
-```text
+```mermaid
 classDiagram
   class CatalogSpec {
     catalog_name

--- a/docs/current-architecture-report.md
+++ b/docs/current-architecture-report.md
@@ -1,0 +1,235 @@
+# Current Architecture Report
+
+This report describes the architecture after the #84 refactor train through
+#92. It is a snapshot, not a claim that the structure is final. The main design
+direction is to keep `Catalog`, `CatalogRecordSet`, and the CLI as public
+presentation surfaces while moving orchestration, domain policy, and persistence
+behind clearer internal interfaces.
+
+## Layer Map
+
+```text
+flowchart TD
+  CLI["CLI presentation"]
+  Catalog["Catalog facade"]
+  RecordSet["CatalogRecordSet"]
+  App["CatalogApplication"]
+  Runner["AddOperationRunner"]
+  Hooks["HookManager / HookDispatcher"]
+  UOW["UnitOfWork"]
+  Planning["Storage planning / naming / classification"]
+  Materialization["Materialization targets / writers"]
+  Secondaries["Secondary artifact operations"]
+  Repository["CatalogRepository protocol"]
+  TinyDB["TinyDbCatalogRepository"]
+  Storage["Storage adapters"]
+  Audit["Audit sink"]
+
+  CLI --> Catalog
+  Catalog --> RecordSet
+  Catalog --> App
+  App --> Runner
+  Runner --> Hooks
+  Runner --> UOW
+  Runner --> Planning
+  Runner --> Materialization
+  Runner --> Secondaries
+  Runner --> Repository
+  Runner --> Audit
+  Materialization --> Storage
+  Repository --> TinyDB
+```
+
+| Layer | Components | Main responsibility |
+|-------|------------|---------------------|
+| Presentation/API | `Catalog`, `CatalogRecordSet`, CLI | Public Python and command-line workflows, argument coercion, user-facing compatibility |
+| Application/orchestration | `CatalogApplication`, `AddOperationRunner`, operation requests/services, hooks, unit of work | Operation sequencing, rollback boundaries, hook dispatch, audit coordination |
+| Domain/policy | naming, storage planning, materialization intent, classification, validation, replica planning, secondary artifacts | Catalog rules that are independent of the storage backend |
+| Data/infrastructure | repositories, TinyDB implementation, storage adapters, writers, audit sink | Persistence and filesystem or fsspec side effects |
+
+## Primary Add Flow
+
+```text
+sequenceDiagram
+  participant User
+  participant Catalog
+  participant App as CatalogApplication
+  participant Runner as AddOperationRunner
+  participant Hooks
+  participant Planner as Storage planner
+  participant Writer
+  participant Repo as Repository
+  participant Secondary as Secondary artifacts
+  participant Audit
+
+  User->>Catalog: add_file/add_artifact
+  Catalog->>Catalog: validate public arguments
+  Catalog->>App: delegate request construction
+  App->>Runner: AddOperationRequest
+  Runner->>Hooks: before/after metadata validation
+  Runner->>Planner: plan primary locator
+  Runner->>Hooks: resolve locator
+  Runner->>Writer: write/copy/move if required
+  Runner->>Hooks: extract metadata
+  Runner->>Repo: stage CatalogRecord
+  Runner->>Secondary: materialize ordered follow-up artifacts
+  Runner->>Hooks: after_record_write / before_commit / after_commit
+  Runner->>Audit: operation events
+```
+
+## CRC Cards
+
+| Class or module | Role | Collaborators |
+|-----------------|------|---------------|
+| `Catalog` | Public facade for create/open, add, reference, collection, search, metadata update, path resolution, spec updates, and audit access. | `CatalogSpec`, `CatalogApplication`, `CatalogRepository`, `HookManager`, `JsonlAuditSink`, `UnitOfWork`, `CatalogRecordSet`. |
+| `CatalogRecordSet` | Public result container for searches and record lists, including display helpers and optional dataframe conversion. | `CatalogRecord`, search output, CLI. |
+| CLI (`cli.py`) | Command-line presentation layer: parse arguments, call `Catalog`, render tables and machine-readable output. | `Catalog`, `CatalogRecordSet`, `SearchQuery`, `RecordSchema`. |
+| `CatalogSpec` / `RecordSchema` | Self-describing catalog configuration and schema defaults stored in `catalog.json`. | `Catalog`, validation, CLI. |
+| `CatalogRecord` / `ArtifactLocator` | Persisted record model and locator abstraction. Keeps compatibility path fields while the locator model becomes primary. | repository, storage planning, search, record sets, validation. |
+| `CatalogApplication` | Internal application service that turns public add requests into runner requests, chooses copy/move writers, and schedules secondary artifacts. | `Catalog`, `AddOperationRunner`, storage planning, writers, `TemplateLinkSecondaryArtifact`. |
+| `AddOperationRunner` | Lifecycle coordinator for add operations: validation, hooks, storage planning, writing, record staging, secondary artifacts, commit, rollback, audit. | `AddOperationRequest`, `OperationServices`, `HookDispatcher`, `UnitOfWork`, writers, repository, audit sink. |
+| `OperationServices` | Bundle of runner dependencies and callbacks. | `Catalog`, hooks, repository, validation, audit. |
+| `OperationContext` | Mutable operation-scoped context shared with hooks and writers. | hooks, writers, runner, storage plans, rollback registrar. |
+| Hook protocols / `HookDispatcher` | Structural plugin extension points for lifecycle phases. | `OperationContext`, `ValidationReport`, `HookManager`, runner. |
+| `UnitOfWork` | Best-effort rollback coordinator for staged record writes and side-effect cleanup. | repository, writers, secondary artifacts, hooks. |
+| `CatalogRepository` | Backend protocol for record persistence and search. | `Catalog`, runner, `TinyDbCatalogRepository`, `CatalogRecord`. |
+| `TinyDbCatalogRepository` | Current TinyDB-backed repository implementation. | TinyDB, search predicates, `CatalogRecord`. |
+| `SearchQuery` and search helpers | Backend-neutral search terms and in-memory matching semantics. | repository, `CatalogRecordSet`, CLI. |
+| Naming module | Template rendering, generated naming context, public versus internal template-field policy. | storage planning, template replicas, replica views. |
+| Storage planning | Primary locator policy for UUID, template, and user-provided targets. | naming, locators, storage roots, `StoragePlan`. |
+| Materialization module | Internal representation of how planned targets become write targets. | operation runner, storage plans, writers. |
+| Storage adapters | Local and fsspec-like target operations. | writers, storage planning, artifact locators. |
+| Writers | Copy, move, unzip, function, and memory/path writer helpers. | `OperationContext`, `OperationSource`, `ArtifactLocator`, storage helpers. |
+| Classification | Cheap artifact and collection classification metadata. | `Catalog.add_collection`, record metadata, docs/examples. |
+| `SecondaryArtifactOperation` | Ordered post-record operations inside the add rollback boundary. | runner, `UnitOfWork`, `CatalogRecord`. |
+| `TemplateLinkSecondaryArtifact` / `template_replicas` | Required human-readable symlink for UUID primary managed files. | naming, transactions, replica link helpers, runner. |
+| `replicas` | Generated local symlink view planning and application for existing records. | `Catalog.plan_view`, `CatalogRecord`, replica context, link helpers. |
+| Audit sink and events | Structured operation logging and CLI failure correlation. | runner, `Catalog`, CLI, `UnitOfWork`. |
+
+## Data Model Sketch
+
+```text
+classDiagram
+  class CatalogSpec {
+    catalog_name
+    default_schema
+    record_schemas
+  }
+  class RecordSchema {
+    directory_template
+    filename_template
+    metadata_fields
+  }
+  class CatalogRecord {
+    id
+    catalog
+    record_type
+    locator
+    user_metadata
+    derived_metadata
+    naming_metadata
+  }
+  class ArtifactLocator {
+    kind
+    value
+    relative_path
+  }
+  class CatalogRepository {
+    <<protocol>>
+    insert(record)
+    update(record)
+    search(query)
+  }
+
+  CatalogSpec --> RecordSchema
+  CatalogRecord --> ArtifactLocator
+  CatalogRepository --> CatalogRecord
+```
+
+## Current Responsibility Hotspots
+
+### `Catalog`
+
+`Catalog` has moved toward a facade, but it still has several reasons to
+change:
+
+- public API argument validation and coercion
+- catalog creation/opening and spec serialization
+- schema and metadata mutation APIs
+- audit event adaptation
+- repository and runner dependency construction
+- search and record-set construction
+- compatibility helpers such as path resolution
+
+This is the largest single-responsibility concern. The direction is correct,
+but more extraction would make changes less risky.
+
+### `CatalogApplication`
+
+`CatalogApplication` is the right kind of orchestration boundary, but it still
+depends on a concrete `Catalog` object and reaches through catalog helper
+methods. A smaller services protocol would better satisfy dependency inversion.
+
+### `OperationContext`
+
+`OperationContext` is intentionally broad because hooks and writers need a
+shared mutable object. That makes it flexible, but phase-specific access is not
+expressed in the type system. Hook authors can see fields that may be invalid
+or not meaningful in the current phase.
+
+### Storage Planning
+
+Storage planning is function-based and currently branches over UUID, template,
+URL-path, local-root, and user-provided placement. This is readable today, but
+new placement policies may make the module harder to change without strategy
+objects or a planner protocol.
+
+### Metadata And Naming
+
+User metadata, derived metadata, classification metadata, naming metadata, and
+top-level record fields are now distinct, but several modules still need to
+know parts of the resolution policy. The #92 field policy helps by separating
+human-readable naming fields from internal identifiers, but naming remains a
+central domain rule that deserves careful tests.
+
+## SOLID Review
+
+| Principle | Current state |
+|-----------|---------------|
+| Single responsibility | Improving. `AddOperationRunner`, storage planning, secondary artifacts, and repository are now clearer. `Catalog` and `OperationContext` remain broad. |
+| Open/closed | Mixed. Hook protocols, writer protocols, repository protocol, and storage adapters support extension. Storage placement still uses branching in functions. |
+| Liskov substitution | Good where protocols are explicit: repository, hooks, writers, secondary artifact operations. Concrete code should keep depending on those protocols where possible. |
+| Interface segregation | Good for hook phase protocols and repository. Less strong for `OperationContext` and `CatalogApplication`, which expose broad collaborators. |
+| Dependency inversion | Repository is the strongest example. `CatalogApplication` depending on concrete `Catalog` is the main remaining inversion gap. |
+
+## Suggested Improvements
+
+1. Split `Catalog` internals into smaller services:
+   schema/spec service, metadata update service, audit adapter, and operation
+   service factory.
+
+2. Replace `CatalogApplication(catalog: Catalog)` with explicit service
+   protocols for the operations it needs. That would keep the application layer
+   from depending on facade private methods.
+
+3. Introduce storage planner strategies before adding more placement policies.
+   `UuidPrimaryPlanner`, `TemplatePrimaryPlanner`, and `UserProvidedPlanner`
+   could share a protocol while keeping current function wrappers for
+   compatibility.
+
+4. Consider phase-specific hook context views. The runtime can keep one mutable
+   `OperationContext`, but protocols could expose narrower read/write surfaces
+   for validation, locator resolution, writing, and post-write hooks.
+
+5. Keep collection semantics above storage adapters. Storage targets should
+   remain file-like or directory-like; collection behavior should stay in
+   domain policy and classification metadata.
+
+6. Move CLI display formatting into helper modules if command complexity grows.
+   The CLI should remain presentation logic over the Python API, not a second
+   orchestration layer.
+
+7. Keep interface tests close to the owning module. Public `Catalog` tests
+   should cover behavior smoke/regression cases; lower-level behavior should be
+   asserted against storage planners, materializers, runners, repositories, and
+   secondary artifact interfaces.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -245,10 +245,9 @@ Questions to resolve in that PR:
 - should repository `insert(...)` return the assigned id, or the full persisted
   `CatalogRecord`?
 - what is the cleanest shape for batch insert return values?
-- how should managed-file naming behave if templates want `{id}` before the
-  record is persisted?
-- should id-based naming remain supported, or should it become discouraged or
-  removed from the default design?
+- follow-up from #92: managed storage templates should not depend on `{id}`
+  before the record is persisted; generated replica views may use persisted
+  record ids after write
 - how much query expressiveness should the repository interface expose before it
   becomes too backend-specific?
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,6 @@ searching records.
    :caption: Development notes
 
    architecture
-   current-architecture-report
    roadmap
    ideas
    adr/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ searching records.
    :caption: Development notes
 
    architecture
+   current-architecture-report
    roadmap
    ideas
    adr/index

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -251,20 +251,21 @@ move, or open the NetCDF members. The explicit ``collection_pattern`` and
 
 ### 3. Process the collection into a Zarr artifact
 
-The processing writer is domain code. A small helper turns the collection record
-into an operation source by using the collection's reader and glob hints. The
-writer opens the matching NetCDF members with ``xarray.open_mfdataset()``, calls
-a project-specific ``create_cams_bc()`` function, and writes the returned
-dataset to a single ``.zarr`` store.
+The processing writer is domain code. A small helper uses the collection's
+reader and glob hints to open the matching NetCDF members with
+``xarray.open_mfdataset()`` and pass the opened dataset as the operation-source
+payload. A function writer consumes that dataset, calls a project-specific
+``create_cams_bc()`` function, and writes the returned dataset to a single
+``.zarr`` store.
 
 ```python
-import shutil
-from dataclasses import dataclass
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import xarray as xr
 
-from ogcat import ArtifactLocator, CatalogRecord, OperationContext, OperationSource, memory_source
+from ogcat import CatalogRecord, OperationSource, memory_source, source_writer
 
 
 def create_cams_bc(ds: xr.Dataset, *, species: str, domain: str) -> xr.Dataset:
@@ -272,8 +273,9 @@ def create_cams_bc(ds: xr.Dataset, *, species: str, domain: str) -> xr.Dataset:
     ...
 
 
-def xarray_collection_source(record: CatalogRecord, **metadata: object) -> OperationSource:
-    """Build an operation source from a collection record's xarray hints."""
+@contextmanager
+def xarray_collection_source(record: CatalogRecord, **metadata: object) -> Iterator[OperationSource]:
+    """Open a collection record as an xarray-backed operation source."""
     collection_root = record.path()
     if collection_root is None:
         raise ValueError("Expected collection record to have a local path.")
@@ -291,57 +293,42 @@ def xarray_collection_source(record: CatalogRecord, **metadata: object) -> Opera
     source_metadata = {
         "collection_record_id": record.id,
         "collection_pattern": collection_pattern,
+        "input_file_count": len(input_paths),
         "input_paths": [str(path) for path in input_paths],
         "reader_hint": classification["reader_hint"],
     }
     source_metadata.update(metadata)
-    return memory_source(None, kind="xarray_netcdf_collection", metadata=source_metadata)
 
-
-@dataclass(frozen=True)
-class CamsBoundaryConditionWriter:
-    """Write processed CAMS boundary conditions to a planned Zarr directory."""
-
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        target_path = target.as_path()
-        if target_path is None:
-            raise ValueError("CAMS boundary-condition writer requires a path target.")
-        if target_path.exists():
-            raise FileExistsError(target_path)
-
-        input_paths = [Path(path) for path in source.metadata["input_paths"]]
-        species = str(source.metadata.get("species", "co2"))
-        processing_domain = str(source.metadata["processing_domain"])
-
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        context.rollback(
-            lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
-            description=f"remove processed Zarr store {target_path}",
+    with xr.open_mfdataset(input_paths) as ds:
+        yield memory_source(
+            ds,
+            kind="xarray_netcdf_collection",
+            metadata=source_metadata,
         )
 
-        with xr.open_mfdataset(input_paths) as ds:
-            processed = create_cams_bc(ds, species=species, domain=processing_domain)
-            processed.to_zarr(target_path, mode="w")
 
-        context.derived_metadata.update(
-            {
-                "input_record_id": source.metadata["collection_record_id"],
-                "raw_zip_record_id": source.metadata["raw_zip_record_id"],
-                "input_file_count": len(input_paths),
-                "input_collection_pattern": source.metadata["collection_pattern"],
-                "input_reader": source.metadata["reader_hint"],
-                "species": species,
-                "bc_input": "cams",
-                "bc_input_version": "cams73_latest",
-                "domain": processing_domain.lower(),
-                "reader_hint": "xarray.open_zarr",
-            }
-        )
+def write_cams_boundary_conditions(source: OperationSource, target: Path) -> dict[str, object]:
+    """Write processed CAMS boundary conditions from an opened xarray dataset."""
+    if not isinstance(source.payload, xr.Dataset):
+        raise TypeError("Expected source.payload to be an xarray Dataset.")
+
+    species = str(source.metadata.get("species", "co2"))
+    processing_domain = str(source.metadata["processing_domain"])
+    processed = create_cams_bc(source.payload, species=species, domain=processing_domain)
+    processed.to_zarr(target, mode="w")
+
+    return {
+        "input_record_id": source.metadata["collection_record_id"],
+        "raw_zip_record_id": source.metadata["raw_zip_record_id"],
+        "input_file_count": source.metadata["input_file_count"],
+        "input_collection_pattern": source.metadata["collection_pattern"],
+        "input_reader": source.metadata["reader_hint"],
+        "species": species,
+        "bc_input": "cams",
+        "bc_input_version": "cams73_latest",
+        "domain": processing_domain.lower(),
+        "reader_hint": "xarray.open_zarr",
+    }
 ```
 
 Plan and write the processed artifact:
@@ -368,18 +355,23 @@ processed_plan = catalog.plan_artifact_storage(
     metadata=processed_metadata,
 )
 
-processed_record = catalog.add_artifact(
-    record_type="boundary_conditions",
-    storage_plan=processed_plan,
-    metadata=processed_metadata,
-    source=xarray_collection_source(
-        collection_record,
-        raw_zip_record_id=raw_zip_record.id,
-        species="co2",
-        processing_domain="EUROPE",
-    ),
-    artifact_writer=CamsBoundaryConditionWriter(),
-)
+with xarray_collection_source(
+    collection_record,
+    raw_zip_record_id=raw_zip_record.id,
+    species="co2",
+    processing_domain="EUROPE",
+) as source:
+    processed_record = catalog.add_artifact(
+        record_type="boundary_conditions",
+        storage_plan=processed_plan,
+        metadata=processed_metadata,
+        source=source,
+        artifact_writer=source_writer(
+            write_cams_boundary_conditions,
+            target_kind="directory",
+            source_kind="xarray_netcdf_collection",
+        ),
+    )
 ```
 
 The resulting record is a generic directory artifact whose locator points to the

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -260,7 +260,11 @@ collection_record = catalog.add_artifact(
 The resulting record points at a managed directory under ``data/objects``. It is
 still one logical dataset, not 36 separate file records. The explicit
 ``collection_pattern`` and ``reader_hint`` in the classification metadata
-document how downstream code should read the members.
+document how downstream code should read the members. This uses the lower-level
+artifact writer path because managed collections are not yet a first-class
+``add_collection(...)`` write target. When that API grows, archive-to-collection
+workflows should be expressible without manually attaching collection
+classification metadata.
 
 ### 3. Process the collection into a Zarr artifact
 
@@ -366,6 +370,7 @@ processed_plan = catalog.plan_artifact_storage(
     target_kind="directory",
     write_mode="write",
     metadata=processed_metadata,
+    primary_location="template",
 )
 
 with xarray_collection_source(
@@ -388,9 +393,10 @@ with xarray_collection_source(
 ```
 
 The resulting record is a generic directory artifact whose locator points to the
-``.zarr`` store. The fact that it can be opened with xarray, and the provenance
-needed to rebuild it, are ordinary metadata rather than special ogcat core
-concepts.
+schema-rendered ``.zarr`` store at
+``boundary_conditions/co2/europe/cams_co2_europe.zarr``. The fact that it can be
+opened with xarray, and the provenance needed to rebuild it, are ordinary
+metadata rather than special ogcat core concepts.
 
 ### Variant: build the fsspec input at processing time
 
@@ -529,6 +535,7 @@ fsspec_processed_plan = catalog.plan_artifact_storage(
     target_kind="directory",
     write_mode="write",
     metadata=fsspec_processed_metadata,
+    primary_location="template",
 )
 
 fsspec_processed_record = catalog.add_artifact(

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -666,8 +666,9 @@ This pattern records an external URI first, then creates a managed local copy
 with a custom writer. It is useful when downloads are performed by ``requests``,
 ``curl``, an authenticated client, or a project-specific API.
 
-The catalog can use UUIDs in storage names so the downloaded filename does not
-need to be meaningful:
+The catalog can use its default UUID primary placement so the downloaded source
+filename does not need to be meaningful. The schema template remains
+human-readable:
 
 ```python
 from pathlib import Path
@@ -680,7 +681,7 @@ catalog = Catalog.create(
         catalog_name="downloads",
         default_schema=RecordSchema(
             directory_template="downloads/{year_added}",
-            filename_template="{uuid}{original_suffix}",
+            filename_template="{title_slug|original_stem}{original_suffix}",
         ),
     ),
 )

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -7,8 +7,9 @@ network-specific work.
 ## CAMS zip to processed boundary conditions
 
 This workflow tracks a raw CAMS download, extracts its NetCDF members into a
-managed directory artifact, and writes a processed Zarr store with provenance
-linking the output back to the raw inputs.
+pipeline-controlled directory, records those members as one collection artifact,
+and writes a processed Zarr store with provenance linking the output back to
+the raw inputs.
 
 The example uses the CAMS global inversion-optimised greenhouse gas fluxes and
 concentrations dataset from the Copernicus Atmosphere Data Store:
@@ -31,6 +32,9 @@ cams73_latest_co2_conc_surface_inst_202002.nc
 cams73_latest_co2_conc_surface_inst_202212.nc
 ```
 
+The archive listing contains 36 monthly NetCDF files covering 2020-01 through
+2022-12, with a total uncompressed size of 184,833,238,572 bytes.
+
 In this naming convention, ``latest`` is the input version, ``co2`` is the
 species, ``conc`` means concentration, and ``surface_inst`` indicates surface in
 situ observations. The ``73`` in ``cams73`` is kept as part of the upstream input
@@ -38,10 +42,10 @@ version string because the workflow does not interpret it further.
 
 ### Catalog spec
 
-The raw data schemas use readable title slugs and year/month fields when those
-are present. Raw files and extracted raw collections live under ``files/raw``.
-The processed boundary-condition schema uses species, domain, and boundary
-condition input metadata.
+The raw download and extracted NetCDF collection are explicit references. They
+do not use schema templates because ogcat is not choosing their storage
+locations. The processed boundary-condition schema does use templates because
+ogcat owns the Zarr output target.
 
 ```python
 from pathlib import Path
@@ -49,48 +53,50 @@ from pathlib import Path
 from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 
 
-def required_field(name: str, description: str) -> MetadataFieldDescription:
-    """Describe a required metadata field."""
-    return MetadataFieldDescription(name=name, description=description, required=True)
+species_field = MetadataFieldDescription(
+    name="species",
+    description="Species represented by the data.",
+    required=True,
+)
+product_field = MetadataFieldDescription(
+    name="product",
+    description="Upstream product or data family.",
+    required=True,
+)
+title_field = MetadataFieldDescription(
+    name="title",
+    description="Human-readable data title.",
+    required=True,
+)
+domain_field = MetadataFieldDescription(
+    name="domain",
+    description="Processing or model domain.",
+    required=True,
+)
+bc_input_field = MetadataFieldDescription(
+    name="bc_input",
+    description="Boundary-condition input product.",
+    required=True,
+)
 
 catalog = Catalog.create(
     Path("cams-bc-catalog"),
     CatalogSpec(
         catalog_name="cams_bc",
-        default_schema=RecordSchema(
-            directory_template="raw/{product}/{species}",
-            filename_template="{title_slug|original_stem}_{year_month_or_original_stem}{original_suffix}",
-        ),
         record_schemas={
             "raw_download": RecordSchema(
                 description="Raw downloaded files, including archives.",
-                directory_template="raw/{product}/{species}",
-                filename_template="{title_slug|original_stem}{original_suffix}",
-                metadata_fields=[
-                    required_field("species", "Species represented by the data."),
-                    required_field("product", "Upstream product or data family."),
-                    required_field("title", "Human-readable data title."),
-                ],
+                metadata_fields=[species_field, product_field, title_field],
             ),
             "raw_netcdf_collection": RecordSchema(
-                description="Raw NetCDF file collections extracted from archive artifacts.",
-                directory_template="raw/{product}/{species}",
-                filename_template="{title_slug|original_stem}",
-                metadata_fields=[
-                    required_field("species", "Species represented by the data."),
-                    required_field("product", "Upstream product or data family."),
-                    required_field("title", "Human-readable data title."),
-                ],
+                description="Raw NetCDF collections extracted from archive artifacts.",
+                metadata_fields=[species_field, product_field, title_field],
             ),
             "boundary_conditions": RecordSchema(
                 description="Processed boundary-condition stores.",
                 directory_template="boundary_conditions/{species}/{domain}",
                 filename_template="{bc_input}_{species}_{domain}.zarr",
-                metadata_fields=[
-                    required_field("species", "Species represented by the data."),
-                    required_field("domain", "Processing or model domain."),
-                    required_field("bc_input", "Boundary-condition input product."),
-                ],
+                metadata_fields=[species_field, domain_field, bc_input_field],
             ),
         },
     ),
@@ -112,6 +118,13 @@ locator and metadata but does not copy or inspect the archive.
 ```python
 from datetime import date
 from pathlib import Path
+
+CAMS_MEMBER_PATTERN = "cams73_latest_co2_conc_surface_inst_*.nc"
+CAMS_EXPECTED_MEMBERS = [
+    f"cams73_latest_co2_conc_surface_inst_{year}{month:02d}.nc"
+    for year in range(2020, 2023)
+    for month in range(1, 13)
+]
 
 downloaded_zip = Path("~/Downloads/bab75005df9571750d518b0aacdedb35.zip").expanduser()
 ads_dataset = (
@@ -135,22 +148,76 @@ raw_zip_record = catalog.add_reference(
             "contains global concentration fields for CO2."
         ),
         "archive_name": downloaded_zip.name,
-        "archive_member_glob": "*.nc",
-        "member_count": 36,
+        "archive_member_glob": CAMS_MEMBER_PATTERN,
+        "member_count": len(CAMS_EXPECTED_MEMBERS),
         "time_coverage": "2020-01/2022-12",
+        "uncompressed_bytes": 184_833_238_572,
         "bc_input": "cams",
         "bc_input_version": "cams73_latest",
     },
 )
 ```
 
-### 2. Extract the NetCDF collection into managed storage
+### 2. Extract and record the NetCDF collection
 
-The extracted collection is a directory artifact. ``UnzipArtifactWriter`` owns
-the write operation and rollback cleanup. ogcat owns the plan and record.
+The extraction location is chosen by the pipeline, not by a catalog naming
+template. This is useful for raw scientific inputs: the physical files stay in a
+domain-controlled workspace, while ogcat records the logical collection and the
+member pattern that downstream code should read.
 
 ```python
-from ogcat import UnzipArtifactWriter, path_source
+import fnmatch
+import shutil
+import zipfile
+
+
+def extract_cams_members(
+    zip_path: Path,
+    target_dir: Path,
+    *,
+    member_pattern: str,
+    expected_members: list[str],
+) -> list[Path]:
+    """Extract matching CAMS members into a pipeline-controlled directory."""
+    if target_dir.exists():
+        raise FileExistsError(target_dir)
+    target_dir.mkdir(parents=True)
+
+    try:
+        with zipfile.ZipFile(zip_path) as archive:
+            members = {
+                Path(member.filename).name: member
+                for member in archive.infolist()
+                if not member.is_dir() and fnmatch.fnmatch(Path(member.filename).name, member_pattern)
+            }
+            expected_names = sorted(expected_members)
+            matched_names = sorted(members)
+            if matched_names != expected_names:
+                missing = sorted(set(expected_names) - set(matched_names))
+                unexpected = sorted(set(matched_names) - set(expected_names))
+                raise ValueError(f"Unexpected CAMS members: missing={missing}, unexpected={unexpected}.")
+
+            extracted: list[Path] = []
+            for name in expected_names:
+                member = members[name]
+                destination = target_dir / Path(member.filename).name
+                with archive.open(member) as source_file, destination.open("wb") as target_file:
+                    shutil.copyfileobj(source_file, target_file)
+                extracted.append(destination)
+    except Exception:
+        shutil.rmtree(target_dir, ignore_errors=True)
+        raise
+
+    return sorted(extracted)
+
+
+extracted_dir = Path("raw-cams-work/cams73_latest_co2_conc_surface_inst_202001-202212")
+extract_cams_members(
+    downloaded_zip,
+    extracted_dir,
+    member_pattern=CAMS_MEMBER_PATTERN,
+    expected_members=CAMS_EXPECTED_MEMBERS,
+)
 
 collection_metadata = {
     "species": "co2",
@@ -160,35 +227,35 @@ collection_metadata = {
     "source_record_id": raw_zip_record.id,
     "source_url": ads_dataset,
     "archive_name": downloaded_zip.name,
-    "archive_member_glob": "*.nc",
-    "member_count": 36,
+    "archive_member_glob": CAMS_MEMBER_PATTERN,
+    "member_count": len(CAMS_EXPECTED_MEMBERS),
     "time_coverage": "2020-01/2022-12",
     "bc_input": "cams",
     "bc_input_version": "cams73_latest",
 }
 
-collection_plan = catalog.plan_artifact_storage(
-    downloaded_zip,
+collection_record = catalog.add_collection(
+    extracted_dir,
     record_type="raw_netcdf_collection",
-    target_kind="directory",
-    write_mode="write",
     metadata=collection_metadata,
-)
-
-collection_record = catalog.add_artifact(
-    record_type="raw_netcdf_collection",
-    storage_plan=collection_plan,
-    metadata=collection_metadata,
-    source=path_source(downloaded_zip, kind="zip_file"),
-    artifact_writer=UnzipArtifactWriter(),
+    collection_pattern=CAMS_MEMBER_PATTERN,
+    member_format="netcdf",
+    member_suffixes=[".nc"],
+    reader_hint="xarray.open_mfdataset",
 )
 ```
 
+``add_collection(...)`` records one logical dataset. It does not scan, copy,
+move, or open the NetCDF members. The explicit ``collection_pattern`` and
+``reader_hint`` document how the collection should be read.
+
 ### 3. Process the collection into a Zarr artifact
 
-The processing writer is domain code. It opens the extracted NetCDF files with
-``xarray.open_mfdataset()``, calls a project-specific ``create_cams_bc()``
-function, and writes the returned dataset to a single ``.zarr`` store.
+The processing writer is domain code. A small helper turns the collection record
+into an operation source by using the collection's reader and glob hints. The
+writer opens the matching NetCDF members with ``xarray.open_mfdataset()``, calls
+a project-specific ``create_cams_bc()`` function, and writes the returned
+dataset to a single ``.zarr`` store.
 
 ```python
 import shutil
@@ -197,12 +264,38 @@ from pathlib import Path
 
 import xarray as xr
 
-from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+from ogcat import ArtifactLocator, CatalogRecord, OperationContext, OperationSource, memory_source
 
 
 def create_cams_bc(ds: xr.Dataset, *, species: str, domain: str) -> xr.Dataset:
     """Create boundary-condition data from CAMS concentration fields."""
     ...
+
+
+def xarray_collection_source(record: CatalogRecord, **metadata: object) -> OperationSource:
+    """Build an operation source from a collection record's xarray hints."""
+    collection_root = record.path()
+    if collection_root is None:
+        raise ValueError("Expected collection record to have a local path.")
+
+    classification = record.derived_metadata.get("classification", {})
+    if classification.get("reader_hint") != "xarray.open_mfdataset":
+        raise ValueError("Collection is not marked for xarray.open_mfdataset.")
+
+    collection_pattern = str(classification["collection_pattern"])
+    input_paths = sorted(collection_root.glob(collection_pattern))
+    expected_count = record.user_metadata.get("member_count")
+    if expected_count is not None and len(input_paths) != int(expected_count):
+        raise ValueError(f"Expected {expected_count} members, found {len(input_paths)}.")
+
+    source_metadata = {
+        "collection_record_id": record.id,
+        "collection_pattern": collection_pattern,
+        "input_paths": [str(path) for path in input_paths],
+        "reader_hint": classification["reader_hint"],
+    }
+    source_metadata.update(metadata)
+    return memory_source(None, kind="xarray_netcdf_collection", metadata=source_metadata)
 
 
 @dataclass(frozen=True)
@@ -221,8 +314,7 @@ class CamsBoundaryConditionWriter:
         if target_path.exists():
             raise FileExistsError(target_path)
 
-        collection_path = Path(source.metadata["collection_path"])
-        input_paths = sorted(collection_path.glob("cams73_latest_co2_conc_surface_inst_*.nc"))
+        input_paths = [Path(path) for path in source.metadata["input_paths"]]
         species = str(source.metadata.get("species", "co2"))
         processing_domain = str(source.metadata["processing_domain"])
 
@@ -241,7 +333,8 @@ class CamsBoundaryConditionWriter:
                 "input_record_id": source.metadata["collection_record_id"],
                 "raw_zip_record_id": source.metadata["raw_zip_record_id"],
                 "input_file_count": len(input_paths),
-                "input_files": [path.name for path in input_paths],
+                "input_collection_pattern": source.metadata["collection_pattern"],
+                "input_reader": source.metadata["reader_hint"],
                 "species": species,
                 "bc_input": "cams",
                 "bc_input_version": "cams73_latest",
@@ -254,10 +347,6 @@ class CamsBoundaryConditionWriter:
 Plan and write the processed artifact:
 
 ```python
-collection_path = collection_record.path()
-if collection_path is None:
-    raise RuntimeError("Expected extracted collection to have a local path.")
-
 processed_metadata = {
     "species": "co2",
     "domain": "europe",
@@ -268,12 +357,8 @@ processed_metadata = {
     "raw_zip_record_id": raw_zip_record.id,
     "source_url": ads_dataset,
     "processing_domain": "EUROPE",
-    "provenance": {
-        "raw_zip_record_id": raw_zip_record.id,
-        "netcdf_collection_record_id": collection_record.id,
-        "operation": "create_cams_bc",
-        "opened_with": "xarray.open_mfdataset",
-    },
+    "operation": "create_cams_bc",
+    "opened_with": "xarray.open_mfdataset",
 }
 
 processed_plan = catalog.plan_artifact_storage(
@@ -287,16 +372,11 @@ processed_record = catalog.add_artifact(
     record_type="boundary_conditions",
     storage_plan=processed_plan,
     metadata=processed_metadata,
-    source=memory_source(
-        None,
-        kind="cams_netcdf_collection",
-        metadata={
-            "collection_path": str(collection_path),
-            "collection_record_id": collection_record.id,
-            "raw_zip_record_id": raw_zip_record.id,
-            "species": "co2",
-            "processing_domain": "EUROPE",
-        },
+    source=xarray_collection_source(
+        collection_record,
+        raw_zip_record_id=raw_zip_record.id,
+        species="co2",
+        processing_domain="EUROPE",
     ),
     artifact_writer=CamsBoundaryConditionWriter(),
 )
@@ -307,209 +387,19 @@ The resulting record is a generic directory artifact whose locator points to the
 needed to rebuild it, are ordinary metadata rather than special ogcat core
 concepts.
 
-## Local CAMS zip to processed Zarr with temporary extraction
+### Variant: build the fsspec input at processing time
 
-The same operation can avoid a persistent extracted collection when the raw zip
-already lives on a filesystem visible to the processing job. fsspec can still be
-useful here: the writer can wrap the already-recorded local path as a ``file://``
-URL-path, open it through ``fsspec.open_local()``, and then treat it as a zip
-filesystem. The writer extracts the NetCDF members into a temporary directory
-only long enough for ``xarray.open_mfdataset()`` and writes a single managed
-Zarr artifact.
-
-This pattern is useful when the intermediate NetCDF collection is an
-implementation detail of the processing step rather than an artifact you want to
-keep in the catalog.
-
-The raw zip can be the same path-backed reference recorded earlier. Its metadata
-does not need to choose this later processing strategy. A compact archive
-summary, such as ``archive_member_glob="*.nc"`` and ``member_count=36``, is
-usually enough for downstream processing decisions. A full ``ncdump -h`` for
-every member would probably be better as a separate sidecar artifact than as
-inline catalog metadata.
-
-```python
-zip_path = raw_zip_record.path()
-if zip_path is None:
-    raise RuntimeError("Expected the raw CAMS zip record to have a local path.")
-```
-
-Then use a writer that opens the zip through fsspec, extracts the NetCDF members
-into a temporary directory, opens them with ``xarray.open_mfdataset()``, and
-removes the temporary files when the operation finishes. The target Zarr store is
-the only managed artifact created by this operation.
-
-```python
-import shutil
-import tempfile
-from dataclasses import dataclass
-from pathlib import Path
-
-import fsspec
-import xarray as xr
-
-from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
-
-
-@dataclass(frozen=True)
-class LocalCamsZipToZarrWriter:
-    """Create a Zarr store directly from a local CAMS zip path."""
-
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        target_path = target.as_path()
-        if target_path is None:
-            raise ValueError("CAMS writer requires a local Zarr target.")
-        if target_path.exists():
-            raise FileExistsError(target_path)
-
-        zip_path = Path(str(source.metadata["zip_path"]))
-        zip_urlpath = zip_path.as_uri()
-        species = str(source.metadata.get("species", "co2"))
-        processing_domain = str(source.metadata["processing_domain"])
-        member_glob = str(source.metadata.get("archive_member_glob", "*.nc"))
-
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        context.rollback(
-            lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
-            description=f"remove processed Zarr store {target_path}",
-        )
-
-        with tempfile.TemporaryDirectory(prefix="ogcat-cams-") as work_dir:
-            work_path = Path(work_dir)
-            extracted_dir = work_path / "netcdf"
-            extracted_dir.mkdir()
-
-            local_zip = fsspec.open_local(zip_urlpath, mode="rb")
-            zip_fs = fsspec.filesystem("zip", fo=local_zip)
-            try:
-                input_paths: list[Path] = []
-                for member in sorted(zip_fs.glob(member_glob)):
-                    local_member = extracted_dir / Path(member).name
-                    with zip_fs.open(member, "rb") as src, local_member.open("wb") as dst:
-                        shutil.copyfileobj(src, dst)
-                    input_paths.append(local_member)
-
-                with xr.open_mfdataset(input_paths) as ds:
-                    processed = create_cams_bc(ds, species=species, domain=processing_domain)
-                    processed.to_zarr(target_path, mode="w")
-            finally:
-                zip_fs.close()
-
-        context.derived_metadata.update(
-            {
-                "raw_zip_record_id": source.metadata["raw_zip_record_id"],
-                "zip_urlpath": zip_urlpath,
-                "archive_member_glob": member_glob,
-                "input_file_count": len(input_paths),
-                "input_files": [path.name for path in input_paths],
-                "temporary_extract": "NetCDF members extracted inside a TemporaryDirectory",
-                "species": species,
-                "bc_input": "cams",
-                "bc_input_version": "cams73_latest",
-                "domain": processing_domain.lower(),
-                "reader_hint": "xarray.open_zarr",
-            }
-        )
-```
-
-Plan and run the processing step:
-
-```python
-local_processed_metadata = {
-    "species": "co2",
-    "domain": "europe",
-    "bc_input": "cams",
-    "bc_input_version": "cams73_latest",
-    "title": "CAMS CO2 boundary conditions for EUROPE",
-    "source_record_id": raw_zip_record.id,
-    "source_url": ads_dataset,
-    "processing_domain": "EUROPE",
-    "provenance": {
-        "raw_zip_record_id": raw_zip_record.id,
-        "operation": "create_cams_bc",
-        "opened_with": "xarray.open_mfdataset",
-        "zip_access": "fsspec zip filesystem over local file URL",
-    },
-}
-
-local_processed_plan = catalog.plan_artifact_storage(
-    record_type="boundary_conditions",
-    target_kind="directory",
-    write_mode="write",
-    metadata=local_processed_metadata,
-)
-
-local_processed_record = catalog.add_artifact(
-    record_type="boundary_conditions",
-    storage_plan=local_processed_plan,
-    metadata=local_processed_metadata,
-    source=memory_source(
-        None,
-        kind="local_cams_zip_urlpath",
-        metadata={
-            "zip_path": str(zip_path),
-            "raw_zip_record_id": raw_zip_record.id,
-            "species": "co2",
-            "processing_domain": "EUROPE",
-            "archive_member_glob": raw_zip_record.user_metadata.get("archive_member_glob", "*.nc"),
-        },
-    ),
-    artifact_writer=LocalCamsZipToZarrWriter(),
-)
-```
-
-This example still keeps fsspec and xarray out of ogcat core. ogcat records the
-local zip path and the processed Zarr locator; the writer owns the temporary
-extracted NetCDF files, processing call, and cleanup. If the zip later moves to a
-remote filesystem, the same writer shape can be adapted to use fsspec URL
-chaining and a temporary ``simplecache`` directory before opening the zip
-filesystem.
-
-### Variant: build the fsspec chain at processing time
-
-The raw zip record does not need to know how it will be processed later. Keep the
-raw record as a plain path or URL-path reference, then decide during the
-processing operation whether to unzip permanently, read through fsspec, cache
-members temporarily, or use some other domain-specific strategy.
-
-In this variant, a hook builds the fsspec URL pattern only during the processing
-operation, immediately before the custom writer runs:
+The persistent collection is useful when the extracted NetCDF files are shared
+inputs. If the extraction is only an implementation detail, run this variant
+instead of the collection-backed processing step above. Keep the raw zip record
+as the source of truth and build the fsspec URL path during the processing
+operation. The hook below prepares a ``simplecache`` plus ``zip`` URL path only
+for this operation; the writer then receives local cached member files from
+fsspec and writes the same managed Zarr output.
 
 ```text
-simplecache::zip://*.nc::file:///.../bab75005df9571750d518b0aacdedb35.zip
+simplecache::zip://cams73_latest_co2_conc_surface_inst_*.nc::file:///.../bab75005df9571750d518b0aacdedb35.zip
 ```
-
-The existing ``resolve_artifact_locator`` hook is best kept for the artifact
-being written, which in this operation is the output Zarr store. The input
-interpretation belongs with this processing operation, so the example uses
-``before_validate_metadata`` to enrich the operation source instead of rewriting
-the raw data record.
-
-The chain uses fsspec's zip filesystem and ``simplecache``. fsspec's chaining
-syntax with ``::`` passes the nested path through each filesystem layer. With
-``simplecache`` as the outer layer, the selected zip members can be cached as
-local files in a directory chosen by the writer.
-
-The zip record stays faithful to the source file. In this example, reuse the
-``raw_zip_record`` created earlier from ``~/Downloads`` rather than creating a
-second record just to support the fsspec processing path:
-
-```python
-assert raw_zip_record.locator.kind == "path"
-assert raw_zip_record.user_metadata["archive_member_glob"] == "*.nc"
-```
-
-The processing operation receives the raw record's locator as source metadata. A
-hook converts that locator and archive member glob to a fsspec URL path and stores it on
-``context.source.metadata``. The writer then gives ``simplecache`` a temporary
-directory, receives local cached member files from ``fsspec.open_local()``, opens
-them with xarray, and lets the temporary directory clean up the cache when it
-exits.
 
 ```python
 import shutil
@@ -536,7 +426,7 @@ def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_glob: str) -> st
 
 @dataclass(frozen=True)
 class CamsZipMemberUrlpathHook:
-    """Prepare a chained fsspec URL path for a CAMS processing operation."""
+    """Prepare a fsspec zip-member URL path for CAMS processing."""
 
     def before_validate_metadata(self, context: OperationContext) -> None:
         if context.record_type != "boundary_conditions":
@@ -545,7 +435,7 @@ class CamsZipMemberUrlpathHook:
             return
 
         raw_locator = ArtifactLocator.from_dict(context.source.metadata["raw_locator"])
-        member_glob = str(context.source.metadata.get("archive_member_glob", "*.nc"))
+        member_glob = str(context.source.metadata["archive_member_glob"])
         context.source.metadata["input_urlpath"] = cams_zip_member_urlpath(
             raw_locator,
             member_glob=member_glob,
@@ -585,6 +475,9 @@ class CamsZipChainToZarrWriter:
                 simplecache={"cache_storage": cache_dir},
             )
             input_paths = [Path(path) for path in local_members]
+            expected_count = int(source.metadata["member_count"])
+            if len(input_paths) != expected_count:
+                raise ValueError(f"Expected {expected_count} members, found {len(input_paths)}.")
 
             with xr.open_mfdataset(input_paths) as ds:
                 processed = create_cams_bc(ds, species=species, domain=processing_domain)
@@ -594,9 +487,8 @@ class CamsZipChainToZarrWriter:
             {
                 "raw_zip_record_id": source.metadata["raw_zip_record_id"],
                 "input_urlpath": input_urlpath,
-                "archive_member_glob": source.metadata.get("archive_member_glob", "*.nc"),
+                "archive_member_glob": source.metadata["archive_member_glob"],
                 "input_file_count": len(input_paths),
-                "input_files": [path.name for path in input_paths],
                 "temporary_cache": "fsspec simplecache inside a TemporaryDirectory",
                 "species": species,
                 "bc_input": "cams",
@@ -607,12 +499,13 @@ class CamsZipChainToZarrWriter:
         )
 ```
 
-Then plan and write the final Zarr artifact:
+Then plan the same kind of boundary-condition artifact, but pass the raw zip
+record's locator and archive hints as operation-source metadata:
 
 ```python
 catalog.hook_manager.register(CamsZipMemberUrlpathHook())
 
-zip_chain_processed_metadata = {
+fsspec_processed_metadata = {
     "species": "co2",
     "domain": "europe",
     "bc_input": "cams",
@@ -621,25 +514,22 @@ zip_chain_processed_metadata = {
     "source_record_id": raw_zip_record.id,
     "source_url": ads_dataset,
     "processing_domain": "EUROPE",
-    "provenance": {
-        "raw_zip_record_id": raw_zip_record.id,
-        "operation": "create_cams_bc",
-        "opened_with": "xarray.open_mfdataset",
-        "zip_access": "writer built fsspec chain from raw locator",
-    },
+    "operation": "create_cams_bc",
+    "opened_with": "xarray.open_mfdataset",
+    "zip_access": "fsspec simplecache over zip filesystem",
 }
 
-zip_chain_processed_plan = catalog.plan_artifact_storage(
+fsspec_processed_plan = catalog.plan_artifact_storage(
     record_type="boundary_conditions",
     target_kind="directory",
     write_mode="write",
-    metadata=zip_chain_processed_metadata,
+    metadata=fsspec_processed_metadata,
 )
 
-zip_chain_processed_record = catalog.add_artifact(
+fsspec_processed_record = catalog.add_artifact(
     record_type="boundary_conditions",
-    storage_plan=zip_chain_processed_plan,
-    metadata=zip_chain_processed_metadata,
+    storage_plan=fsspec_processed_plan,
+    metadata=fsspec_processed_metadata,
     source=memory_source(
         None,
         kind="cams_zip_member_urlpath",
@@ -648,17 +538,17 @@ zip_chain_processed_record = catalog.add_artifact(
             "raw_zip_record_id": raw_zip_record.id,
             "species": "co2",
             "processing_domain": "EUROPE",
-            "archive_member_glob": raw_zip_record.user_metadata.get("archive_member_glob", "*.nc"),
+            "archive_member_glob": raw_zip_record.user_metadata["archive_member_glob"],
+            "member_count": raw_zip_record.user_metadata["member_count"],
         },
     ),
     artifact_writer=CamsZipChainToZarrWriter(),
 )
 ```
 
-This version leaves the raw record independent of the later processing strategy.
-The processing operation chooses the fsspec interpretation when the writer runs,
-so future workflows can use the same raw zip record with different extraction or
-transformation approaches.
+This variant demonstrates fsspec without making the raw zip record depend on a
+specific processing strategy. The tradeoff is that the NetCDF member collection
+is not independently searchable in the catalog.
 
 ## URI reference followed by a download writer
 

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -666,9 +666,9 @@ This pattern records an external URI first, then creates a managed local copy
 with a custom writer. It is useful when downloads are performed by ``requests``,
 ``curl``, an authenticated client, or a project-specific API.
 
-The catalog can use its default UUID primary placement so the downloaded source
-filename does not need to be meaningful. The schema template remains
-human-readable:
+The catalog can plan a template-primary target so the downloaded source
+filename does not need to be meaningful, while the managed output still lands
+at a human-readable path:
 
 ```python
 from pathlib import Path
@@ -757,6 +757,7 @@ download_plan = catalog.plan_artifact_storage(
     Path("example.nc"),
     write_mode="write",
     metadata=download_metadata,
+    primary_location="template",
 )
 
 download_record = catalog.add_artifact(

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -7,9 +7,9 @@ network-specific work.
 ## CAMS zip to processed boundary conditions
 
 This workflow tracks a raw CAMS download, extracts its NetCDF members into a
-pipeline-controlled directory, records those members as one collection artifact,
-and writes a processed Zarr store with provenance linking the output back to
-the raw inputs.
+UUID-managed collection directory, records those members as one collection
+artifact, and writes a processed Zarr store with provenance linking the output
+back to the raw inputs.
 
 The example uses the CAMS global inversion-optimised greenhouse gas fluxes and
 concentrations dataset from the Copernicus Atmosphere Data Store:
@@ -42,10 +42,10 @@ version string because the workflow does not interpret it further.
 
 ### Catalog spec
 
-The raw download and extracted NetCDF collection are explicit references. They
-do not use schema templates because ogcat is not choosing their storage
-locations. The processed boundary-condition schema does use templates because
-ogcat owns the Zarr output target.
+The raw download is an explicit reference. The extracted NetCDF collection and
+processed boundary-condition store are ogcat-owned outputs. The collection uses
+UUID primary storage because the member filenames already carry the useful human
+meaning; the processed Zarr store uses a human-readable schema template.
 
 ```python
 from pathlib import Path
@@ -158,66 +158,68 @@ raw_zip_record = catalog.add_reference(
 )
 ```
 
-### 2. Extract and record the NetCDF collection
+### 2. Extract the NetCDF collection into managed storage
 
-The extraction location is chosen by the pipeline, not by a catalog naming
-template. This is useful for raw scientific inputs: the physical files stay in a
-domain-controlled workspace, while ogcat records the logical collection and the
-member pattern that downstream code should read.
+Here the extraction is an ogcat-managed write. A writer validates the archive
+members, extracts the NetCDF files into the planned UUID directory target, and
+returns collection classification metadata. General ``add_artifact(...)`` writes
+do not schedule template-link replicas, so the managed collection has only the
+UUID primary location.
 
 ```python
 import fnmatch
 import shutil
 import zipfile
 
-
-def extract_cams_members(
-    zip_path: Path,
-    target_dir: Path,
-    *,
-    member_pattern: str,
-    expected_members: list[str],
-) -> list[Path]:
-    """Extract matching CAMS members into a pipeline-controlled directory."""
-    if target_dir.exists():
-        raise FileExistsError(target_dir)
-    target_dir.mkdir(parents=True)
-
-    try:
-        with zipfile.ZipFile(zip_path) as archive:
-            members = {
-                Path(member.filename).name: member
-                for member in archive.infolist()
-                if not member.is_dir() and fnmatch.fnmatch(Path(member.filename).name, member_pattern)
-            }
-            expected_names = sorted(expected_members)
-            matched_names = sorted(members)
-            if matched_names != expected_names:
-                missing = sorted(set(expected_names) - set(matched_names))
-                unexpected = sorted(set(matched_names) - set(expected_names))
-                raise ValueError(f"Unexpected CAMS members: missing={missing}, unexpected={unexpected}.")
-
-            extracted: list[Path] = []
-            for name in expected_names:
-                member = members[name]
-                destination = target_dir / Path(member.filename).name
-                with archive.open(member) as source_file, destination.open("wb") as target_file:
-                    shutil.copyfileobj(source_file, target_file)
-                extracted.append(destination)
-    except Exception:
-        shutil.rmtree(target_dir, ignore_errors=True)
-        raise
-
-    return sorted(extracted)
-
-
-extracted_dir = Path("raw-cams-work/cams73_latest_co2_conc_surface_inst_202001-202212")
-extract_cams_members(
-    downloaded_zip,
-    extracted_dir,
-    member_pattern=CAMS_MEMBER_PATTERN,
-    expected_members=CAMS_EXPECTED_MEMBERS,
+from ogcat import (
+    OperationSource,
+    collection_classification_metadata,
+    path_source,
+    source_writer,
 )
+
+
+def write_cams_collection_archive(
+    source: OperationSource,
+    target_dir: Path,
+) -> dict[str, object]:
+    """Extract the expected CAMS NetCDF members into a managed directory."""
+    if source.path is None:
+        raise ValueError("CAMS collection writer requires a local zip source path.")
+
+    with zipfile.ZipFile(source.path) as archive:
+        members: dict[str, zipfile.ZipInfo] = {}
+        for member in archive.infolist():
+            member_name = Path(member.filename).name
+            if member.is_dir() or not fnmatch.fnmatch(member_name, CAMS_MEMBER_PATTERN):
+                continue
+            if member_name in members:
+                raise ValueError(f"Duplicate CAMS archive member basename: {member_name}")
+            members[member_name] = member
+
+        expected_names = sorted(CAMS_EXPECTED_MEMBERS)
+        matched_names = sorted(members)
+        if matched_names != expected_names:
+            missing = sorted(set(expected_names) - set(matched_names))
+            unexpected = sorted(set(matched_names) - set(expected_names))
+            raise ValueError(f"Unexpected CAMS members: missing={missing}, unexpected={unexpected}.")
+
+        for name in expected_names:
+            member = members[name]
+            destination = target_dir / name
+            with archive.open(member) as source_file, destination.open("wb") as target_file:
+                shutil.copyfileobj(source_file, target_file)
+
+    return {
+        "extracted_file_count": len(expected_names),
+        "extracted_names": expected_names,
+        "classification": collection_classification_metadata(
+            collection_pattern=CAMS_MEMBER_PATTERN,
+            member_format="netcdf",
+            member_suffixes=[".nc"],
+            reader_hint="xarray.open_mfdataset",
+        ),
+    }
 
 collection_metadata = {
     "species": "co2",
@@ -234,20 +236,31 @@ collection_metadata = {
     "bc_input_version": "cams73_latest",
 }
 
-collection_record = catalog.add_collection(
-    extracted_dir,
+collection_plan = catalog.plan_artifact_storage(
     record_type="raw_netcdf_collection",
     metadata=collection_metadata,
-    collection_pattern=CAMS_MEMBER_PATTERN,
-    member_format="netcdf",
-    member_suffixes=[".nc"],
-    reader_hint="xarray.open_mfdataset",
+    target_kind="directory",
+    write_mode="write",
+    primary_location="uuid",
+)
+
+collection_record = catalog.add_artifact(
+    record_type="raw_netcdf_collection",
+    storage_plan=collection_plan,
+    metadata=collection_metadata,
+    source=path_source(downloaded_zip, kind="zip_file"),
+    artifact_writer=source_writer(
+        write_cams_collection_archive,
+        target_kind="directory",
+        source_kind="zip_file",
+    ),
 )
 ```
 
-``add_collection(...)`` records one logical dataset. It does not scan, copy,
-move, or open the NetCDF members. The explicit ``collection_pattern`` and
-``reader_hint`` document how the collection should be read.
+The resulting record points at a managed directory under ``data/objects``. It is
+still one logical dataset, not 36 separate file records. The explicit
+``collection_pattern`` and ``reader_hint`` in the classification metadata
+document how downstream code should read the members.
 
 ### 3. Process the collection into a Zarr artifact
 

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -2,7 +2,7 @@
 
 from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
 from ogcat.catalog import Catalog
-from ogcat.classification import classify_artifact
+from ogcat.classification import classify_artifact, collection_classification_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.plugins import PluginRegistry
@@ -62,6 +62,7 @@ __all__ = [
     "CatalogRecordSet",
     "CatalogSpec",
     "classify_artifact",
+    "collection_classification_metadata",
     "CopyArtifactWriter",
     "FsspecStorageAdapter",
     "FunctionArtifactWriter",

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -10,23 +10,30 @@ from typing import Any
 _TEMPLATE_PATTERN = re.compile(r"\{([^{}]+)\}")
 _SLUG_SEPARATOR_PATTERN = re.compile(r"[\s_]+")
 _COMPRESSED_SUFFIXES = {".gz", ".bz2", ".xz", ".zip", ".zst"}
-_RESERVED_TEMPLATE_FIELDS = frozenset(
+_PUBLIC_NAMING_TEMPLATE_FIELDS = frozenset(
     {
         "date_added",
-        "artifact_uuid",
-        "id",
-        "operation_id",
         "original_filename",
         "original_stem",
         "original_suffix",
         "title_slug",
-        "uuid",
         "year_added",
         "year_month_or_original_stem",
     }
 )
+_INTERNAL_NAMING_TEMPLATE_FIELDS = frozenset(
+    {
+        "artifact_uuid",
+        "id",
+        "operation_id",
+        "uuid",
+    }
+)
+_RESERVED_TEMPLATE_FIELDS = _PUBLIC_NAMING_TEMPLATE_FIELDS | _INTERNAL_NAMING_TEMPLATE_FIELDS
 
 
+PUBLIC_NAMING_TEMPLATE_FIELDS = _PUBLIC_NAMING_TEMPLATE_FIELDS
+INTERNAL_NAMING_TEMPLATE_FIELDS = _INTERNAL_NAMING_TEMPLATE_FIELDS
 RESERVED_TEMPLATE_FIELDS = _RESERVED_TEMPLATE_FIELDS
 
 
@@ -128,6 +135,50 @@ def render_template(template: str, context: dict[str, Any]) -> str:
     return _TEMPLATE_PATTERN.sub(replace, template)
 
 
+def referenced_template_fields(template: str) -> frozenset[str]:
+    """Return named fields referenced directly by a template.
+
+    Literal fallback values are ignored, but fallback expressions that name
+    reserved generated fields are included so internal fields cannot be reached
+    through ``{field|uuid}`` style templates.
+    """
+    fields: set[str] = set()
+    for match in _TEMPLATE_PATTERN.finditer(template):
+        expr = match.group(1)
+        if "|" in expr:
+            field, fallback = expr.split("|", 1)
+            fallback = fallback.strip()
+        else:
+            field, fallback = expr, ""
+        field = field.strip()
+        if field:
+            fields.add(field)
+        if fallback in _RESERVED_TEMPLATE_FIELDS:
+            fields.add(fallback)
+    return frozenset(fields)
+
+
+def validate_human_readable_template_fields(*templates: str) -> None:
+    """Reject internal storage identifiers in human-readable naming templates.
+
+    Schema storage templates are intended to be stable, readable paths based on
+    user metadata and cheap derived naming context. Internal identifiers remain
+    available to storage planning, audit, and operation internals, but should
+    not become user-facing naming policy.
+
+    Args:
+        *templates: Directory or filename templates to validate.
+
+    Raises:
+        ValueError: If any template references an internal naming field.
+    """
+    referenced = set().union(*(referenced_template_fields(template) for template in templates))
+    internal_fields = sorted(referenced & _INTERNAL_NAMING_TEMPLATE_FIELDS)
+    if internal_fields:
+        joined = ", ".join(internal_fields)
+        raise ValueError(f"Naming templates cannot use internal template field(s): {joined}")
+
+
 def ensure_unique_path(path: Path, *, exists: Callable[[Path], bool] | None = None) -> Path:
     """Return a unique path by appending numeric suffixes if needed."""
     path_exists = Path.exists if exists is None else exists
@@ -225,6 +276,7 @@ def render_storage_location(
     exists: Callable[[Path], bool] | None = None,
 ) -> tuple[Path, str, str]:
     """Render directory and filename templates into a final storage path."""
+    validate_human_readable_template_fields(directory_template, filename_template)
     rel_dir = render_template(directory_template, context)
     rel_dir = "/".join(_normalise_segment(part) for part in rel_dir.split("/") if part)
 

--- a/src/ogcat/naming.py
+++ b/src/ogcat/naming.py
@@ -136,11 +136,13 @@ def render_template(template: str, context: dict[str, Any]) -> str:
 
 
 def referenced_template_fields(template: str) -> frozenset[str]:
-    """Return named fields referenced directly by a template.
+    """Return possible context fields referenced by a template.
 
-    Literal fallback values are ignored, but fallback expressions that name
-    reserved generated fields are included so internal fields cannot be reached
-    through ``{field|uuid}`` style templates.
+    Fallback tokens are ambiguous because :func:`render_template` treats them
+    as context lookups when a matching context key exists, otherwise as literal
+    fallback text. This extractor reports non-empty fallback tokens as possible
+    field references so callers do not miss metadata dependencies such as
+    ``{title_slug|dataset_id}``.
     """
     fields: set[str] = set()
     for match in _TEMPLATE_PATTERN.finditer(template):
@@ -153,7 +155,7 @@ def referenced_template_fields(template: str) -> frozenset[str]:
         field = field.strip()
         if field:
             fields.add(field)
-        if fallback in _RESERVED_TEMPLATE_FIELDS:
+        if fallback:
             fields.add(fallback)
     return frozenset(fields)
 

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -9,6 +9,7 @@ from typing import Literal, Protocol
 
 from ogcat.hooks import OperationContext
 from ogcat.models import CatalogRecord, MetadataDict
+from ogcat.naming import validate_human_readable_template_fields
 from ogcat.replica_types import ReplicaMode
 from ogcat.template_replicas import materialize_template_link_replica
 from ogcat.transactions import UnitOfWork
@@ -66,6 +67,10 @@ class TemplateLinkSecondaryArtifact:
     filename_template: str
     role: SecondaryArtifactRole = "template_link"
     mode: ReplicaMode = "symlink"
+
+    def __post_init__(self) -> None:
+        """Validate template-link fields before operation execution starts."""
+        validate_human_readable_template_fields(self.directory_template, self.filename_template)
 
     def run(
         self,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -583,8 +583,8 @@ def test_add_file_rejects_internal_identifiers_in_template_replicas(
         catalog.add_file(source)
 
     assert catalog.repository.all() == []
-    assert list((root / "data" / "files").rglob("reserved.nc")) == []
-    assert list((root / "data" / "objects").rglob("reserved.nc")) == []
+    assert list((root / "data" / "files").rglob("*")) == []
+    assert list((root / "data" / "objects").rglob("*")) == []
 
 
 def test_add_file_allows_domain_identifier_metadata_in_template_replicas(

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -614,6 +614,24 @@ def test_add_file_allows_domain_identifier_metadata_in_template_replicas(
     assert expected_replica.is_symlink()
 
 
+def test_add_reference_allows_identifier_metadata_without_template_context(tmp_path: Path) -> None:
+    """Explicit-locator records can persist identifier-like user metadata."""
+    source = tmp_path / "external.nc"
+    source.write_text("dummy", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_reference(
+        source,
+        metadata={
+            "id": "domain-id",
+            "uuid": "domain-uuid",
+        },
+    )
+
+    assert record.user_metadata["id"] == "domain-id"
+    assert record.user_metadata["uuid"] == "domain-uuid"
+
+
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -554,6 +554,66 @@ def test_add_file_template_primary_rejects_artifact_uuid_metadata(tmp_path: Path
     assert list((root / "data" / "files").rglob("reserved.nc")) == []
 
 
+@pytest.mark.parametrize("field_name", ["artifact_uuid", "id", "operation_id", "uuid"])
+def test_add_file_rejects_internal_identifiers_in_template_replicas(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    """Default template replicas reject internal identifier template fields."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "reserved.nc"
+    source.write_text("dummy", encoding="utf-8")
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{year_added}",
+                filename_template=f"{{{field_name}}}{{original_suffix}}",
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"Naming templates cannot use internal template field\\(s\\): {field_name}",
+    ):
+        catalog.add_file(source)
+
+    assert catalog.repository.all() == []
+    assert list((root / "data" / "files").rglob("reserved.nc")) == []
+    assert list((root / "data" / "objects").rglob("reserved.nc")) == []
+
+
+def test_add_file_allows_domain_identifier_metadata_in_template_replicas(
+    tmp_path: Path,
+) -> None:
+    """Domain identifiers remain available through explicit metadata names."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "named.nc"
+    source.write_text("dummy", encoding="utf-8")
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(
+        root,
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{dataset_id}",
+                filename_template="{dataset_id}{original_suffix}",
+            ),
+        ),
+    )
+
+    record = catalog.add_file(source, metadata={"dataset_id": "site-a-2026"})
+
+    expected_replica = root / "data" / "files" / "site-a-2026" / "site-a-2026.nc"
+    assert _template_replica_path(record) == expected_replica
+    assert expected_replica.is_symlink()
+
+
 def test_add_file_preserves_dotted_stems_and_simple_suffixes(tmp_path: Path) -> None:
     source_dir = tmp_path / "source"
     source_dir.mkdir()

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,68 @@
+"""Naming-template policy tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat.naming import (
+    referenced_template_fields,
+    render_storage_location,
+    validate_human_readable_template_fields,
+)
+
+
+def test_referenced_template_fields_includes_reserved_fallback_fields() -> None:
+    """Template field extraction sees internal fields used as fallbacks."""
+    assert referenced_template_fields("{title_slug|uuid}_{species}") == frozenset(
+        {"title_slug", "uuid", "species"}
+    )
+
+
+@pytest.mark.parametrize("field_name", ["artifact_uuid", "id", "operation_id", "uuid"])
+def test_human_readable_templates_reject_internal_identifier_fields(field_name: str) -> None:
+    """Human-readable storage templates cannot reference internal identifiers."""
+    with pytest.raises(
+        ValueError,
+        match=f"Naming templates cannot use internal template field\\(s\\): {field_name}",
+    ):
+        validate_human_readable_template_fields(f"{{{field_name}}}.nc")
+
+
+@pytest.mark.parametrize("field_name", ["artifact_uuid", "id", "operation_id", "uuid"])
+def test_render_storage_location_rejects_internal_identifier_fields(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    """Storage-path rendering enforces the internal identifier policy."""
+    with pytest.raises(
+        ValueError,
+        match=f"Naming templates cannot use internal template field\\(s\\): {field_name}",
+    ):
+        render_storage_location(
+            files_root=tmp_path / "files",
+            directory_template="{species}",
+            filename_template=f"{{{field_name}}}.nc",
+            context={"species": "co2", field_name: "internal-value"},
+        )
+
+
+def test_render_storage_location_allows_public_fields_and_metadata(tmp_path: Path) -> None:
+    """Storage templates can use public generated fields and user metadata."""
+    target, relative_path, resolved_filename = render_storage_location(
+        files_root=tmp_path / "files",
+        directory_template="{year_added}/{species}",
+        filename_template="{title_slug|original_stem}{original_suffix}",
+        context={
+            "year_added": "2026",
+            "species": "co2",
+            "title_slug": "surface-flux",
+            "original_stem": "raw_flux",
+            "original_suffix": ".nc",
+        },
+    )
+
+    assert target == tmp_path / "files" / "2026" / "co2" / "surface-flux.nc"
+    assert relative_path == "files/2026/co2/surface-flux.nc"
+    assert resolved_filename == "surface-flux.nc"

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -13,7 +13,14 @@ from ogcat.naming import (
 )
 
 
-def test_referenced_template_fields_includes_reserved_fallback_fields() -> None:
+def test_referenced_template_fields_includes_fallback_context_fields() -> None:
+    """Template field extraction includes possible fallback context lookups."""
+    assert referenced_template_fields("{title_slug|dataset_id}_{species}") == frozenset(
+        {"title_slug", "dataset_id", "species"}
+    )
+
+
+def test_referenced_template_fields_includes_internal_fallback_fields() -> None:
     """Template field extraction sees internal fields used as fallbacks."""
     assert referenced_template_fields("{title_slug|uuid}_{species}") == frozenset(
         {"title_slug", "uuid", "species"}

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -425,6 +425,32 @@ def test_plan_artifact_storage_template_primary_rejects_artifact_uuid_metadata(
         )
 
 
+@pytest.mark.parametrize("field_name", ["artifact_uuid", "id", "operation_id", "uuid"])
+def test_plan_artifact_storage_template_primary_rejects_internal_template_fields(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    """Dry-run template planning rejects internal identifier template fields."""
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(
+            catalog_name="files",
+            default_schema=RecordSchema(
+                directory_template="{year_added}",
+                filename_template=f"{{{field_name}}}{{original_suffix}}",
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=f"Naming templates cannot use internal template field\\(s\\): {field_name}",
+    ):
+        catalog.plan_artifact_storage(source, primary_location="template")
+
+
 def test_add_artifact_uses_planned_timestamp_for_date_named_paths(tmp_path: Path) -> None:
     """Records created from plans keep the timestamp used for date templates."""
     catalog = Catalog.create(


### PR DESCRIPTION
## Summary

- Split naming-template fields into public human-readable fields and internal identifier fields.
- Reject `id`, `uuid`, `operation_id`, and `artifact_uuid` in storage/template-link naming templates while keeping generated replica views able to use persisted record fields such as `id`.
- Document the field policy in concepts, README, MVP notes, and tutorial examples.
- Add an architecture report with CRC-style component entries, flow diagrams, SOLID concerns, and improvement suggestions.

## Architecture checkpoint

This finishes the last open child issue for #84. Human-readable storage naming now depends on user metadata and stable generated naming fields, while UUID-style identifiers stay inside storage planning, audit, and record metadata internals. `Catalog` remains the public facade; the new architecture report records the current responsibilities and the remaining hotspots.

Closes #92.
Refs #84.

## Checks

- `uv run ruff check src/ogcat tests`
- `uv run ruff format --check src/ogcat tests`
- `uv run pyright`
- `uv run pytest`
- `uv run sphinx-build -b html docs docs/_build/html`