### PR TITLE
Add inline artifact descriptors to catalog records

### DIFF
--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -11,7 +11,12 @@ Models and specifications
 
 .. autoclass:: ogcat.CatalogRecord
    :members:
-   :exclude-members: catalog, time_added, id, record_type, locator, stored_abspath, stored_relpath, storage_mode, original_path, original_filename, suffixes, user_metadata, derived_metadata, naming_metadata
+   :exclude-members: catalog, time_added, id, record_type, locator, artifacts, stored_abspath, stored_relpath, storage_mode, original_path, original_filename, suffixes, user_metadata, derived_metadata, naming_metadata
+   :member-order: bysource
+
+.. autoclass:: ogcat.ArtifactDescriptor
+   :members:
+   :exclude-members: id, role, locator, state, relationship, claims, facets
    :member-order: bysource
 
 .. autoclass:: ogcat.ArtifactLocator

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -1,7 +1,12 @@
 # Catalog records
 
-A catalog record represents one catalogued artifact.  Every record contains a
-fixed set of reserved fields plus three metadata namespaces.
+A catalog record is the logical catalog entry used for search, schema
+validation, and user metadata. Every record contains a fixed set of reserved
+fields, one or more artifact descriptors, and three metadata namespaces.
+
+For compatibility, the top-level ``locator`` remains the shortcut to the
+record's data artifact. Code that calls ``record.locator`` or ``record.path()``
+continues to work for ordinary single-artifact records.
 
 ## Reserved fields
 
@@ -9,8 +14,9 @@ fixed set of reserved fields plus three metadata namespaces.
 |-------|-------------|
 | ``id`` | Stable string identifier assigned at ingest time. |
 | ``catalog`` | Name of the catalog that owns the record. |
-| ``record_type`` | Kind of artifact, e.g. ``managed_file`` or ``external_reference``. |
-| ``locator`` | Describes where the artifact lives (see [Locators and storage](locators-and-storage.md)). |
+| ``record_type`` | Logical schema/search type, e.g. ``managed_file`` or ``external_reference``. |
+| ``locator`` | Compatibility shortcut to the data artifact locator (see [Locators and storage](locators-and-storage.md)). |
+| ``artifacts`` | Inline descriptors for the data artifact plus optional auxiliary artifacts, view links, manifests, previews, logs, or derived artifacts. |
 | ``storage_mode`` | How the artifact was stored, e.g. ``copy``, ``move``, or ``external``. |
 | ``original_filename`` | Source filename at ingest time. |
 | ``suffixes`` | File suffix list derived from the source path. |
@@ -70,6 +76,32 @@ suffix list.
     template inputs; use explicit user metadata such as ``dataset_id`` for
     domain identifiers that should appear in human-readable paths.
 
+## Artifact descriptors
+
+``artifacts`` is a JSON-compatible list owned by the record. The first
+``data_artifact`` descriptor is the source for the top-level ``record.locator``
+compatibility value. Existing locator-only records are upgraded on read by
+synthesizing a ``data_artifact`` descriptor from the stored locator.
+
+The first descriptor shape is deliberately small:
+
+```json
+{
+  "id": "data",
+  "role": "data_artifact",
+  "locator": {"kind": "path", "value": "/abs/path/data.nc", "relative_path": "data/objects/ab/data.nc"},
+  "state": "available",
+  "relationship": {},
+  "claims": [],
+  "facets": []
+}
+```
+
+Current standard roles are ``data_artifact``, ``auxiliary_artifact``,
+``view_link``, ``manifest``, ``preview``, ``log``, and ``derived_artifact``.
+Claims and facets are placeholders for future typed reader, writer, and
+converter work; they are not dispatch keys in this slice.
+
 ## Searching across namespaces
 
 When you search with an unqualified field name such as ``species``, ogcat
@@ -102,4 +134,5 @@ print(record.id)
 print(record.record_type)          # "managed_file"
 print(record.user_metadata)        # {"species": "CO2", ...}
 print(record.path())               # stored Path
+print(record.artifacts[0].role)    # "data_artifact"
 ```

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -2,7 +2,9 @@
 
 A catalog record is the logical catalog entry used for search, schema
 validation, and user metadata. Every record contains a fixed set of reserved
-fields, one or more artifact descriptors, and three metadata namespaces.
+fields, zero or more artifact descriptors, and three metadata namespaces.
+Ordinary records with a physical or referenced data artifact have a
+``data_artifact`` descriptor.
 
 For compatibility, the top-level ``locator`` remains the shortcut to the
 record's data artifact. Code that calls ``record.locator`` or ``record.path()``
@@ -78,7 +80,7 @@ suffix list.
 
 ## Artifact descriptors
 
-``artifacts`` is a JSON-compatible list owned by the record. The first
+``artifacts`` is a JSON-compatible list owned by the record. The
 ``data_artifact`` descriptor is the source for the top-level ``record.locator``
 compatibility value. Existing locator-only records are upgraded on read by
 synthesizing a ``data_artifact`` descriptor from the stored locator.
@@ -97,10 +99,12 @@ The first descriptor shape is deliberately small:
 }
 ```
 
-Current standard roles are ``data_artifact``, ``auxiliary_artifact``,
+Current first-slice roles are ``data_artifact``, ``auxiliary_artifact``,
 ``view_link``, ``manifest``, ``preview``, ``log``, and ``derived_artifact``.
-Claims and facets are placeholders for future typed reader, writer, and
-converter work; they are not dispatch keys in this slice.
+Descriptor roles are stored as strings so future ADR or plugin-owned roles can
+be persisted before their lifecycle behavior exists. Claims and facets are
+placeholders for future typed reader, writer, and converter work; they are not
+dispatch keys in this slice.
 
 ## Searching across namespaces
 

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -1,8 +1,13 @@
 # Locators and storage
 
-A *locator* tells ogcat where a catalogued artifact lives.  The locator is
-stored in the catalog record alongside the metadata and is independent of how
-the file ended up there.
+A *locator* tells ogcat where an artifact lives or can be resolved. Artifact
+descriptors store locators for the data artifact and for auxiliary artifacts
+such as view links, manifests, previews, logs, or derived outputs.
+
+The top-level ``record.locator`` remains a compatibility shortcut to the
+record's data artifact locator. This keeps simple calls such as
+``record.path()`` and ``record.locator.value`` useful for ordinary library calls
+while allowing a record to own more than one artifact descriptor.
 
 ## Locator kinds
 
@@ -49,8 +54,8 @@ Use the three catalog add methods for different storage responsibilities:
 
 ``catalog.add_file()`` copies or moves the source file into the catalog's
 ``data/objects/`` tree by default and records a ``path`` locator pointing at
-that UUID-backed primary copy. The configured directory and filename templates
-create a human-readable symlink replica, not the canonical artifact path.
+that UUID-backed data artifact. The configured directory and filename templates
+create a human-readable symlink view link, not the canonical artifact path.
 
 ```python
 record = catalog.add_file(
@@ -61,8 +66,8 @@ record = catalog.add_file(
 print(record.path())      # primary UUID path inside data/objects/
 ```
 
-Pass ``create_template_replica=False`` to keep only the UUID primary copy and
-skip the human-readable template symlink:
+Pass ``create_template_replica=False`` to keep only the UUID data artifact and
+skip the human-readable template symlink view:
 
 ```python
 record = catalog.add_file(
@@ -72,7 +77,7 @@ record = catalog.add_file(
 )
 ```
 
-The human-readable replica location is derived from directory and filename
+The human-readable view-link location is derived from directory and filename
 templates stored in ``catalog.json``. The defaults are:
 
 ```

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -1,0 +1,62 @@
+# Design Note: Artifact Descriptors
+
+This note records the first implementation slice from ADR 0002's virtual
+artifact filesystem model.
+
+## Chosen Shape
+
+`CatalogRecord` remains the logical catalog entry. It now owns an inline
+`artifacts` list whose items describe concrete or virtual artifacts associated
+with the record.
+
+The first descriptor shape is intentionally small and JSON-compatible:
+
+```json
+{
+  "id": "data",
+  "role": "data_artifact",
+  "locator": {
+    "kind": "path",
+    "value": "/abs/path/to/data.nc",
+    "relative_path": "data/objects/ab/data.nc"
+  },
+  "state": "available",
+  "relationship": {},
+  "claims": [],
+  "facets": []
+}
+```
+
+The current standard roles are `data_artifact`, `auxiliary_artifact`,
+`view_link`, `manifest`, `preview`, `log`, and `derived_artifact`.
+
+## Compatibility Locator
+
+`record.locator` is still persisted and exposed as the compatibility shortcut
+to the first `data_artifact` descriptor's locator. Existing code that passes
+`record.locator.value` or `record.path()` to ordinary libraries keeps working.
+
+When an older catalog record has no `artifacts` list, ogcat synthesizes a
+`data_artifact` descriptor from the stored `locator`, or from legacy
+`stored_abspath` and `stored_relpath` fields. Records without a meaningful
+locator remain artifact-less until a real artifact is assigned.
+
+## Why Inline
+
+TinyDB stores catalog records as whole JSON documents, and this slice does not
+introduce independent artifact CRUD, locks, permissions, replicas, or a reader
+registry. Inline descriptors keep artifact membership transactionally tied to
+the record with the current backend and avoid a migration to a second registry
+before there is a real lifecycle that needs it.
+
+Namespaced metadata was rejected for this slice because artifacts are now part
+of the durable public model, not derived metadata or a plugin-specific
+experiment.
+
+## Current Limits
+
+`record_type` remains schema and search metadata. It is not an I/O dispatch key.
+
+`claims` and `facets` are placeholders for later typed reader, writer, and
+converter work. This change does not implement replicas, cache/archive policy,
+mount resolution, permissions, locks, or Intake integration.

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -5,9 +5,9 @@ artifact filesystem model.
 
 ## Chosen Shape
 
-`CatalogRecord` remains the logical catalog entry. It now owns an inline
+`CatalogRecord` remains the logical catalog entry. It now has an inline
 `artifacts` list whose items describe concrete or virtual artifacts associated
-with the record.
+with the record. Records without a meaningful locator may have an empty list.
 
 The first descriptor shape is intentionally small and JSON-compatible:
 
@@ -27,8 +27,11 @@ The first descriptor shape is intentionally small and JSON-compatible:
 }
 ```
 
-The current standard roles are `data_artifact`, `auxiliary_artifact`,
-`view_link`, `manifest`, `preview`, `log`, and `derived_artifact`.
+The current first-slice roles are `data_artifact`, `auxiliary_artifact`,
+`view_link`, `manifest`, `preview`, `log`, and `derived_artifact`. Roles are
+stored as strings, not enforced as a closed enum, so future ADR roles such as
+`replica`, `cache_copy`, and `archive_copy` can be persisted before their
+behavior is implemented.
 
 ## Compatibility Locator
 
@@ -56,6 +59,10 @@ experiment.
 ## Current Limits
 
 `record_type` remains schema and search metadata. It is not an I/O dispatch key.
+
+Only one current `data_artifact` descriptor is accepted in this slice. Replica
+leadership remains deferred to later `leader` or `write_leader` fields instead
+of overloading `primary`.
 
 `claims` and `facets` are placeholders for later typed reader, writer, and
 converter work. This change does not implement replicas, cache/archive policy,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ searching records.
    adr/index
    design-note-record-schemas
    design-note-artifact-locators
+   design-note-artifact-descriptors
    design-note-hooks-plugins
    design-note-virtual-artifact-filesystem-research
    ogcat_long_term_plan

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -4,7 +4,7 @@ from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
-from ogcat.models import ArtifactLocator, CatalogRecord, MetadataFieldDescription
+from ogcat.models import ArtifactDescriptor, ArtifactLocator, CatalogRecord, MetadataFieldDescription
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
 from ogcat.replicas import (
@@ -54,6 +54,7 @@ from ogcat.writers import (
 
 __all__ = [
     "ArtifactLocator",
+    "ArtifactDescriptor",
     "ArtifactWriter",
     "AuditEvent",
     "AuditSink",

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -13,6 +13,19 @@ JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 MetadataDict: TypeAlias = dict[str, JsonValue]
 
+DATA_ARTIFACT_ID = "data"
+STANDARD_ARTIFACT_ROLES = frozenset(
+    {
+        "data_artifact",
+        "auxiliary_artifact",
+        "view_link",
+        "manifest",
+        "preview",
+        "log",
+        "derived_artifact",
+    }
+)
+
 
 def normalize_metadata(
     metadata: object,
@@ -242,6 +255,107 @@ class ArtifactLocator:
 
 
 @dataclass(slots=True)
+class ArtifactDescriptor:
+    """Persistent descriptor for one artifact owned by a catalog record.
+
+    Args:
+        id: Record-local artifact identifier.
+        role: Artifact role, such as ``"data_artifact"`` or ``"view_link"``.
+        locator: Optional locator for physical or resolvable artifacts.
+        state: Lightweight lifecycle or availability state.
+        relationship: JSON-compatible relationship metadata.
+        claims: Placeholder list for future claim descriptors.
+        facets: Placeholder list for future facet descriptors.
+    """
+
+    id: str
+    role: str
+    locator: ArtifactLocator | None = None
+    state: str = "available"
+    relationship: MetadataDict = field(default_factory=dict)
+    claims: list[MetadataDict] = field(default_factory=list)
+    facets: list[MetadataDict] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Normalize descriptor fields to the supported JSON-safe shape."""
+        self.id = str(self.id)
+        self.role = str(self.role)
+        self.state = str(self.state)
+        if not self.id:
+            raise ValueError("artifact descriptor id cannot be empty")
+        if self.role not in STANDARD_ARTIFACT_ROLES:
+            supported = ", ".join(sorted(STANDARD_ARTIFACT_ROLES))
+            raise ValueError(f"Unsupported artifact role {self.role!r}; expected one of: {supported}")
+        if self.locator is not None and not isinstance(self.locator, ArtifactLocator):
+            raise TypeError(
+                "artifact descriptor locator must be an ArtifactLocator or None, "
+                f"got {type(self.locator).__name__}"
+            )
+        self.relationship = _coerce_required_metadata_dict(
+            self.relationship,
+            field_name=f"artifacts[{self.id}].relationship",
+        )
+        self.claims = _coerce_metadata_mapping_list(
+            self.claims,
+            field_name=f"artifacts[{self.id}].claims",
+        )
+        self.facets = _coerce_metadata_mapping_list(
+            self.facets,
+            field_name=f"artifacts[{self.id}].facets",
+        )
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Convert the artifact descriptor to a plain dictionary."""
+        return cast(
+            dict[str, JsonValue],
+            {
+                "id": self.id,
+                "role": self.role,
+                "locator": None if self.locator is None else self.locator.to_dict(),
+                "state": self.state,
+                "relationship": normalize_metadata(
+                    self.relationship,
+                    field_name=f"artifacts[{self.id}].relationship",
+                ),
+                "claims": [
+                    normalize_metadata(claim, field_name=f"artifacts[{self.id}].claims[{index}]")
+                    for index, claim in enumerate(self.claims)
+                ],
+                "facets": [
+                    normalize_metadata(facet, field_name=f"artifacts[{self.id}].facets[{index}]")
+                    for index, facet in enumerate(self.facets)
+                ],
+            },
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, JsonValue]) -> ArtifactDescriptor:
+        """Build an artifact descriptor from a plain dictionary."""
+        if "id" not in data:
+            raise ValueError("artifact descriptor dictionary is missing required key: id")
+        if "role" not in data:
+            raise ValueError("artifact descriptor dictionary is missing required key: role")
+        return cls(
+            id=str(data["id"]),
+            role=str(data["role"]),
+            locator=_coerce_optional_locator(data.get("locator")),
+            state="available" if data.get("state") is None else str(data["state"]),
+            relationship=_coerce_required_metadata_dict(
+                data.get("relationship", {}),
+                field_name=f"artifacts[{data['id']}].relationship",
+            ),
+            claims=_coerce_metadata_mapping_list(
+                data.get("claims", []),
+                field_name=f"artifacts[{data['id']}].claims",
+            ),
+            facets=_coerce_metadata_mapping_list(
+                data.get("facets", []),
+                field_name=f"artifacts[{data['id']}].facets",
+            ),
+        )
+
+
+@dataclass(slots=True)
 class CatalogRecord:
     """A single catalogued artifact record.
 
@@ -251,6 +365,7 @@ class CatalogRecord:
         id: Repository-assigned record identifier.
         record_type: Logical record type.
         locator: Artifact locator.
+        artifacts: Artifact descriptors owned by this record.
         stored_abspath: Backwards-compatible absolute path for path records.
         stored_relpath: Backwards-compatible catalog-relative path.
         storage_mode: Storage mode such as ``"copy"``, ``"move"``, or
@@ -268,6 +383,7 @@ class CatalogRecord:
     id: str | None = None
     record_type: str = "managed_file"
     locator: ArtifactLocator = field(default_factory=lambda: ArtifactLocator(kind="opaque", value=""))
+    artifacts: list[ArtifactDescriptor] = field(default_factory=list)
     stored_abspath: str | None = None
     stored_relpath: str | None = None
     storage_mode: str | None = None
@@ -294,6 +410,12 @@ class CatalogRecord:
                 self.stored_abspath,
                 relative_path=self.stored_relpath,
             )
+        self.artifacts = _coerce_artifact_descriptors(self.artifacts)
+        data_locator = _first_data_artifact_locator(self.artifacts)
+        if data_locator is not None:
+            self.locator = data_locator
+        elif not self.artifacts and _locator_has_value(self.locator):
+            self.artifacts = [_data_artifact_descriptor(self.locator)]
         locator_path = self.locator.as_path()
         if locator_path is not None and self.stored_abspath is None:
             self.stored_abspath = str(locator_path)
@@ -320,6 +442,7 @@ class CatalogRecord:
                 "catalog": self.catalog,
                 "record_type": self.record_type,
                 "locator": self.locator.to_dict(),
+                "artifacts": [artifact.to_dict() for artifact in self.artifacts],
                 "stored_abspath": self.stored_abspath,
                 "stored_relpath": self.stored_relpath,
                 "storage_mode": self.storage_mode,
@@ -350,6 +473,7 @@ class CatalogRecord:
             time_added=str(data["time_added"]),
             record_type="managed_file" if record_type is None else str(record_type),
             locator=locator,
+            artifacts=_coerce_artifact_descriptors(data.get("artifacts", [])),
             stored_abspath=(None if data.get("stored_abspath") is None else str(data["stored_abspath"])),
             stored_relpath=(None if data.get("stored_relpath") is None else str(data["stored_relpath"])),
             storage_mode=(None if data.get("storage_mode") is None else str(data["storage_mode"])),
@@ -381,6 +505,87 @@ def _coerce_locator(
         str(stored_abspath),
         relative_path=None if stored_relpath is None else str(stored_relpath),
     )
+
+
+def _coerce_optional_locator(value: object) -> ArtifactLocator | None:
+    """Coerce optional artifact descriptor locator data."""
+    if value is None:
+        return None
+    if isinstance(value, ArtifactLocator):
+        return value
+    if isinstance(value, Mapping):
+        return ArtifactLocator.from_dict(dict(cast(dict[str, JsonValue], value)))
+    raise TypeError(f"artifact descriptor locator must be a dictionary or None, got {type(value).__name__}")
+
+
+def _coerce_artifact_descriptors(value: object) -> list[ArtifactDescriptor]:
+    """Coerce artifact descriptor input to descriptor objects."""
+    if value is None:
+        return []
+    if not isinstance(value, list | tuple):
+        raise TypeError(f"artifacts must be a list of artifact descriptors, got {type(value).__name__}")
+
+    descriptors: list[ArtifactDescriptor] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(value):
+        if isinstance(item, ArtifactDescriptor):
+            descriptor = item
+        elif isinstance(item, Mapping):
+            descriptor = ArtifactDescriptor.from_dict(dict(cast(dict[str, JsonValue], item)))
+        else:
+            raise TypeError(
+                f"artifacts[{index}] must be an ArtifactDescriptor or dictionary, got {type(item).__name__}"
+            )
+        if descriptor.id in seen_ids:
+            raise ValueError(f"artifacts contains duplicate artifact id: {descriptor.id!r}")
+        seen_ids.add(descriptor.id)
+        descriptors.append(descriptor)
+    return descriptors
+
+
+def _coerce_required_metadata_dict(value: object, *, field_name: str) -> MetadataDict:
+    """Coerce a descriptor metadata mapping and fail when the shape is wrong."""
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a dictionary, got {type(value).__name__}")
+    return normalize_metadata(value, field_name=field_name)
+
+
+def _coerce_metadata_mapping_list(value: object, *, field_name: str) -> list[MetadataDict]:
+    """Coerce a list of descriptor metadata mappings."""
+    if value is None:
+        return []
+    if not isinstance(value, list | tuple):
+        raise TypeError(f"{field_name} must be a list of dictionaries, got {type(value).__name__}")
+
+    metadata_items: list[MetadataDict] = []
+    for index, item in enumerate(value):
+        metadata_items.append(
+            _coerce_required_metadata_dict(
+                item,
+                field_name=f"{field_name}[{index}]",
+            )
+        )
+    return metadata_items
+
+
+def _first_data_artifact_locator(artifacts: list[ArtifactDescriptor]) -> ArtifactLocator | None:
+    """Return the first data-artifact locator in a descriptor list."""
+    for artifact in artifacts:
+        if artifact.role == "data_artifact" and artifact.locator is not None:
+            return artifact.locator
+    return None
+
+
+def _locator_has_value(locator: ArtifactLocator) -> bool:
+    """Return whether a locator describes a meaningful artifact location."""
+    return bool(locator.value.strip())
+
+
+def _data_artifact_descriptor(locator: ArtifactLocator) -> ArtifactDescriptor:
+    """Build the compatibility data artifact descriptor for a locator."""
+    return ArtifactDescriptor(id=DATA_ARTIFACT_ID, role="data_artifact", locator=locator)
 
 
 def _coerce_string_list(value: JsonValue) -> list[str]:

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -14,6 +14,7 @@ JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 MetadataDict: TypeAlias = dict[str, JsonValue]
 
 DATA_ARTIFACT_ID = "data"
+# Descriptive vocabulary from ADR 0002; descriptor roles remain open strings.
 STANDARD_ARTIFACT_ROLES = frozenset(
     {
         "data_artifact",
@@ -23,6 +24,9 @@ STANDARD_ARTIFACT_ROLES = frozenset(
         "preview",
         "log",
         "derived_artifact",
+        "replica",
+        "cache_copy",
+        "archive_copy",
     }
 )
 
@@ -283,9 +287,8 @@ class ArtifactDescriptor:
         self.state = str(self.state)
         if not self.id:
             raise ValueError("artifact descriptor id cannot be empty")
-        if self.role not in STANDARD_ARTIFACT_ROLES:
-            supported = ", ".join(sorted(STANDARD_ARTIFACT_ROLES))
-            raise ValueError(f"Unsupported artifact role {self.role!r}; expected one of: {supported}")
+        if not self.role.strip():
+            raise ValueError("artifact descriptor role cannot be empty")
         if self.locator is not None and not isinstance(self.locator, ArtifactLocator):
             raise TypeError(
                 "artifact descriptor locator must be an ArtifactLocator or None, "
@@ -335,9 +338,11 @@ class ArtifactDescriptor:
             raise ValueError("artifact descriptor dictionary is missing required key: id")
         if "role" not in data:
             raise ValueError("artifact descriptor dictionary is missing required key: role")
+        raw_id = data["id"]
+        raw_role = data["role"]
         return cls(
-            id=str(data["id"]),
-            role=str(data["role"]),
+            id="" if raw_id is None else str(raw_id),
+            role="" if raw_role is None else str(raw_role),
             locator=_coerce_optional_locator(data.get("locator")),
             state="available" if data.get("state") is None else str(data["state"]),
             relationship=_coerce_required_metadata_dict(
@@ -414,17 +419,12 @@ class CatalogRecord:
         data_locator = _first_data_artifact_locator(self.artifacts)
         if data_locator is not None:
             self.locator = data_locator
+            _sync_path_fields_from_locator(self)
         elif not self.artifacts and _locator_has_value(self.locator):
             self.artifacts = [_data_artifact_descriptor(self.locator)]
-        locator_path = self.locator.as_path()
-        if locator_path is not None and self.stored_abspath is None:
-            self.stored_abspath = str(locator_path)
-        if (
-            self.locator.kind == "path"
-            and self.locator.relative_path is not None
-            and self.stored_relpath is None
-        ):
-            self.stored_relpath = self.locator.relative_path
+            _fill_missing_path_fields_from_locator(self)
+        else:
+            _fill_missing_path_fields_from_locator(self)
 
     def path(self) -> Path | None:
         """Return a local path for path-backed records."""
@@ -527,6 +527,7 @@ def _coerce_artifact_descriptors(value: object) -> list[ArtifactDescriptor]:
 
     descriptors: list[ArtifactDescriptor] = []
     seen_ids: set[str] = set()
+    data_artifact_seen = False
     for index, item in enumerate(value):
         if isinstance(item, ArtifactDescriptor):
             descriptor = item
@@ -538,6 +539,10 @@ def _coerce_artifact_descriptors(value: object) -> list[ArtifactDescriptor]:
             )
         if descriptor.id in seen_ids:
             raise ValueError(f"artifacts contains duplicate artifact id: {descriptor.id!r}")
+        if descriptor.role == "data_artifact":
+            if data_artifact_seen:
+                raise ValueError("artifacts contains multiple data_artifact descriptors")
+            data_artifact_seen = True
         seen_ids.add(descriptor.id)
         descriptors.append(descriptor)
     return descriptors
@@ -571,11 +576,35 @@ def _coerce_metadata_mapping_list(value: object, *, field_name: str) -> list[Met
 
 
 def _first_data_artifact_locator(artifacts: list[ArtifactDescriptor]) -> ArtifactLocator | None:
-    """Return the first data-artifact locator in a descriptor list."""
+    """Return the data-artifact locator in a descriptor list."""
     for artifact in artifacts:
         if artifact.role == "data_artifact" and artifact.locator is not None:
             return artifact.locator
     return None
+
+
+def _sync_path_fields_from_locator(record: CatalogRecord) -> None:
+    """Replace legacy path fields from the current compatibility locator."""
+    locator_path = record.locator.as_path()
+    if locator_path is None:
+        record.stored_abspath = None
+        record.stored_relpath = None
+        return
+    record.stored_abspath = str(locator_path)
+    record.stored_relpath = record.locator.relative_path
+
+
+def _fill_missing_path_fields_from_locator(record: CatalogRecord) -> None:
+    """Populate missing legacy path fields from the current compatibility locator."""
+    locator_path = record.locator.as_path()
+    if locator_path is not None and record.stored_abspath is None:
+        record.stored_abspath = str(locator_path)
+    if (
+        record.locator.kind == "path"
+        and record.locator.relative_path is not None
+        and record.stored_relpath is None
+    ):
+        record.stored_relpath = record.locator.relative_path
 
 
 def _locator_has_value(locator: ArtifactLocator) -> bool:

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -486,12 +486,18 @@ class AddOperationRunner(OperationRunner):
     ) -> CatalogRecord:
         """Persist secondary artifact metadata and emit its audit event."""
         persisted = record
+        updated_record = record
         if result.naming_metadata_updates:
             naming_metadata = dict(record.naming_metadata)
             naming_metadata.update(result.naming_metadata_updates)
-            persisted = self.request.transaction.update_staged_record(
-                replace(record, naming_metadata=naming_metadata)
+            updated_record = replace(updated_record, naming_metadata=naming_metadata)
+        if result.artifacts:
+            updated_record = replace(
+                updated_record,
+                artifacts=[*updated_record.artifacts, *result.artifacts],
             )
+        if updated_record != record:
+            persisted = self.request.transaction.update_staged_record(updated_record)
         self.dependencies.emit_operation_audit(
             add_plan.context,
             event_type=result.event_type,

--- a/src/ogcat/search.py
+++ b/src/ogcat/search.py
@@ -17,6 +17,7 @@ _RESERVED_FIELDS = {
     "catalog",
     "record_type",
     "locator",
+    "artifacts",
     "stored_abspath",
     "stored_relpath",
     "storage_mode",

--- a/src/ogcat/secondary_artifacts.py
+++ b/src/ogcat/secondary_artifacts.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal, Protocol
 
 from ogcat.hooks import OperationContext
-from ogcat.models import CatalogRecord, MetadataDict
+from ogcat.models import DATA_ARTIFACT_ID, ArtifactDescriptor, ArtifactLocator, CatalogRecord, MetadataDict
 from ogcat.naming import validate_human_readable_template_fields
 from ogcat.replica_types import ReplicaMode
 from ogcat.template_replicas import materialize_template_link_replica
@@ -28,6 +28,7 @@ class SecondaryArtifactResult:
         event_type: Audit event type to emit after successful materialization.
         naming_metadata_updates: Metadata fields to merge onto the staged
             catalog record.
+        artifacts: Artifact descriptors to append to the staged record.
         audit_details: Structured audit details for the operation.
     """
 
@@ -36,6 +37,7 @@ class SecondaryArtifactResult:
     message: str
     event_type: str = "secondary_artifact"
     naming_metadata_updates: MetadataDict = field(default_factory=dict)
+    artifacts: tuple[ArtifactDescriptor, ...] = ()
     audit_details: Mapping[str, object] = field(default_factory=dict)
 
 
@@ -95,6 +97,30 @@ class TemplateLinkSecondaryArtifact:
             message="Template symlink replica created.",
             event_type="replica",
             naming_metadata_updates=materialized.naming_metadata,
+            artifacts=(
+                ArtifactDescriptor(
+                    id="template_link",
+                    role="view_link",
+                    locator=ArtifactLocator.path(
+                        materialized.target_path,
+                        relative_path=materialized.catalog_relative_path,
+                    ),
+                    relationship={
+                        "kind": "view_of",
+                        "target_artifact_id": DATA_ARTIFACT_ID,
+                        "view_role": self.role,
+                    },
+                    facets=[
+                        {
+                            "kind": "local_symlink",
+                            "mode": self.mode,
+                            "storage_relative_path": materialized.storage_relative_path,
+                            "resolved_directory": materialized.resolved_directory,
+                            "resolved_filename": materialized.resolved_filename,
+                        }
+                    ],
+                ),
+            ),
             audit_details={
                 "replica_role": self.role,
                 "replica_mode": self.mode,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -46,6 +46,19 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     assert expected_replica.is_symlink()
     assert expected_replica.resolve() == expected_primary
     assert _template_replica_path(record) == expected_replica
+    assert [artifact.role for artifact in record.artifacts] == ["data_artifact", "view_link"]
+    assert record.artifacts[0].id == "data"
+    assert record.artifacts[0].locator == record.locator
+    assert record.artifacts[1].id == "template_link"
+    assert record.artifacts[1].locator == ArtifactLocator.path(
+        expected_replica,
+        relative_path=expected_replica.relative_to(root).as_posix(),
+    )
+    assert record.artifacts[1].relationship == {
+        "kind": "view_of",
+        "target_artifact_id": "data",
+        "view_role": "template_link",
+    }
     assert record.original_filename == "example.nc"
     assert record.suffixes == [".nc"]
     assert record.storage_mode == "copy"
@@ -90,6 +103,8 @@ def test_add_file_uuid_primary_can_skip_template_replica(tmp_path: Path) -> None
     assert not expected_replica.is_symlink()
     assert "template_replica_path" not in record.naming_metadata
     assert "template_replica_storage_relative_path" not in record.naming_metadata
+    assert [artifact.role for artifact in record.artifacts] == ["data_artifact"]
+    assert record.artifacts[0].locator == record.locator
     assert record.naming_metadata["primary_location"] == "uuid"
 
 
@@ -957,6 +972,9 @@ def test_add_artifact_supports_non_path_locator_records(tmp_path: Path) -> None:
     assert record.record_type == "external_reference"
     assert record.locator.kind == "uri"
     assert record.locator.value == "s3://bucket/example.zarr"
+    assert [artifact.role for artifact in record.artifacts] == ["data_artifact"]
+    assert record.artifacts[0].id == "data"
+    assert record.artifacts[0].locator == record.locator
     assert record.stored_abspath is None
     assert catalog.path(_record_id(record)) is None
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -6,6 +6,8 @@ import json
 from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
 from ogcat.models import ArtifactDescriptor, ArtifactLocator, CatalogRecord
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
@@ -214,6 +216,69 @@ def test_record_round_trips_with_data_and_preview_artifacts() -> None:
     assert isinstance(artifacts_payload[1], dict)
     assert artifacts_payload[1]["role"] == "preview"
     assert reloaded == record
+
+
+def test_data_artifact_locator_refreshes_compatibility_path_fields() -> None:
+    """Inline data artifacts keep the legacy locator and path fields aligned."""
+    data_locator = ArtifactLocator.path(
+        "/tmp/catalog/files/current.nc",
+        relative_path="files/current.nc",
+    )
+    record = CatalogRecord(
+        id="rec_000005",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        locator=ArtifactLocator.path(
+            "/tmp/catalog/files/stale.nc",
+            relative_path="files/stale.nc",
+        ),
+        stored_abspath="/tmp/catalog/files/stale.nc",
+        stored_relpath="files/stale.nc",
+        artifacts=[
+            ArtifactDescriptor(
+                id="data",
+                role="data_artifact",
+                locator=data_locator,
+            )
+        ],
+    )
+
+    assert record.locator == data_locator
+    assert record.stored_abspath == "/tmp/catalog/files/current.nc"
+    assert record.stored_relpath == "files/current.nc"
+    assert record.path() == Path("/tmp/catalog/files/current.nc")
+
+
+def test_record_rejects_multiple_data_artifacts() -> None:
+    """Only one current data artifact is allowed before replica leadership exists."""
+    with pytest.raises(ValueError, match="multiple data_artifact"):
+        CatalogRecord(
+            catalog="fluxes",
+            time_added="2026-04-23T12:00:00Z",
+            artifacts=[
+                ArtifactDescriptor(
+                    id="data",
+                    role="data_artifact",
+                    locator=ArtifactLocator.path("/tmp/catalog/files/current.nc"),
+                ),
+                ArtifactDescriptor(
+                    id="data-copy",
+                    role="data_artifact",
+                    locator=ArtifactLocator.path("/tmp/catalog/files/copy.nc"),
+                ),
+            ],
+        )
+
+
+def test_artifact_descriptor_allows_extension_roles_without_dispatch_semantics() -> None:
+    """Extension roles can persist before ogcat assigns them dispatch behavior."""
+    descriptor = ArtifactDescriptor(
+        id="plugin-report",
+        role="plugin_defined_artifact",
+        relationship={"target_artifact_id": "data"},
+    )
+
+    assert descriptor.to_dict()["role"] == "plugin_defined_artifact"
 
 
 def test_repository_insert_many(tmp_path: Path) -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 
-from ogcat.models import ArtifactLocator, CatalogRecord
+from ogcat.models import ArtifactDescriptor, ArtifactLocator, CatalogRecord
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
 
@@ -102,6 +102,16 @@ def test_from_dict_upgrades_legacy_path_only_records() -> None:
         "/tmp/catalog/files/example.nc",
         relative_path="files/example.nc",
     )
+    assert record.artifacts == [
+        ArtifactDescriptor(
+            id="data",
+            role="data_artifact",
+            locator=ArtifactLocator.path(
+                "/tmp/catalog/files/example.nc",
+                relative_path="files/example.nc",
+            ),
+        )
+    ]
     assert record.path() == Path("/tmp/catalog/files/example.nc")
 
 
@@ -141,7 +151,69 @@ def test_record_to_dict_stays_json_serialisable() -> None:
         "value": "s3://bucket/example.zarr",
         "relative_path": None,
     }
+    assert payload["artifacts"] == [
+        {
+            "id": "data",
+            "role": "data_artifact",
+            "locator": {
+                "kind": "uri",
+                "value": "s3://bucket/example.zarr",
+                "relative_path": None,
+            },
+            "state": "available",
+            "relationship": {},
+            "claims": [],
+            "facets": [],
+        }
+    ]
     assert json.loads(json.dumps(payload)) == payload
+
+
+def test_record_round_trips_with_data_and_preview_artifacts() -> None:
+    """Records can persist a data artifact plus an auxiliary preview descriptor."""
+    data_locator = ArtifactLocator.path(
+        "/tmp/catalog/files/example.nc",
+        relative_path="files/example.nc",
+    )
+    preview_locator = ArtifactLocator.path(
+        "/tmp/catalog/previews/example.png",
+        relative_path="previews/example.png",
+    )
+    record = CatalogRecord(
+        id="rec_000004",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        record_type="managed_file",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/stale-compat.zarr"),
+        artifacts=[
+            ArtifactDescriptor(
+                id="data",
+                role="data_artifact",
+                locator=data_locator,
+                claims=[{"kind": "representation", "name": "netcdf"}],
+            ),
+            ArtifactDescriptor(
+                id="preview",
+                role="preview",
+                locator=preview_locator,
+                relationship={"kind": "derived_from", "target_artifact_id": "data"},
+                facets=[{"kind": "image", "format": "png"}],
+            ),
+        ],
+        user_metadata={"species": "CO2"},
+    )
+
+    payload = record.to_dict()
+    reloaded = CatalogRecord.from_dict(payload)
+
+    assert record.locator == data_locator
+    assert record.path() == Path("/tmp/catalog/files/example.nc")
+    assert payload["locator"] == data_locator.to_dict()
+    artifacts_payload = payload["artifacts"]
+    assert isinstance(artifacts_payload, list)
+    assert isinstance(artifacts_payload[1], dict)
+    assert artifacts_payload[1]["role"] == "preview"
+    assert reloaded == record
 
 
 def test_repository_insert_many(tmp_path: Path) -> None:
@@ -207,6 +279,7 @@ def test_record_without_locator_does_not_resolve_to_current_directory() -> None:
 
     assert record.stored_abspath is None
     assert record.path() is None
+    assert record.artifacts == []
 
 
 def test_empty_path_locator_does_not_resolve_to_current_directory() -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -225,6 +225,20 @@ def test_search_shortcuts_resolve_for_whole_metadata_namespaces(tmp_path: Path) 
     assert catalog.search(query=SearchQuery.missing("user")) == []
 
 
+def test_search_supports_top_level_artifacts_field(tmp_path: Path) -> None:
+    """Artifact descriptors are searchable as a reserved top-level record field."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_artifact(
+        record_type="external_reference",
+        locator=ArtifactLocator(kind="uri", value="s3://bucket/site.zarr"),
+    )
+
+    assert [r.id for r in catalog.search(exists=["artifacts"])] == [record.id]
+    assert [r.id for r in catalog.search(contains={"artifacts": record.artifacts[0].to_dict()})] == [
+        record.id
+    ]
+
+
 def test_search_equality_against_list_requires_exact_list(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
     tagged = catalog.add_artifact(

--- a/tests/test_secondary_artifacts.py
+++ b/tests/test_secondary_artifacts.py
@@ -72,6 +72,17 @@ def test_template_link_secondary_artifact_materializes_metadata_and_rollback(
         assert link_path == expected_link_path
         assert result.role == "template_link"
         assert result.mode == "symlink"
+        assert len(result.artifacts) == 1
+        assert result.artifacts[0].role == "view_link"
+        assert result.artifacts[0].locator == ArtifactLocator.path(
+            expected_link_path,
+            relative_path="data/files/2026/alpha/alpha.nc",
+        )
+        assert result.artifacts[0].relationship == {
+            "kind": "view_of",
+            "target_artifact_id": "data",
+            "view_role": "template_link",
+        }
         assert link_path.is_symlink()
         assert not Path(os.readlink(link_path)).is_absolute()
         assert link_path.resolve() == primary_path


### PR DESCRIPTION
## Summary
- Added an inline `ArtifactDescriptor` model on `CatalogRecord` and kept `record.locator` as the compatibility shortcut to the data artifact.
- Persisted a default `data_artifact` descriptor for existing single-locator records and a `view_link` descriptor for the managed template symlink path.
- Updated the catalog/locator docs to reflect the new mental model and added a focused design note for the migration path.

Closes #115

## Testing
- Added model/repository coverage for legacy locator-only records, round-tripping a record with multiple artifacts, and preserving `record.path()` compatibility.
- Added add-operation coverage for `add_artifact()`, default `add_file()`, and the no-template-replica path.
- Validation passed: focused tests, `ruff check`, `ruff format --check`, `pyright`, and the full test suite (`423 passed, 1 skipped`).