### PR TITLE
[codex] Allow UUID add_file without template replica

### DIFF
--- a/docs/api/replicas.rst
+++ b/docs/api/replicas.rst
@@ -2,8 +2,8 @@ Replica views
 =============
 
 Replica views are user-requested generated link trees derived from catalog
-records. They are separate from required secondary artifacts, such as the
-default template-link created during UUID-primary ``add_file()`` operations.
+records. They are separate from secondary artifacts, such as the default
+template-link created during UUID-primary ``add_file()`` operations.
 Secondary artifact internals are documented on the internals page.
 
 .. automodule:: ogcat.replicas

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,10 +145,10 @@ there, if at all. That distinction is important for future directory-backed coll
 and `.zarr`-style outputs because `Catalog` should not branch on file versus directory versus
 collection.
 
-Secondary artifacts, such as the default human-readable template symlink for UUID primary storage,
-are modeled as ordered secondary operations. They run after the primary record is staged and has an
-id, but before commit, so their filesystem effects and record metadata updates remain part of the
-same rollback boundary.
+Secondary artifacts, such as the optional default human-readable template symlink for UUID primary
+storage, are modeled as ordered secondary operations. Any selected secondary operations run after
+the primary record is staged and has an id, but before commit, so their filesystem effects and
+record metadata updates remain part of the same rollback boundary.
 
 ## Collection Artifacts And Directory Targets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,10 +145,10 @@ there, if at all. That distinction is important for future directory-backed coll
 and `.zarr`-style outputs because `Catalog` should not branch on file versus directory versus
 collection.
 
-Required secondary artifacts, such as the default human-readable template symlink for UUID primary
-storage, are modeled as ordered secondary operations. They run after the primary record is staged
-and has an id, but before commit, so their filesystem effects and record metadata updates remain
-part of the same rollback boundary.
+Secondary artifacts, such as the default human-readable template symlink for UUID primary storage,
+are modeled as ordered secondary operations. They run after the primary record is staged and has an
+id, but before commit, so their filesystem effects and record metadata updates remain part of the
+same rollback boundary.
 
 ## Collection Artifacts And Directory Targets
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -61,6 +61,17 @@ record = catalog.add_file(
 print(record.path())      # primary UUID path inside data/objects/
 ```
 
+Pass ``create_template_replica=False`` to keep only the UUID primary copy and
+skip the human-readable template symlink:
+
+```python
+record = catalog.add_file(
+    Path("data.nc"),
+    metadata={"species": "CO2"},
+    create_template_replica=False,
+)
+```
+
 The human-readable replica location is derived from directory and filename
 templates stored in ``catalog.json``. The defaults are:
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -189,6 +189,7 @@ class Catalog:
         operation: str | None = None,
         record_type: str | None = None,
         primary_location: PrimaryLocation = "uuid",
+        create_template_replica: bool = True,
     ) -> CatalogRecord:
         """Add a local file using managed copy or move.
 
@@ -198,8 +199,11 @@ class Catalog:
             operation: ``"copy"`` or ``"move"``. Defaults to the catalog spec.
             record_type: Optional named schema to validate against.
             primary_location: ``"uuid"`` stores the primary artifact under a
-                UUID path and creates a template symlink replica. ``"template"``
-                stores the primary artifact at the rendered template path.
+                UUID path. ``"template"`` stores the primary artifact at the
+                rendered template path.
+            create_template_replica: Whether UUID-primary file adds create a
+                human-readable template symlink replica. Ignored for
+                template-primary adds.
 
         Returns:
             Persisted catalog record.
@@ -233,6 +237,7 @@ class Catalog:
             filename_template=filename_template,
             operation=chosen_operation,
             primary_location=resolved_primary_location,
+            create_template_replica=create_template_replica,
             time_added=timestamp,
         )
 

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -57,6 +57,7 @@ class CatalogApplication:
         filename_template: str,
         operation: str,
         primary_location: PrimaryLocation,
+        create_template_replica: bool,
         time_added: str,
     ) -> CatalogRecord:
         """Run the managed local-file add operation."""
@@ -126,6 +127,7 @@ class CatalogApplication:
         materialization_intent = writer_intent(artifact_writer)
         secondary_artifact_operations = self._template_link_secondary_artifacts(
             primary_location=primary_location,
+            create_template_replica=create_template_replica,
             directory_template=directory_template,
             filename_template=filename_template,
         )
@@ -267,11 +269,12 @@ class CatalogApplication:
         self,
         *,
         primary_location: PrimaryLocation,
+        create_template_replica: bool,
         directory_template: str,
         filename_template: str,
     ) -> tuple[SecondaryArtifactOperation, ...]:
         """Return default secondary artifacts for UUID primary file adds."""
-        if primary_location != "uuid":
+        if primary_location != "uuid" or not create_template_replica:
             return ()
         return (
             TemplateLinkSecondaryArtifact(

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -59,7 +59,7 @@ class SecondaryArtifactOperation(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class TemplateLinkSecondaryArtifact:
-    """Required template-link symlink secondary for UUID primary artifacts."""
+    """Template-link symlink secondary for UUID primary artifacts."""
 
     catalog_root: Path
     files_root: Path

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -69,6 +69,30 @@ def test_add_file_template_replica_uses_relative_symlink_target(tmp_path: Path) 
     assert replica_path.resolve() == _stored_path(record)
 
 
+def test_add_file_uuid_primary_can_skip_template_replica(tmp_path: Path) -> None:
+    """UUID-primary managed ingest can omit the human-readable template replica."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source, create_template_replica=False)
+
+    artifact_uuid = str(record.naming_metadata["artifact_uuid"])
+    expected_primary = root / "data" / "objects" / artifact_uuid[:2] / f"{artifact_uuid}.nc"
+    expected_replica = root / "data" / "files" / record.time_added[:4] / "example" / "example.nc"
+    assert _stored_path(record) == expected_primary
+    assert expected_primary.exists()
+    assert not expected_replica.exists()
+    assert not expected_replica.is_symlink()
+    assert "template_replica_path" not in record.naming_metadata
+    assert "template_replica_storage_relative_path" not in record.naming_metadata
+    assert record.naming_metadata["primary_location"] == "uuid"
+
+
 def test_add_file_can_store_primary_at_template_path(tmp_path: Path) -> None:
     """Callers can request the template path as the primary artifact location."""
     source_dir = tmp_path / "source"

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -58,6 +58,7 @@ def test_add_file_facade_delegates_to_application_service(
     assert captured["record_type"] == "managed_file"
     assert captured["operation"] == "copy"
     assert captured["primary_location"] == "uuid"
+    assert captured["create_template_replica"] is True
 
 
 def test_run_add_operation_delegates_to_operation_runner(
@@ -182,6 +183,42 @@ def test_add_file_template_primary_request_has_no_template_link_secondary(
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
 
     catalog.add_file(source, operation="copy", primary_location="template")
+
+    request = requests[0]
+    assert request.operation_type == "add_file"
+    assert request.secondary_artifact_operations == ()
+
+
+def test_add_file_uuid_primary_can_skip_template_link_secondary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UUID-primary file requests can skip the template-link secondary."""
+    requests: list[AddOperationRequest] = []
+
+    class FakeRunner(OperationRunner):
+        def __init__(self, request: AddOperationRequest) -> None:
+            self.request = request
+
+        def run(self) -> CatalogRecord:
+            return CatalogRecord(
+                catalog="files",
+                time_added="2026-05-15T00:00:00Z",
+                id="runner",
+                record_type=self.request.record_type,
+                locator=ArtifactLocator.path(tmp_path / "stored.nc"),
+            )
+
+    def build_fake_runner(self: Catalog, request: AddOperationRequest) -> OperationRunner:
+        requests.append(request)
+        return FakeRunner(request)
+
+    monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
+    source = tmp_path / "source.nc"
+    source.write_text("payload", encoding="utf-8")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    catalog.add_file(source, operation="copy", create_template_replica=False)
 
     request = requests[0]
     assert request.operation_type == "add_file"


### PR DESCRIPTION
## Summary

- Adds `create_template_replica` to `Catalog.add_file(...)`, defaulting to the existing behavior.
- Skips the template-link secondary artifact when callers use `primary_location="uuid"` with `create_template_replica=False`.
- Documents the opt-out and updates wording that described template-link secondaries as required.

## Root Cause

`CatalogApplication.add_file(...)` scheduled `TemplateLinkSecondaryArtifact` for every UUID-primary managed file add, so callers could not keep UUID primary storage without also creating a template-path symlink.

## Validation

- `uv run pytest tests/test_add.py tests/test_add_operation_lifecycle.py -q`
- `uv run ruff check src/ogcat/catalog.py src/ogcat/catalog_application.py src/ogcat/secondary_artifacts.py tests/test_add.py tests/test_add_operation_lifecycle.py`
- `uv run ruff format --check src/ogcat/catalog.py src/ogcat/catalog_application.py src/ogcat/secondary_artifacts.py tests/test_add.py tests/test_add_operation_lifecycle.py`
- `uv run pyright`
- `uv run pytest`

Closes #112