### PR TITLE
Support managed directory artifacts in add_file ingest

### DIFF
--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -33,7 +33,8 @@ directly, but ogcat does not interpret them beyond recording the string value.
 Use the three catalog add methods for different storage responsibilities:
 
 - ``Catalog.add_file(...)`` is for managed local ingest. It copies or moves a
-  local source into the catalog's ``data/objects/`` tree by default.
+  local source file, or a file-like directory store such as ``.zarr``, into the
+  catalog's ``data/objects/`` tree by default.
 - ``Catalog.add_reference(...)`` is for artifacts that already exist. It records
   a local path, URI, URI locator, or URL-path locator without copying, moving,
   or writing artifact data.
@@ -47,10 +48,11 @@ Use the three catalog add methods for different storage responsibilities:
 
 ## Managed files
 
-``catalog.add_file()`` copies or moves the source file into the catalog's
-``data/objects/`` tree by default and records a ``path`` locator pointing at
-that UUID-backed primary copy. The configured directory and filename templates
-create a human-readable symlink replica, not the canonical artifact path.
+``catalog.add_file()`` copies or moves the source file or file-like directory
+store into the catalog's ``data/objects/`` tree by default and records a
+``path`` locator pointing at that UUID-backed primary copy. The configured
+directory and filename templates create a human-readable symlink replica, not
+the canonical artifact path.
 
 ```python
 record = catalog.add_file(

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -191,10 +191,10 @@ class Catalog:
         primary_location: PrimaryLocation = "uuid",
         create_template_replica: bool = True,
     ) -> CatalogRecord:
-        """Add a local file using managed copy or move.
+        """Add a local file or file-like directory store using managed copy or move.
 
         Args:
-            path: Source file to ingest.
+            path: Source file or file-like directory store to ingest.
             metadata: JSON-compatible user metadata.
             operation: ``"copy"`` or ``"move"``. Defaults to the catalog spec.
             record_type: Optional named schema to validate against.

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -33,7 +33,12 @@ from ogcat.storage_planning import (
     plan_primary_storage,
 )
 from ogcat.transactions import UnitOfWork
-from ogcat.writers import CopyArtifactWriter, MoveArtifactWriter
+from ogcat.writers import (
+    CopyArtifactWriter,
+    CopyDirectoryArtifactWriter,
+    MoveArtifactWriter,
+    MoveDirectoryArtifactWriter,
+)
 
 if TYPE_CHECKING:
     from ogcat.catalog import Catalog
@@ -121,9 +126,7 @@ class CatalogApplication:
                 context.derived_metadata.update(extract_derived_metadata(locator_path))
 
         source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
-        artifact_writer: ArtifactWriter = (
-            CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()
-        )
+        artifact_writer = _managed_path_writer(source=source, operation=operation)
         materialization_intent = writer_intent(artifact_writer)
         secondary_artifact_operations = self._template_link_secondary_artifacts(
             primary_location=primary_location,
@@ -284,6 +287,13 @@ class CatalogApplication:
                 filename_template=filename_template,
             ),
         )
+
+
+def _managed_path_writer(*, source: Path, operation: str) -> ArtifactWriter:
+    """Return the managed-ingest writer for the source path shape."""
+    if source.is_dir():
+        return CopyDirectoryArtifactWriter() if operation == "copy" else MoveDirectoryArtifactWriter()
+    return CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()
 
 
 __all__ = ["CatalogApplication"]

--- a/src/ogcat/extractors/__init__.py
+++ b/src/ogcat/extractors/__init__.py
@@ -45,22 +45,38 @@ def extract_derived_metadata(path: str | Path, *, include_errors: bool = False) 
     errors: MetadataDict = {}
 
     for extractor in _EXTRACTORS:
-        if not extractor.can_extract(source):
+        try:
+            can_extract = extractor.can_extract(source)
+        except Exception as exc:
+            # Extractor selection is best-effort too; a broken optional
+            # extractor must not block artifact ingest.
+            if include_errors:
+                errors[_extractor_name(extractor)] = f"{type(exc).__name__}: {exc}"
+            continue
+        if not can_extract:
             continue
         try:
             extracted = extractor.extract(source)
         except Exception as exc:
             # Derived metadata is best-effort and should not block file ingestion.
             if include_errors:
-                errors[extractor.name] = f"{type(exc).__name__}: {exc}"
+                errors[_extractor_name(extractor)] = f"{type(exc).__name__}: {exc}"
             continue
         if extracted is not None:
-            derived[extractor.name] = extracted
+            derived[_extractor_name(extractor)] = extracted
 
     if errors:
         derived["extractor_errors"] = errors
 
     return derived
+
+
+def _extractor_name(extractor: DerivedMetadataExtractor) -> str:
+    """Return a stable extractor name for metadata and error reporting."""
+    try:
+        return str(extractor.name)
+    except Exception:
+        return type(extractor).__name__
 
 
 def _default_extractors() -> tuple[DerivedMetadataExtractor, ...]:

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -172,6 +172,42 @@ class CopyArtifactWriter:
 
 
 @dataclass(frozen=True, slots=True)
+class CopyDirectoryArtifactWriter:
+    """Artifact writer that copies a local source directory to a directory target."""
+
+    source_kind: str = "local_file"
+    target_kind: ClassVar[TargetKind] = "directory"
+    write_mode: ClassVar[WriteMode] = "copy"
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Copy a local source directory to the target and register rollback."""
+        if source.kind != self.source_kind or source.path is None:
+            raise ValueError(f"copy writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+        if not source.path.is_dir():
+            raise ValueError(f"copy directory writer requires an existing directory: {source.path}")
+        if target.kind != "path":
+            raise ValueError("copy directory writer currently requires a path-backed target")
+        adapter = adapter_for_locator(target)
+        ensure_target_absent(target, adapter=adapter)
+        target_path = require_local_path(target)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(
+            lambda locator=target, storage=adapter: remove_target(
+                locator,
+                target_kind=self.target_kind,
+                adapter=storage,
+            ),
+            description=f"remove copied {self.target_kind} artifact {target.value}",
+        )
+        shutil.copytree(source.path, target_path)
+
+
+@dataclass(frozen=True, slots=True)
 class MoveArtifactWriter:
     """Artifact writer that moves a local source path to a storage target."""
 
@@ -204,6 +240,42 @@ class MoveArtifactWriter:
             description=f"restore moved file from {target_path} to {source.path}",
         )
         adapter.move_from_path(source.path, target)
+
+
+@dataclass(frozen=True, slots=True)
+class MoveDirectoryArtifactWriter:
+    """Artifact writer that moves a local source directory to a directory target."""
+
+    source_kind: str = "local_file"
+    target_kind: ClassVar[TargetKind] = "directory"
+    write_mode: ClassVar[WriteMode] = "move"
+
+    def write(
+        self,
+        context: OperationContext,
+        source: OperationSource,
+        target: ArtifactLocator,
+    ) -> None:
+        """Move a local source directory to the target and register rollback."""
+        if source.kind != self.source_kind or source.path is None:
+            raise ValueError(f"move writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+        if not source.path.is_dir():
+            raise ValueError(f"move directory writer requires an existing directory: {source.path}")
+        if target.kind != "path":
+            raise ValueError("move directory writer currently requires a path-backed target")
+        adapter = adapter_for_locator(target)
+        ensure_target_absent(target, adapter=adapter)
+        target_path = require_local_path(target)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        context.rollback(
+            lambda source_path=source.path, stored_path=target_path: _rollback_moved_target(
+                source_path=source_path,
+                target_path=stored_path,
+                target_kind=self.target_kind,
+            ),
+            description=f"restore moved {self.target_kind} from {target_path} to {source.path}",
+        )
+        shutil.move(str(source.path), str(target_path))
 
 
 def source_writer(
@@ -391,19 +463,26 @@ def _remove_target(target_path: Path, target_kind: TargetKind) -> None:
 
 def _rollback_moved_file(*, source_path: Path, target_path: Path) -> None:
     """Restore a moved file when possible, otherwise remove the moved target."""
+    _rollback_moved_target(source_path=source_path, target_path=target_path, target_kind="file")
+
+
+def _rollback_moved_target(*, source_path: Path, target_path: Path, target_kind: TargetKind) -> None:
+    """Restore a moved target when possible, otherwise remove the moved target."""
     if not target_path.exists():
         return
     if not source_path.exists():
         source_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(target_path), str(source_path))
         return
-    target_path.unlink(missing_ok=True)
+    _remove_target(target_path, target_kind)
 
 
 __all__ = [
     "CopyArtifactWriter",
+    "CopyDirectoryArtifactWriter",
     "FunctionArtifactWriter",
     "MemoryWriteFunction",
+    "MoveDirectoryArtifactWriter",
     "MoveArtifactWriter",
     "PathWriteFunction",
     "SourceWriteFunction",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -24,6 +24,15 @@ def _template_replica_path(record: CatalogRecord) -> Path:
     return Path(str(record.naming_metadata["template_replica_path"]))
 
 
+def _write_zarr_store(path: Path) -> None:
+    """Write a tiny directory tree that behaves like a Zarr store for ingest tests."""
+    path.mkdir()
+    (path / "zarr.json").write_text("{}", encoding="utf-8")
+    chunks = path / "data"
+    chunks.mkdir()
+    (chunks / "0").write_text("chunk", encoding="utf-8")
+
+
 def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     """Default managed ingest writes a UUID primary and a template symlink replica."""
     source_dir = tmp_path / "source"
@@ -50,6 +59,62 @@ def test_add_file_uses_generic_default_storage_layout(tmp_path: Path) -> None:
     assert record.suffixes == [".nc"]
     assert record.storage_mode == "copy"
     assert record.naming_metadata["primary_location"] == "uuid"
+
+
+def test_add_file_copies_zarr_directory_as_managed_artifact(tmp_path: Path) -> None:
+    """Managed ingest should copy a file-like directory store as one artifact."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "example.zarr"
+    _write_zarr_store(source)
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source)
+
+    artifact_uuid = str(record.naming_metadata["artifact_uuid"])
+    expected_primary = root / "data" / "objects" / artifact_uuid[:2] / f"{artifact_uuid}.zarr"
+    replica_path = _template_replica_path(record)
+    classification = record.derived_metadata["classification"]
+    assert isinstance(classification, dict)
+
+    assert source.is_dir()
+    assert _stored_path(record) == expected_primary
+    assert expected_primary.is_dir()
+    assert (expected_primary / "zarr.json").read_text(encoding="utf-8") == "{}"
+    assert (expected_primary / "data" / "0").read_text(encoding="utf-8") == "chunk"
+    assert replica_path.is_symlink()
+    assert replica_path.resolve() == expected_primary
+    assert record.suffixes == [".zarr"]
+    assert record.storage_mode == "copy"
+    assert classification["artifact_kind"] == "zarr_store"
+    assert classification["format"] == "zarr"
+
+
+def test_add_file_moves_zarr_directory_as_managed_artifact(tmp_path: Path) -> None:
+    """Managed move ingest should transfer a file-like directory store."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "moved.zarr"
+    _write_zarr_store(source)
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source, operation="move", create_template_replica=False)
+
+    stored_path = _stored_path(record)
+    classification = record.derived_metadata["classification"]
+    assert isinstance(classification, dict)
+
+    assert not source.exists()
+    assert stored_path.is_dir()
+    assert (stored_path / "zarr.json").read_text(encoding="utf-8") == "{}"
+    assert record.storage_mode == "move"
+    assert record.suffixes == [".zarr"]
+    assert classification["artifact_kind"] == "zarr_store"
+    assert classification["format"] == "zarr"
 
 
 def test_add_file_template_replica_uses_relative_symlink_target(tmp_path: Path) -> None:
@@ -902,6 +967,33 @@ def test_add_file_removes_copied_target_when_metadata_extraction_fails(
     assert list((root / "data" / "files").rglob("*.nc")) == []
 
 
+def test_add_file_removes_copied_directory_when_metadata_extraction_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollback should remove a copied directory target if later metadata extraction fails."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "metadata.zarr"
+    _write_zarr_store(source)
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_extract(path: Path) -> dict[str, object]:
+        raise ValueError("simulated metadata failure")
+
+    monkeypatch.setattr("ogcat.catalog_application.extract_derived_metadata", fail_extract)
+
+    with pytest.raises(ValueError, match="simulated metadata failure"):
+        catalog.add_file(source, create_template_replica=False)
+
+    assert source.is_dir()
+    assert (source / "zarr.json").exists()
+    assert catalog.describe()["record_count"] == 0
+    assert list((root / "data" / "objects").rglob("*.zarr")) == []
+
+
 def test_add_file_restores_moved_file_when_record_write_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -925,6 +1017,34 @@ def test_add_file_restores_moved_file_when_record_write_fails(
     assert list((root / "data" / "files").rglob("*.nc")) == []
     assert source.exists()
     assert source.read_text(encoding="utf-8") == "dummy"
+    assert catalog.describe()["record_count"] == 0
+
+
+def test_add_file_restores_moved_directory_when_record_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollback should restore a moved directory if record persistence fails."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = source_dir / "moved.zarr"
+    _write_zarr_store(source)
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    def fail_insert(record: CatalogRecord) -> CatalogRecord:
+        raise OSError("simulated record write failure")
+
+    monkeypatch.setattr(catalog.repository, "insert", fail_insert)
+
+    with pytest.raises(OSError, match="simulated record write failure"):
+        catalog.add_file(source, operation="move", create_template_replica=False)
+
+    assert list((root / "data" / "objects").rglob("*.zarr")) == []
+    assert source.is_dir()
+    assert (source / "zarr.json").read_text(encoding="utf-8") == "{}"
+    assert (source / "data" / "0").read_text(encoding="utf-8") == "chunk"
     assert catalog.describe()["record_count"] == 0
 
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -44,6 +44,60 @@ def test_extract_derived_metadata_can_report_extractor_errors(
     }
 
 
+def test_extract_derived_metadata_can_report_extractor_selection_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Broken extractor selection should not fail best-effort metadata extraction."""
+    source = tmp_path / "example.zarr"
+    source.mkdir()
+
+    class BrokenCanExtract:
+        name = "broken_can_extract"
+
+        def can_extract(self, path: Path) -> bool:
+            raise TypeError("simulated selection failure")
+
+        def extract(self, path: Path) -> None:
+            raise AssertionError("selection failure should skip extraction")
+
+    monkeypatch.setattr(extractors, "_EXTRACTORS", (BrokenCanExtract(),))
+
+    assert extract_derived_metadata(source) == {}
+    assert extract_derived_metadata(source, include_errors=True) == {
+        "extractor_errors": {"broken_can_extract": "TypeError: simulated selection failure"}
+    }
+
+
+def test_add_file_zarr_directory_keeps_working_when_extractor_selection_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default extractor selection errors should not block managed directory ingest."""
+    source = tmp_path / "example.zarr"
+    source.mkdir()
+    (source / "zarr.json").write_text("{}", encoding="utf-8")
+
+    class BrokenCanExtract:
+        name = "broken_can_extract"
+
+        def can_extract(self, path: Path) -> bool:
+            raise TypeError("simulated selection failure")
+
+        def extract(self, path: Path) -> None:
+            raise AssertionError("selection failure should skip extraction")
+
+    monkeypatch.setattr(extractors, "_EXTRACTORS", (BrokenCanExtract(),))
+
+    root = tmp_path / "catalog"
+    catalog = Catalog.create(root, CatalogSpec(catalog_name="files"))
+
+    record = catalog.add_file(source, create_template_replica=False)
+
+    stored_path = record.path()
+    assert stored_path is not None
+    assert stored_path.is_dir()
+    assert "extractor_errors" not in record.derived_metadata
+
+
 def test_extract_derived_metadata_can_report_unreadable_netcdf_paths(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Add directory-aware managed ingest so `Catalog.add_file()` can copy or move file-like directory stores such as `.zarr`
- Keep rollback correct for directory copy/move failures and preserve existing file ingest behavior
- Make extractor selection best-effort so a broken optional extractor cannot block ingest
- Update docs and add coverage for `.zarr` copy/move, rollback, and extractor isolation

## Testing
- `uv run ruff check src/ogcat/catalog.py src/ogcat/catalog_application.py src/ogcat/extractors/__init__.py src/ogcat/writers.py tests/test_add.py tests/test_extractors.py`
- `uv run ruff format --check src/ogcat/catalog.py src/ogcat/catalog_application.py src/ogcat/extractors/__init__.py src/ogcat/writers.py tests/test_add.py tests/test_extractors.py`
- `uv run pyright`
- `uv run pytest tests/test_add.py tests/test_extractors.py -q`
- `uv run pytest`