### PR TITLE
Define artifact claim and facet schemas

### DIFF
--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -187,6 +187,14 @@ directory, prefix, archive, or manifest-shaped artifacts with collection claims,
 interfaces, and facets. A plain directory is not a collection unless explicitly
 claimed as one.
 
+Issue #121 and PR #122 clarified this boundary for managed directory artifacts:
+a `.zarr` directory ingested through `add_file()` is one directory-backed data
+artifact, not a collection. A directory of NetCDF members opened with a glob is
+a collection only when the artifact carries explicit collection claims/facets
+such as member pattern, member format, member suffixes, and reader hint. Storage
+shape (`directory`) must remain separate from data type (`zarr`, `netcdf`) and
+access interface (`collection`, `zarr-group`, `xarray-dataset`).
+
 Managed collection writes should be supported by the general artifact operation
 model. Issue #109 should be the first concrete pressure test: archive members
 can be extracted into managed directory or prefix storage and recorded as one

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -19,6 +19,40 @@ Models and specifications
    :exclude-members: id, role, locator, state, relationship, claims, facets
    :member-order: bysource
 
+.. autoclass:: ogcat.ArtifactClaim
+   :members:
+   :exclude-members: kind, name, namespace, version, evidence, confidence, metadata
+   :member-order: bysource
+
+.. autoclass:: ogcat.DataTypeClaim
+   :members:
+   :member-order: bysource
+
+.. autoclass:: ogcat.RepresentationClaim
+   :members:
+   :member-order: bysource
+
+.. autoclass:: ogcat.InterfaceClaim
+   :members:
+   :member-order: bysource
+
+.. autoclass:: ogcat.ArtifactFacet
+   :members:
+   :exclude-members: kind, name, namespace, version, evidence, confidence, metadata
+   :member-order: bysource
+
+.. autofunction:: ogcat.iter_claims
+
+.. autofunction:: ogcat.has_claim
+
+.. autofunction:: ogcat.claim_key
+
+.. autofunction:: ogcat.iter_facets
+
+.. autofunction:: ogcat.has_facet
+
+.. autofunction:: ogcat.facet_key
+
 .. autoclass:: ogcat.ArtifactLocator
    :members:
    :exclude-members: kind, value, relative_path

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -157,6 +157,15 @@ repository load.
 Claims and facets are not dispatch keys in this slice. Reader/open behavior and
 reader/writer/converter registries are deferred.
 
+A directory-backed artifact is not automatically a collection. For example, a
+managed ``.zarr`` directory added with ``add_file()`` is one data artifact with
+a directory representation and Zarr data type. A directory of ``.nc`` files is a
+collection only when collection claims/facets such as member pattern, member
+format, and member suffixes are explicitly attached. See
+[Artifact Claims And Facets](../design-note-artifact-claims-and-facets.md) for
+worked examples covering Zarr stores, NetCDF collections, CSV-like tables,
+single NetCDF files, and grouped NetCDF/HDF5 files.
+
 ## Searching across namespaces
 
 When you search with an unqualified field name such as ``species``, ogcat

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -71,6 +71,11 @@ subtype vocabulary. Use the classification ``suffixes`` field or the record's
 top-level ``suffixes`` field when you need to search or display the literal
 suffix list.
 
+Classification metadata remains in ``derived_metadata`` for now. It is not
+automatically mirrored into artifact facets in the first claim/facet schema
+slice, so existing classification search behavior and catalog compatibility are
+preserved.
+
 ``naming_metadata``
 :   Internal metadata used to evaluate directory and filename templates.  You
     do not normally need to read or set this directly. Fields such as
@@ -94,17 +99,63 @@ The first descriptor shape is deliberately small:
   "locator": {"kind": "path", "value": "/abs/path/data.nc", "relative_path": "data/objects/ab/data.nc"},
   "state": "available",
   "relationship": {},
-  "claims": [],
-  "facets": []
+  "claims": [
+    {
+      "kind": "interface",
+      "name": "bytes",
+      "namespace": "ogcat.core",
+      "version": "1",
+      "evidence": "validated",
+      "confidence": "validated",
+      "metadata": {}
+    }
+  ],
+  "facets": [
+    {
+      "kind": "suffix",
+      "name": "suffixes",
+      "namespace": "ogcat.core",
+      "version": "1",
+      "evidence": "inferred",
+      "confidence": "inferred",
+      "metadata": {"suffixes": [".nc"]}
+    }
+  ]
 }
 ```
 
 Current first-slice roles are ``data_artifact``, ``auxiliary_artifact``,
 ``view_link``, ``manifest``, ``preview``, ``log``, and ``derived_artifact``.
 Descriptor roles are stored as strings so future ADR or plugin-owned roles can
-be persisted before their lifecycle behavior exists. Claims and facets are
-placeholders for future typed reader, writer, and converter work; they are not
-dispatch keys in this slice.
+be persisted before their lifecycle behavior exists.
+
+``claims`` describe artifact facts that future readers, writers, and converters
+can use for dispatch. Core recognizes the claim kinds ``data_type``,
+``representation``, and ``interface``. The vocabulary of claim names remains
+open and namespaced. For example, one artifact can carry an ``interface`` claim
+named ``bytes`` in the ``ogcat.core`` namespace, a ``data_type`` claim named
+``netcdf`` in the ``org.unidata`` namespace, and an ``interface`` claim named
+``xarray-dataset`` in the ``pydata.xarray`` namespace without importing any of
+those optional reader libraries.
+
+``facets`` describe structured facts such as suffixes, size, modification time,
+checksums, archive member summaries, manifests, validation results, or
+plugin-specific details. Claims and facets always normalize to this envelope:
+``kind``, ``name``, ``namespace``, ``version``, ``evidence``, ``confidence``,
+and ``metadata``. ``metadata`` is a JSON-compatible dictionary for the
+structured payload.
+
+The first evidence and confidence vocabulary is ``declared``, ``inferred``,
+``probed``, ``validated``, ``stale``, and ``failed``. Suffix-only detection
+should be recorded as inferred, for example with
+``metadata={"source": "suffix", "suffixes": [".nc"]}``, not as validated
+truth. Missing namespace, version, evidence, confidence, and metadata fields in
+older raw dict payloads are filled with defaults when records are read. Invalid
+claim and facet shapes fail during descriptor or record construction, including
+repository load.
+
+Claims and facets are not dispatch keys in this slice. Reader/open behavior and
+reader/writer/converter registries are deferred.
 
 ## Searching across namespaces
 

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -133,6 +133,154 @@ This slice provides the schema and constructors. It does not automatically
 generate these claims and facets during ingest, and it does not use them for
 reader dispatch yet.
 
+Small query helpers in ``ogcat.artifact_claims`` support the next registry
+slice without duplicating normalization logic: ``iter_claims()``,
+``has_claim()``, ``claim_key()``, ``iter_facets()``, ``has_facet()``, and
+``facet_key()``.
+
+## Worked Examples
+
+These examples are design targets for writers, inspectors, and future readers.
+They are not automatic output in this schema slice.
+
+### Zarr Directory Store
+
+Issue #121 and PR #122 made ``add_file()`` intentionally support managed
+directory artifacts such as ``example.zarr``. A Zarr store is a directory-shaped
+artifact, but it is one dataset artifact, not a collection. The useful claims
+separate storage shape, data type, and optional interfaces:
+
+```json
+{
+  "claims": [
+    {"kind": "representation", "name": "directory", "namespace": "ogcat.core"},
+    {"kind": "data_type", "name": "zarr", "namespace": "zarr.dev"},
+    {"kind": "interface", "name": "directory-listing", "namespace": "ogcat.core"},
+    {"kind": "interface", "name": "zarr-group", "namespace": "zarr.dev"},
+    {"kind": "interface", "name": "xarray-dataset", "namespace": "pydata.xarray"}
+  ],
+  "facets": [
+    {"kind": "suffix", "name": "suffixes", "metadata": {"suffixes": [".zarr"]}}
+  ]
+}
+```
+
+The Zarr and xarray claims do not mean core imports those libraries. They are
+capability claims that a plugin or optional reader can satisfy later.
+
+### NetCDF Member Collection
+
+A directory of NetCDF files opened with a glob is different from a Zarr store.
+It is a directory representation with explicit collection semantics:
+
+```json
+{
+  "claims": [
+    {"kind": "representation", "name": "directory", "namespace": "ogcat.core"},
+    {"kind": "interface", "name": "collection", "namespace": "ogcat.core"},
+    {"kind": "interface", "name": "xarray-dataset", "namespace": "pydata.xarray"}
+  ],
+  "facets": [
+    {
+      "kind": "collection",
+      "name": "members",
+      "metadata": {
+        "pattern": "*.nc",
+        "member_format": "netcdf",
+        "member_suffixes": [".nc"],
+        "reader_hint": "xarray.open_mfdataset"
+      }
+    }
+  ]
+}
+```
+
+This is the claim/facet shape that issue #109 can use for managed collection
+writes. A reader can dispatch on the ``collection`` or ``xarray-dataset``
+interface and then use the member facet to decide how to open the directory.
+
+### CSV-Like Table
+
+CSV-like data can stay dependency-light in core by recording text and table
+interfaces without importing pandas:
+
+```json
+{
+  "claims": [
+    {"kind": "representation", "name": "text", "namespace": "ogcat.core"},
+    {"kind": "data_type", "name": "csv", "namespace": "iana.media-types"},
+    {"kind": "interface", "name": "text", "namespace": "ogcat.core"},
+    {"kind": "interface", "name": "table", "namespace": "ogcat.core"}
+  ]
+}
+```
+
+### Single NetCDF File
+
+A single NetCDF-like artifact has file representation and can advertise both
+cheap byte access and optional scientific interfaces:
+
+```json
+{
+  "claims": [
+    {"kind": "representation", "name": "file", "namespace": "ogcat.core"},
+    {"kind": "data_type", "name": "netcdf", "namespace": "org.unidata"},
+    {"kind": "interface", "name": "bytes", "namespace": "ogcat.core"},
+    {"kind": "interface", "name": "xarray-dataset", "namespace": "pydata.xarray"}
+  ]
+}
+```
+
+### Grouped NetCDF/HDF5 File
+
+Groups are structured facts or interfaces, not a reason for a core NetCDF
+dependency:
+
+```json
+{
+  "claims": [
+    {"kind": "data_type", "name": "netcdf", "namespace": "org.unidata"},
+    {"kind": "interface", "name": "netcdf-groups", "namespace": "org.unidata"}
+  ],
+  "facets": [
+    {
+      "kind": "netcdf",
+      "name": "groups",
+      "namespace": "org.unidata",
+      "metadata": {"groups": ["/", "/observations", "/metadata"]}
+    }
+  ]
+}
+```
+
+## Directory Stores Versus Collections
+
+PR #122 clarified an important ADR distinction. Directory-backed artifacts are
+not automatically collections. A managed ``.zarr`` directory added with
+``add_file()`` is one dataset artifact whose representation is ``directory``.
+A managed directory of monthly ``.nc`` files is a collection only when a caller,
+writer, or plugin explicitly adds collection claims/facets such as member
+pattern, member format, and member suffixes.
+
+This keeps storage shape separate from logical dataset shape:
+
+- ``representation=directory`` says how bytes are stored.
+- ``data_type=zarr`` or ``data_type=netcdf`` says what external format or data
+  type is claimed.
+- ``interface=collection`` says member traversal is part of the artifact
+  contract.
+- collection facets say which members participate and how a reader should
+  combine them.
+
+## Writer Result Open Loop
+
+Writers are the natural source of produced artifact claims/facets because they
+know what they materialized. This branch defines the schema, but it does not
+define the merge path from writer output into descriptors. Issue #117 should
+define that path, preserve existing ``None``-returning writers, and decide how
+writer results interact with ``OperationContext``, rollback, storage plans,
+audit metadata, and derived classification metadata.
+
 ## Relationship To Classification Metadata
 
 ``derived_metadata.classification`` remains the current home for cheap inferred

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -1,0 +1,147 @@
+# Design Note: Artifact Claims And Facets
+
+This note records the first claim and facet schema slice from ADR 0002. It is
+limited to JSON-compatible persistence, validation, and documentation. It does
+not implement reader dispatch, writer registration, converters, or optional
+scientific readers.
+
+## Chosen Shape
+
+Artifact claims use one open envelope with a ``kind`` field:
+
+```json
+{
+  "kind": "interface",
+  "name": "bytes",
+  "namespace": "ogcat.core",
+  "version": "1",
+  "evidence": "validated",
+  "confidence": "validated",
+  "metadata": {}
+}
+```
+
+Core recognizes three standard claim kinds from ADR 0002:
+
+- ``data_type`` for source or external forms such as NetCDF, CSV, service, or
+  collection pattern.
+- ``representation`` for storage or encoding shapes such as file, directory,
+  archive, text, or Zarr store.
+- ``interface`` for access contracts such as bytes, text, directory listing,
+  archive members, table, xarray dataset, manifest, or collection.
+
+The kind vocabulary is intentionally open. Plugins may persist their own claim
+kinds, names, and metadata without changing core schema. The Python API exposes
+``ArtifactClaim`` plus small convenience constructors: ``DataTypeClaim``,
+``RepresentationClaim``/``Representation``, and ``InterfaceClaim``.
+
+Facets use the same envelope, but they describe structured facts rather than
+type or interface claims:
+
+```json
+{
+  "kind": "stat",
+  "name": "size",
+  "namespace": "ogcat.core",
+  "version": "1",
+  "evidence": "probed",
+  "confidence": "validated",
+  "metadata": {"bytes": 12345}
+}
+```
+
+The Python API exposes ``ArtifactFacet`` and the alias ``Facet``.
+
+## Required Fields
+
+Normalized claims and facets always contain:
+
+- ``kind``: non-empty category string.
+- ``name``: non-empty namespace-local name.
+- ``namespace``: non-empty owner namespace, defaulting to ``ogcat.core``.
+- ``version``: non-empty schema version string, defaulting to ``1``.
+- ``evidence``: one supported vocabulary term.
+- ``confidence``: one supported vocabulary term, defaulting to ``evidence``.
+- ``metadata``: JSON-compatible dictionary for structured details.
+
+Existing artifact descriptors remain readable. Raw dict claims with missing
+``namespace``, ``version``, ``evidence``, ``confidence``, or ``metadata`` are
+normalized with defaults. Raw dict facets may also omit ``name``; in that case
+``name`` defaults to ``kind`` so earlier payloads such as
+``{"kind": "image", "format": "png"}`` remain readable. Unknown top-level
+fields are folded into ``metadata`` during normalization.
+
+Claims still require both ``kind`` and ``name``. Facets still require ``kind``.
+Invalid evidence, confidence, metadata, list, or item shapes raise
+``ValueError`` or ``TypeError`` during ``ArtifactDescriptor`` and
+``CatalogRecord`` construction, including repository load.
+
+## Evidence And Confidence
+
+The first vocabulary is:
+
+- ``declared``: supplied by caller, writer, plugin, or source metadata.
+- ``inferred``: cheap inference such as locator text, suffix, or directory
+  shape.
+- ``probed``: inspected cheaply without proving domain validity.
+- ``validated``: checked by a validator or reader-specific capability.
+- ``stale``: previously true or declared evidence that may no longer describe
+  the artifact.
+- ``failed``: attempted evidence collection or validation failed.
+
+Suffix-only detection should use ``evidence="inferred"`` and usually
+``confidence="inferred"``. Details such as source and suffix list belong in
+``metadata``:
+
+```json
+{
+  "kind": "representation",
+  "name": "netcdf",
+  "namespace": "ogcat.core",
+  "version": "1",
+  "evidence": "inferred",
+  "confidence": "inferred",
+  "metadata": {"source": "suffix", "suffixes": [".nc"]}
+}
+```
+
+This makes the difference between "looks like NetCDF" and "validated as
+NetCDF" explicit.
+
+## Namespaces
+
+``ogcat.core`` is reserved for core claim and facet names. Plugin-owned claims
+and facets should use a stable namespace such as a package name, plugin id, or
+reverse-DNS string, for example ``pydata.xarray`` or ``org.unidata``. The
+``version`` field is scoped to that namespace and name. Core validates only the
+envelope and JSON compatibility, not plugin-specific schemas.
+
+## Cheap Core Examples
+
+Core can represent common cheap facts without importing optional reader
+libraries:
+
+- interfaces: ``bytes``, ``text``, ``directory-listing``, ``archive-members``,
+  ``manifest``.
+- representations: ``path``, ``file``, ``directory``, ``archive``,
+  ``compressed-file``, ``text``, ``manifest``.
+- facets: ``stat/size``, ``stat/mtime``, ``checksum/sha256``,
+  ``suffix/suffixes``, ``archive/member-summary``, ``manifest/entries``.
+
+This slice provides the schema and constructors. It does not automatically
+generate these claims and facets during ingest, and it does not use them for
+reader dispatch yet.
+
+## Relationship To Classification Metadata
+
+``derived_metadata.classification`` remains the current home for cheap inferred
+facts such as ``artifact_kind``, ``format``, ``archive_format``,
+``inner_format``, ``collection_pattern``, ``member_format``,
+``member_suffixes``, and ``reader_hint``. This slice does not replace that
+namespace and does not automatically mirror classification into facets.
+
+Future migration can mirror selected classification facts into inferred
+claims/facets while preserving the existing derived metadata search behavior.
+For now, the bridge is documentation and compatibility: classification facts
+remain readable and searchable, and new descriptors may add explicit inferred
+claims/facets when a writer or plugin has enough context.

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -72,9 +72,10 @@ normalized with defaults. Raw dict facets may also omit ``name``; in that case
 fields are folded into ``metadata`` during normalization.
 
 Claims still require both ``kind`` and ``name``. Facets still require ``kind``.
-Invalid evidence, confidence, metadata, list, or item shapes raise
-``ValueError`` or ``TypeError`` during ``ArtifactDescriptor`` and
-``CatalogRecord`` construction, including repository load.
+Required identifier fields must be strings; ``None``, non-string values, and
+empty strings are rejected. Invalid evidence, confidence, metadata, list, or
+item shapes raise ``ValueError`` or ``TypeError`` during ``ArtifactDescriptor``
+and ``CatalogRecord`` construction, including repository load.
 
 ## Evidence And Confidence
 

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -22,8 +22,28 @@ The first descriptor shape is intentionally small and JSON-compatible:
   },
   "state": "available",
   "relationship": {},
-  "claims": [],
-  "facets": []
+  "claims": [
+    {
+      "kind": "interface",
+      "name": "bytes",
+      "namespace": "ogcat.core",
+      "version": "1",
+      "evidence": "validated",
+      "confidence": "validated",
+      "metadata": {}
+    }
+  ],
+  "facets": [
+    {
+      "kind": "suffix",
+      "name": "suffixes",
+      "namespace": "ogcat.core",
+      "version": "1",
+      "evidence": "inferred",
+      "confidence": "inferred",
+      "metadata": {"suffixes": [".nc"]}
+    }
+  ]
 }
 ```
 
@@ -56,6 +76,29 @@ Namespaced metadata was rejected for this slice because artifacts are now part
 of the durable public model, not derived metadata or a plugin-specific
 experiment.
 
+## Claims And Facets
+
+Claims and facets now have a small explicit JSON-compatible envelope. Claims
+describe data type, representation, or interface facts. Facets describe
+structured facts such as suffixes, size, mtime, checksum, archive member
+summaries, manifests, or plugin-specific validation results. See
+[Artifact Claims And Facets](design-note-artifact-claims-and-facets.md) for the
+field definitions and compatibility rules.
+
+The claim envelope is generic and open rather than a closed set of scientific
+formats. Core recognizes ``data_type``, ``representation``, and ``interface``
+claim kinds, but plugins may add namespaced claim and facet names without
+changing core. ``ogcat.core`` is reserved for core names.
+
+Evidence and confidence use the first ADR vocabulary: ``declared``,
+``inferred``, ``probed``, ``validated``, ``stale``, and ``failed``. Suffix-only
+detection should be represented as inferred evidence, not validated truth.
+
+Existing raw dict claims and facets remain readable. Missing namespace,
+version, evidence, confidence, and metadata are filled with defaults when the
+shape is otherwise clear. Older facet payloads with extra top-level fields have
+those fields folded into ``metadata``.
+
 ## Current Limits
 
 `record_type` remains schema and search metadata. It is not an I/O dispatch key.
@@ -64,6 +107,13 @@ Only one current `data_artifact` descriptor is accepted in this slice. Replica
 leadership remains deferred to later `leader` or `write_leader` fields instead
 of overloading `primary`.
 
-`claims` and `facets` are placeholders for later typed reader, writer, and
-converter work. This change does not implement replicas, cache/archive policy,
-mount resolution, permissions, locks, or Intake integration.
+`claims` and `facets` are schema and validation metadata only in this slice.
+This change does not implement reader/open behavior, the reader/writer/converter
+registry, replicas, cache/archive policy, mount resolution, permissions, locks,
+or Intake integration.
+
+`derived_metadata.classification` remains the current home for cheap inferred
+classification fields such as `artifact_kind`, `format`, `archive_format`,
+`inner_format`, `collection_pattern`, `member_format`, `member_suffixes`, and
+`reader_hint`. This slice does not replace that namespace or automatically
+mirror those fields into facets.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ searching records.
    design-note-record-schemas
    design-note-artifact-locators
    design-note-artifact-descriptors
+   design-note-artifact-claims-and-facets
    design-note-hooks-plugins
    design-note-virtual-artifact-filesystem-research
    ogcat_long_term_plan

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for ogcat."""
 
+from ogcat.artifact_claims import claim_key, facet_key, has_claim, has_facet, iter_claims, iter_facets
 from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
@@ -77,15 +78,21 @@ __all__ = [
     "CatalogRecordSet",
     "CatalogSpec",
     "classify_artifact",
+    "claim_key",
     "collection_classification_metadata",
     "CopyArtifactWriter",
     "DataTypeClaim",
     "Facet",
+    "facet_key",
     "FsspecStorageAdapter",
     "FunctionArtifactWriter",
+    "has_claim",
+    "has_facet",
     "HookManager",
     "HookWarning",
     "InterfaceClaim",
+    "iter_claims",
+    "iter_facets",
     "JsonlAuditSink",
     "LocalStorageAdapter",
     "MetadataFieldDescription",

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -4,7 +4,19 @@ from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
-from ogcat.models import ArtifactDescriptor, ArtifactLocator, CatalogRecord, MetadataFieldDescription
+from ogcat.models import (
+    ArtifactClaim,
+    ArtifactDescriptor,
+    ArtifactFacet,
+    ArtifactLocator,
+    CatalogRecord,
+    DataTypeClaim,
+    Facet,
+    InterfaceClaim,
+    MetadataFieldDescription,
+    Representation,
+    RepresentationClaim,
+)
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
 from ogcat.replicas import (
@@ -54,7 +66,9 @@ from ogcat.writers import (
 
 __all__ = [
     "ArtifactLocator",
+    "ArtifactClaim",
     "ArtifactDescriptor",
+    "ArtifactFacet",
     "ArtifactWriter",
     "AuditEvent",
     "AuditSink",
@@ -65,10 +79,13 @@ __all__ = [
     "classify_artifact",
     "collection_classification_metadata",
     "CopyArtifactWriter",
+    "DataTypeClaim",
+    "Facet",
     "FsspecStorageAdapter",
     "FunctionArtifactWriter",
     "HookManager",
     "HookWarning",
+    "InterfaceClaim",
     "JsonlAuditSink",
     "LocalStorageAdapter",
     "MetadataFieldDescription",
@@ -85,6 +102,8 @@ __all__ = [
     "ReplicaViewPlan",
     "RollbackFailure",
     "RecordSchema",
+    "Representation",
+    "RepresentationClaim",
     "FieldPath",
     "SearchOp",
     "SearchQuery",

--- a/src/ogcat/artifact_claims.py
+++ b/src/ogcat/artifact_claims.py
@@ -1,0 +1,183 @@
+"""Helpers for querying artifact claims and facets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import TypeAlias
+
+from ogcat.models import ArtifactClaim, ArtifactDescriptor, ArtifactFacet, JsonValue, MetadataDict
+
+ArtifactSchemaKey: TypeAlias = tuple[str, str, str, str]
+
+
+def iter_claims(
+    descriptor: ArtifactDescriptor,
+    *,
+    kind: str | None = None,
+    name: str | None = None,
+    namespace: str | None = None,
+    version: str | None = None,
+) -> Iterator[MetadataDict]:
+    """Yield normalized claims from a descriptor that match optional filters.
+
+    Args:
+        descriptor: Artifact descriptor to inspect.
+        kind: Optional claim kind filter.
+        name: Optional claim name filter.
+        namespace: Optional claim namespace filter.
+        version: Optional claim version filter.
+
+    Yields:
+        Normalized JSON-compatible claim dictionaries.
+    """
+    for claim in descriptor.claims:
+        normalized = _normalize_claim(claim)
+        if _matches_envelope(
+            normalized,
+            kind=kind,
+            name=name,
+            namespace=namespace,
+            version=version,
+        ):
+            yield normalized
+
+
+def has_claim(
+    descriptor: ArtifactDescriptor,
+    *,
+    kind: str | None = None,
+    name: str | None = None,
+    namespace: str | None = None,
+    version: str | None = None,
+) -> bool:
+    """Return whether a descriptor has at least one matching claim."""
+    return (
+        next(
+            iter_claims(
+                descriptor,
+                kind=kind,
+                name=name,
+                namespace=namespace,
+                version=version,
+            ),
+            None,
+        )
+        is not None
+    )
+
+
+def claim_key(claim: ArtifactClaim | Mapping[str, object]) -> ArtifactSchemaKey:
+    """Return the stable lookup key for a claim.
+
+    The key order is ``(namespace, kind, name, version)`` so registry lookup can
+    group by owner namespace before interpreting the namespace-local name.
+    """
+    normalized = _normalize_claim(claim)
+    return _schema_key(normalized)
+
+
+def iter_facets(
+    descriptor: ArtifactDescriptor,
+    *,
+    kind: str | None = None,
+    name: str | None = None,
+    namespace: str | None = None,
+    version: str | None = None,
+) -> Iterator[MetadataDict]:
+    """Yield normalized facets from a descriptor that match optional filters.
+
+    Args:
+        descriptor: Artifact descriptor to inspect.
+        kind: Optional facet kind filter.
+        name: Optional facet name filter.
+        namespace: Optional facet namespace filter.
+        version: Optional facet version filter.
+
+    Yields:
+        Normalized JSON-compatible facet dictionaries.
+    """
+    for facet in descriptor.facets:
+        normalized = _normalize_facet(facet)
+        if _matches_envelope(
+            normalized,
+            kind=kind,
+            name=name,
+            namespace=namespace,
+            version=version,
+        ):
+            yield normalized
+
+
+def has_facet(
+    descriptor: ArtifactDescriptor,
+    *,
+    kind: str | None = None,
+    name: str | None = None,
+    namespace: str | None = None,
+    version: str | None = None,
+) -> bool:
+    """Return whether a descriptor has at least one matching facet."""
+    return (
+        next(
+            iter_facets(
+                descriptor,
+                kind=kind,
+                name=name,
+                namespace=namespace,
+                version=version,
+            ),
+            None,
+        )
+        is not None
+    )
+
+
+def facet_key(facet: ArtifactFacet | Mapping[str, object]) -> ArtifactSchemaKey:
+    """Return the stable lookup key for a facet.
+
+    The key order is ``(namespace, kind, name, version)`` so callers can group
+    facts by owner namespace before interpreting namespace-local names.
+    """
+    normalized = _normalize_facet(facet)
+    return _schema_key(normalized)
+
+
+def _normalize_claim(claim: ArtifactClaim | Mapping[str, object]) -> MetadataDict:
+    """Return one claim as a normalized JSON-compatible dictionary."""
+    if isinstance(claim, ArtifactClaim):
+        return claim.to_dict()
+    return ArtifactClaim.from_dict(claim).to_dict()
+
+
+def _normalize_facet(facet: ArtifactFacet | Mapping[str, object]) -> MetadataDict:
+    """Return one facet as a normalized JSON-compatible dictionary."""
+    if isinstance(facet, ArtifactFacet):
+        return facet.to_dict()
+    return ArtifactFacet.from_dict(facet).to_dict()
+
+
+def _matches_envelope(
+    item: Mapping[str, JsonValue],
+    *,
+    kind: str | None,
+    name: str | None,
+    namespace: str | None,
+    version: str | None,
+) -> bool:
+    """Return whether a normalized claim or facet envelope matches filters."""
+    return (
+        (kind is None or item["kind"] == kind)
+        and (name is None or item["name"] == name)
+        and (namespace is None or item["namespace"] == namespace)
+        and (version is None or item["version"] == version)
+    )
+
+
+def _schema_key(item: Mapping[str, JsonValue]) -> ArtifactSchemaKey:
+    """Return a lookup key from a normalized claim or facet envelope."""
+    return (
+        str(item["namespace"]),
+        str(item["kind"]),
+        str(item["name"]),
+        str(item["version"]),
+    )

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -969,7 +969,11 @@ def _schema_mapping_text_with_default(
 
 def _coerce_required_schema_text(value: object, *, field_name: str) -> str:
     """Coerce a required artifact schema identifier to non-empty text."""
-    text = str(value).strip()
+    if value is None:
+        raise ValueError(f"{field_name} cannot be None")
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value).__name__}")
+    text = value.strip()
     if not text:
         raise ValueError(f"{field_name} cannot be empty")
     return text

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -14,6 +14,40 @@ JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 MetadataDict: TypeAlias = dict[str, JsonValue]
 
 DATA_ARTIFACT_ID = "data"
+CORE_ARTIFACT_NAMESPACE = "ogcat.core"
+ARTIFACT_SCHEMA_VERSION = "1"
+DATA_TYPE_CLAIM_KIND = "data_type"
+REPRESENTATION_CLAIM_KIND = "representation"
+INTERFACE_CLAIM_KIND = "interface"
+STANDARD_CLAIM_KINDS = frozenset(
+    {
+        DATA_TYPE_CLAIM_KIND,
+        REPRESENTATION_CLAIM_KIND,
+        INTERFACE_CLAIM_KIND,
+    }
+)
+ARTIFACT_EVIDENCE_VALUES = frozenset(
+    {
+        "declared",
+        "inferred",
+        "probed",
+        "validated",
+        "stale",
+        "failed",
+    }
+)
+ARTIFACT_CONFIDENCE_VALUES = ARTIFACT_EVIDENCE_VALUES
+ARTIFACT_SCHEMA_FIELDS = frozenset(
+    {
+        "kind",
+        "name",
+        "namespace",
+        "version",
+        "evidence",
+        "confidence",
+        "metadata",
+    }
+)
 # Descriptive vocabulary from ADR 0002; descriptor roles remain open strings.
 STANDARD_ARTIFACT_ROLES = frozenset(
     {
@@ -29,6 +63,8 @@ STANDARD_ARTIFACT_ROLES = frozenset(
         "archive_copy",
     }
 )
+ArtifactClaimInput: TypeAlias = "ArtifactClaim | Mapping[str, object]"
+ArtifactFacetInput: TypeAlias = "ArtifactFacet | Mapping[str, object]"
 
 
 def normalize_metadata(
@@ -259,6 +295,291 @@ class ArtifactLocator:
 
 
 @dataclass(slots=True)
+class ArtifactClaim:
+    """Namespaced claim about an artifact's data type, representation, or interface.
+
+    Args:
+        kind: Claim category. Core recognizes ``"data_type"``, ``"representation"``,
+            and ``"interface"``, but stores other non-empty strings for plugin-owned
+            claim categories.
+        name: Namespaced claim name, such as ``"bytes"``, ``"netcdf"``, or
+            ``"xarray-dataset"``.
+        namespace: Stable namespace that owns the claim name.
+        version: Version of the namespace-local claim schema.
+        evidence: How the claim was produced.
+        confidence: Confidence/status term for the claim. Defaults to ``evidence``.
+        metadata: JSON-compatible structured details for this claim.
+    """
+
+    kind: str
+    name: str
+    namespace: str = CORE_ARTIFACT_NAMESPACE
+    version: str = ARTIFACT_SCHEMA_VERSION
+    evidence: str = "declared"
+    confidence: str | None = None
+    metadata: MetadataDict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize claim fields to the supported JSON-safe shape."""
+        self.kind = _coerce_required_schema_text(self.kind, field_name="claim.kind")
+        self.name = _coerce_required_schema_text(self.name, field_name="claim.name")
+        self.namespace = _coerce_required_schema_text(
+            self.namespace,
+            field_name=f"claim[{self.kind}:{self.name}].namespace",
+        )
+        self.version = _coerce_required_schema_text(
+            self.version,
+            field_name=f"claim[{self.kind}:{self.name}].version",
+        )
+        self.evidence = _coerce_artifact_vocabulary(
+            self.evidence,
+            field_name=f"claim[{self.kind}:{self.name}].evidence",
+            allowed=ARTIFACT_EVIDENCE_VALUES,
+        )
+        self.confidence = _coerce_artifact_vocabulary(
+            self.evidence if self.confidence is None else self.confidence,
+            field_name=f"claim[{self.kind}:{self.name}].confidence",
+            allowed=ARTIFACT_CONFIDENCE_VALUES,
+        )
+        self.metadata = normalize_metadata(
+            self.metadata,
+            field_name=f"claim[{self.kind}:{self.name}].metadata",
+        )
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Convert the claim to its JSON-compatible dictionary shape."""
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "namespace": self.namespace,
+            "version": self.version,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "metadata": normalize_metadata(
+                self.metadata,
+                field_name=f"claim[{self.kind}:{self.name}].metadata",
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object], *, field_name: str = "claim") -> ArtifactClaim:
+        """Build an artifact claim from a plain dictionary."""
+        return cls(
+            kind=_required_schema_mapping_text(data, "kind", field_name=field_name),
+            name=_required_schema_mapping_text(data, "name", field_name=field_name),
+            namespace=_schema_mapping_text_with_default(
+                data,
+                "namespace",
+                field_name=field_name,
+                default=CORE_ARTIFACT_NAMESPACE,
+            ),
+            version=_schema_mapping_text_with_default(
+                data,
+                "version",
+                field_name=field_name,
+                default=ARTIFACT_SCHEMA_VERSION,
+            ),
+            evidence=_schema_mapping_text_with_default(
+                data,
+                "evidence",
+                field_name=field_name,
+                default="declared",
+            ),
+            confidence=_optional_schema_mapping_text(
+                data,
+                "confidence",
+                field_name=field_name,
+                default=None,
+            ),
+            metadata=_schema_metadata_with_extension_fields(data, field_name=field_name),
+        )
+
+
+class DataTypeClaim(ArtifactClaim):
+    """Artifact claim describing the external or source data type."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        namespace: str = CORE_ARTIFACT_NAMESPACE,
+        version: str = ARTIFACT_SCHEMA_VERSION,
+        evidence: str = "declared",
+        confidence: str | None = None,
+        metadata: MetadataDict | None = None,
+    ) -> None:
+        """Create a data type claim."""
+        super().__init__(
+            kind=DATA_TYPE_CLAIM_KIND,
+            name=name,
+            namespace=namespace,
+            version=version,
+            evidence=evidence,
+            confidence=confidence,
+            metadata={} if metadata is None else metadata,
+        )
+
+
+class RepresentationClaim(ArtifactClaim):
+    """Artifact claim describing a storage or encoding representation."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        namespace: str = CORE_ARTIFACT_NAMESPACE,
+        version: str = ARTIFACT_SCHEMA_VERSION,
+        evidence: str = "declared",
+        confidence: str | None = None,
+        metadata: MetadataDict | None = None,
+    ) -> None:
+        """Create a representation claim."""
+        super().__init__(
+            kind=REPRESENTATION_CLAIM_KIND,
+            name=name,
+            namespace=namespace,
+            version=version,
+            evidence=evidence,
+            confidence=confidence,
+            metadata={} if metadata is None else metadata,
+        )
+
+
+class InterfaceClaim(ArtifactClaim):
+    """Artifact claim describing an access interface exposed by an artifact."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        namespace: str = CORE_ARTIFACT_NAMESPACE,
+        version: str = ARTIFACT_SCHEMA_VERSION,
+        evidence: str = "declared",
+        confidence: str | None = None,
+        metadata: MetadataDict | None = None,
+    ) -> None:
+        """Create an interface claim."""
+        super().__init__(
+            kind=INTERFACE_CLAIM_KIND,
+            name=name,
+            namespace=namespace,
+            version=version,
+            evidence=evidence,
+            confidence=confidence,
+            metadata={} if metadata is None else metadata,
+        )
+
+
+@dataclass(slots=True)
+class ArtifactFacet:
+    """Namespaced structured fact about an artifact or claim.
+
+    Args:
+        kind: Facet category, such as ``"stat"``, ``"suffix"``, or a
+            plugin-owned category.
+        name: Namespace-local facet name.
+        namespace: Stable namespace that owns the facet name.
+        version: Version of the namespace-local facet schema.
+        evidence: How the facet was produced.
+        confidence: Confidence/status term for the facet. Defaults to ``evidence``.
+        metadata: JSON-compatible structured fact payload.
+    """
+
+    kind: str
+    name: str
+    namespace: str = CORE_ARTIFACT_NAMESPACE
+    version: str = ARTIFACT_SCHEMA_VERSION
+    evidence: str = "declared"
+    confidence: str | None = None
+    metadata: MetadataDict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize facet fields to the supported JSON-safe shape."""
+        self.kind = _coerce_required_schema_text(self.kind, field_name="facet.kind")
+        self.name = _coerce_required_schema_text(self.name, field_name="facet.name")
+        self.namespace = _coerce_required_schema_text(
+            self.namespace,
+            field_name=f"facet[{self.kind}:{self.name}].namespace",
+        )
+        self.version = _coerce_required_schema_text(
+            self.version,
+            field_name=f"facet[{self.kind}:{self.name}].version",
+        )
+        self.evidence = _coerce_artifact_vocabulary(
+            self.evidence,
+            field_name=f"facet[{self.kind}:{self.name}].evidence",
+            allowed=ARTIFACT_EVIDENCE_VALUES,
+        )
+        self.confidence = _coerce_artifact_vocabulary(
+            self.evidence if self.confidence is None else self.confidence,
+            field_name=f"facet[{self.kind}:{self.name}].confidence",
+            allowed=ARTIFACT_CONFIDENCE_VALUES,
+        )
+        self.metadata = normalize_metadata(
+            self.metadata,
+            field_name=f"facet[{self.kind}:{self.name}].metadata",
+        )
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Convert the facet to its JSON-compatible dictionary shape."""
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "namespace": self.namespace,
+            "version": self.version,
+            "evidence": self.evidence,
+            "confidence": self.confidence,
+            "metadata": normalize_metadata(
+                self.metadata,
+                field_name=f"facet[{self.kind}:{self.name}].metadata",
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object], *, field_name: str = "facet") -> ArtifactFacet:
+        """Build an artifact facet from a plain dictionary."""
+        kind = _required_schema_mapping_text(data, "kind", field_name=field_name)
+        return cls(
+            kind=kind,
+            name=_schema_mapping_text_with_default(
+                data,
+                "name",
+                field_name=field_name,
+                default=kind,
+            ),
+            namespace=_schema_mapping_text_with_default(
+                data,
+                "namespace",
+                field_name=field_name,
+                default=CORE_ARTIFACT_NAMESPACE,
+            ),
+            version=_schema_mapping_text_with_default(
+                data,
+                "version",
+                field_name=field_name,
+                default=ARTIFACT_SCHEMA_VERSION,
+            ),
+            evidence=_schema_mapping_text_with_default(
+                data,
+                "evidence",
+                field_name=field_name,
+                default="declared",
+            ),
+            confidence=_optional_schema_mapping_text(
+                data,
+                "confidence",
+                field_name=field_name,
+                default=None,
+            ),
+            metadata=_schema_metadata_with_extension_fields(data, field_name=field_name),
+        )
+
+
+Representation = RepresentationClaim
+Facet = ArtifactFacet
+
+
+@dataclass(slots=True)
 class ArtifactDescriptor:
     """Persistent descriptor for one artifact owned by a catalog record.
 
@@ -268,8 +589,8 @@ class ArtifactDescriptor:
         locator: Optional locator for physical or resolvable artifacts.
         state: Lightweight lifecycle or availability state.
         relationship: JSON-compatible relationship metadata.
-        claims: Placeholder list for future claim descriptors.
-        facets: Placeholder list for future facet descriptors.
+        claims: Artifact claims normalized to explicit JSON-compatible dictionaries.
+        facets: Artifact facets normalized to explicit JSON-compatible dictionaries.
     """
 
     id: str
@@ -277,8 +598,8 @@ class ArtifactDescriptor:
     locator: ArtifactLocator | None = None
     state: str = "available"
     relationship: MetadataDict = field(default_factory=dict)
-    claims: list[MetadataDict] = field(default_factory=list)
-    facets: list[MetadataDict] = field(default_factory=list)
+    claims: list[ArtifactClaimInput] = field(default_factory=list)
+    facets: list[ArtifactFacetInput] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Normalize descriptor fields to the supported JSON-safe shape."""
@@ -298,11 +619,11 @@ class ArtifactDescriptor:
             self.relationship,
             field_name=f"artifacts[{self.id}].relationship",
         )
-        self.claims = _coerce_metadata_mapping_list(
+        self.claims = _coerce_artifact_claims(
             self.claims,
             field_name=f"artifacts[{self.id}].claims",
         )
-        self.facets = _coerce_metadata_mapping_list(
+        self.facets = _coerce_artifact_facets(
             self.facets,
             field_name=f"artifacts[{self.id}].facets",
         )
@@ -321,11 +642,17 @@ class ArtifactDescriptor:
                     field_name=f"artifacts[{self.id}].relationship",
                 ),
                 "claims": [
-                    normalize_metadata(claim, field_name=f"artifacts[{self.id}].claims[{index}]")
+                    _coerce_artifact_claim(
+                        claim,
+                        field_name=f"artifacts[{self.id}].claims[{index}]",
+                    )
                     for index, claim in enumerate(self.claims)
                 ],
                 "facets": [
-                    normalize_metadata(facet, field_name=f"artifacts[{self.id}].facets[{index}]")
+                    _coerce_artifact_facet(
+                        facet,
+                        field_name=f"artifacts[{self.id}].facets[{index}]",
+                    )
                     for index, facet in enumerate(self.facets)
                 ],
             },
@@ -349,11 +676,11 @@ class ArtifactDescriptor:
                 data.get("relationship", {}),
                 field_name=f"artifacts[{data['id']}].relationship",
             ),
-            claims=_coerce_metadata_mapping_list(
+            claims=_coerce_artifact_claims(
                 data.get("claims", []),
                 field_name=f"artifacts[{data['id']}].claims",
             ),
-            facets=_coerce_metadata_mapping_list(
+            facets=_coerce_artifact_facets(
                 data.get("facets", []),
                 field_name=f"artifacts[{data['id']}].facets",
             ),
@@ -557,22 +884,147 @@ def _coerce_required_metadata_dict(value: object, *, field_name: str) -> Metadat
     return normalize_metadata(value, field_name=field_name)
 
 
-def _coerce_metadata_mapping_list(value: object, *, field_name: str) -> list[MetadataDict]:
-    """Coerce a list of descriptor metadata mappings."""
+def _coerce_artifact_claims(value: object, *, field_name: str) -> list[ArtifactClaimInput]:
+    """Coerce artifact claim input to normalized claim dictionaries."""
     if value is None:
         return []
     if not isinstance(value, list | tuple):
-        raise TypeError(f"{field_name} must be a list of dictionaries, got {type(value).__name__}")
+        raise TypeError(f"{field_name} must be a list of claim dictionaries, got {type(value).__name__}")
 
-    metadata_items: list[MetadataDict] = []
-    for index, item in enumerate(value):
-        metadata_items.append(
-            _coerce_required_metadata_dict(
-                item,
-                field_name=f"{field_name}[{index}]",
-            )
+    claims = [
+        _coerce_artifact_claim(item, field_name=f"{field_name}[{index}]") for index, item in enumerate(value)
+    ]
+    return cast(list[ArtifactClaimInput], claims)
+
+
+def _coerce_artifact_claim(value: object, *, field_name: str) -> MetadataDict:
+    """Coerce one artifact claim input to a normalized claim dictionary."""
+    if isinstance(value, ArtifactClaim):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return ArtifactClaim.from_dict(value, field_name=field_name).to_dict()
+    raise TypeError(f"{field_name} must be an ArtifactClaim or dictionary, got {type(value).__name__}")
+
+
+def _coerce_artifact_facets(value: object, *, field_name: str) -> list[ArtifactFacetInput]:
+    """Coerce artifact facet input to normalized facet dictionaries."""
+    if value is None:
+        return []
+    if not isinstance(value, list | tuple):
+        raise TypeError(f"{field_name} must be a list of facet dictionaries, got {type(value).__name__}")
+
+    facets = [
+        _coerce_artifact_facet(item, field_name=f"{field_name}[{index}]") for index, item in enumerate(value)
+    ]
+    return cast(list[ArtifactFacetInput], facets)
+
+
+def _coerce_artifact_facet(value: object, *, field_name: str) -> MetadataDict:
+    """Coerce one artifact facet input to a normalized facet dictionary."""
+    if isinstance(value, ArtifactFacet):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return ArtifactFacet.from_dict(value, field_name=field_name).to_dict()
+    raise TypeError(f"{field_name} must be an ArtifactFacet or dictionary, got {type(value).__name__}")
+
+
+def _required_schema_mapping_text(
+    data: Mapping[str, object],
+    key: str,
+    *,
+    field_name: str,
+) -> str:
+    """Return a required artifact schema text field from a mapping."""
+    if key not in data:
+        raise ValueError(f"{field_name} is missing required key: {key}")
+    return _coerce_required_schema_text(data[key], field_name=f"{field_name}.{key}")
+
+
+def _optional_schema_mapping_text(
+    data: Mapping[str, object],
+    key: str,
+    *,
+    field_name: str,
+    default: str | None,
+) -> str | None:
+    """Return an optional artifact schema text field from a mapping."""
+    if key not in data or data[key] is None:
+        return default
+    return _coerce_required_schema_text(data[key], field_name=f"{field_name}.{key}")
+
+
+def _schema_mapping_text_with_default(
+    data: Mapping[str, object],
+    key: str,
+    *,
+    field_name: str,
+    default: str,
+) -> str:
+    """Return an optional artifact schema text field with a non-null default."""
+    value = _optional_schema_mapping_text(data, key, field_name=field_name, default=default)
+    if value is None:
+        return default
+    return value
+
+
+def _coerce_required_schema_text(value: object, *, field_name: str) -> str:
+    """Coerce a required artifact schema identifier to non-empty text."""
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{field_name} cannot be empty")
+    return text
+
+
+def _coerce_artifact_vocabulary(
+    value: object,
+    *,
+    field_name: str,
+    allowed: frozenset[str],
+) -> str:
+    """Validate one artifact schema vocabulary value."""
+    text = _coerce_required_schema_text(value, field_name=field_name)
+    if text not in allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise ValueError(f"{field_name} must be one of {allowed_values}; got {text!r}")
+    return text
+
+
+def _schema_metadata_with_extension_fields(
+    data: Mapping[str, object],
+    *,
+    field_name: str,
+) -> MetadataDict:
+    """Return explicit metadata plus legacy extension fields folded into it."""
+    raw_metadata = data.get("metadata", {})
+    if raw_metadata is None:
+        metadata: MetadataDict = {}
+    else:
+        metadata = _coerce_required_metadata_dict(
+            raw_metadata,
+            field_name=f"{field_name}.metadata",
         )
-    return metadata_items
+
+    extra_fields: dict[str, object] = {}
+    for key, value in data.items():
+        normalized_key = str(key)
+        if normalized_key in ARTIFACT_SCHEMA_FIELDS:
+            continue
+        if normalized_key in extra_fields:
+            raise ValueError(
+                f"{field_name} contains duplicate extension key after string normalization: "
+                f"{normalized_key!r}"
+            )
+        extra_fields[normalized_key] = value
+
+    if not extra_fields:
+        return metadata
+
+    extras = normalize_metadata(extra_fields, field_name=field_name)
+    for key, value in extras.items():
+        if key in metadata:
+            raise ValueError(f"{field_name}.metadata duplicates top-level extension key: {key!r}")
+        metadata[key] = value
+    return metadata
 
 
 def _first_data_artifact_locator(artifacts: list[ArtifactDescriptor]) -> ArtifactLocator | None:

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -63,8 +63,6 @@ STANDARD_ARTIFACT_ROLES = frozenset(
         "archive_copy",
     }
 )
-ArtifactClaimInput: TypeAlias = "ArtifactClaim | Mapping[str, object]"
-ArtifactFacetInput: TypeAlias = "ArtifactFacet | Mapping[str, object]"
 
 
 def normalize_metadata(
@@ -577,6 +575,8 @@ class ArtifactFacet:
 
 Representation = RepresentationClaim
 Facet = ArtifactFacet
+ArtifactClaimInput: TypeAlias = ArtifactClaim | Mapping[str, object]
+ArtifactFacetInput: TypeAlias = ArtifactFacet | Mapping[str, object]
 
 
 @dataclass(slots=True)

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -889,7 +889,10 @@ def _coerce_artifact_claims(value: object, *, field_name: str) -> list[ArtifactC
     if value is None:
         return []
     if not isinstance(value, list | tuple):
-        raise TypeError(f"{field_name} must be a list of claim dictionaries, got {type(value).__name__}")
+        raise TypeError(
+            f"{field_name} must be a list of ArtifactClaim objects or dictionaries, "
+            f"got {type(value).__name__}"
+        )
 
     claims = [
         _coerce_artifact_claim(item, field_name=f"{field_name}[{index}]") for index, item in enumerate(value)
@@ -911,7 +914,10 @@ def _coerce_artifact_facets(value: object, *, field_name: str) -> list[ArtifactF
     if value is None:
         return []
     if not isinstance(value, list | tuple):
-        raise TypeError(f"{field_name} must be a list of facet dictionaries, got {type(value).__name__}")
+        raise TypeError(
+            f"{field_name} must be a list of ArtifactFacet objects or dictionaries, "
+            f"got {type(value).__name__}"
+        )
 
     facets = [
         _coerce_artifact_facet(item, field_name=f"{field_name}[{index}]") for index, item in enumerate(value)

--- a/tests/test_artifact_claim_examples.py
+++ b/tests/test_artifact_claim_examples.py
@@ -1,0 +1,270 @@
+"""Claim and facet examples for common artifact shapes."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from ogcat import (
+    ArtifactDescriptor,
+    ArtifactFacet,
+    DataTypeClaim,
+    InterfaceClaim,
+    RepresentationClaim,
+    has_claim,
+    has_facet,
+)
+
+
+def test_zarr_directory_store_example_claims_directory_storage_and_zarr_interfaces() -> None:
+    """A Zarr directory store should be one directory-backed dataset artifact."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("directory", evidence="inferred"),
+            DataTypeClaim("zarr", namespace="zarr.dev", evidence="inferred"),
+            InterfaceClaim("directory-listing"),
+            InterfaceClaim("zarr-group", namespace="zarr.dev"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray"),
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="suffix",
+                name="suffixes",
+                evidence="inferred",
+                metadata={"suffixes": [".zarr"]},
+            )
+        ],
+    )
+
+    assert has_claim(descriptor, kind="representation", name="directory")
+    assert has_claim(descriptor, kind="data_type", name="zarr", namespace="zarr.dev")
+    assert has_claim(descriptor, kind="interface", name="zarr-group", namespace="zarr.dev")
+    assert has_facet(descriptor, kind="suffix", name="suffixes")
+
+
+def test_netcdf_collection_example_claims_collection_interface_and_member_facets() -> None:
+    """A directory of NetCDF members should opt into collection semantics explicitly."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("directory", evidence="declared"),
+            InterfaceClaim("collection", evidence="declared"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray", evidence="declared"),
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="collection",
+                name="members",
+                evidence="declared",
+                metadata={
+                    "pattern": "*.nc",
+                    "member_format": "netcdf",
+                    "member_suffixes": [".nc"],
+                    "reader_hint": "xarray.open_mfdataset",
+                },
+            )
+        ],
+    )
+
+    assert has_claim(descriptor, kind="representation", name="directory")
+    assert has_claim(descriptor, kind="interface", name="collection")
+    assert has_claim(descriptor, kind="interface", name="xarray-dataset", namespace="pydata.xarray")
+    assert has_facet(descriptor, kind="collection", name="members")
+
+
+def test_csv_like_data_example_claims_text_and_table_interfaces() -> None:
+    """A CSV-like artifact should be text representation with a table interface."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("text", evidence="inferred", metadata={"source": "suffix"}),
+            DataTypeClaim("csv", namespace="iana.media-types", evidence="inferred"),
+            InterfaceClaim("text"),
+            InterfaceClaim("table"),
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="suffix",
+                name="suffixes",
+                evidence="inferred",
+                metadata={"suffixes": [".csv"]},
+            )
+        ],
+    )
+
+    assert has_claim(descriptor, kind="representation", name="text")
+    assert has_claim(descriptor, kind="data_type", name="csv", namespace="iana.media-types")
+    assert has_claim(descriptor, kind="interface", name="table")
+
+
+def test_single_netcdf_example_can_claim_xarray_without_importing_xarray() -> None:
+    """A single NetCDF artifact can advertise optional interfaces without core imports."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("file", evidence="inferred"),
+            DataTypeClaim("netcdf", namespace="org.unidata", evidence="inferred"),
+            InterfaceClaim("bytes"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray", evidence="declared"),
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="suffix",
+                name="suffixes",
+                evidence="inferred",
+                metadata={"suffixes": [".nc"]},
+            )
+        ],
+    )
+
+    assert has_claim(descriptor, kind="data_type", name="netcdf", namespace="org.unidata")
+    assert has_claim(descriptor, kind="interface", name="xarray-dataset", namespace="pydata.xarray")
+
+
+def test_grouped_netcdf_example_can_represent_groups_without_opening_file() -> None:
+    """Grouped NetCDF/HDF5 files can carry group facets without reader imports."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("file", evidence="declared"),
+            DataTypeClaim("netcdf", namespace="org.unidata", evidence="declared"),
+            InterfaceClaim("netcdf-groups", namespace="org.unidata", evidence="declared"),
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="netcdf",
+                name="groups",
+                namespace="org.unidata",
+                evidence="declared",
+                metadata={"groups": ["/", "/observations", "/metadata"]},
+            )
+        ],
+    )
+
+    assert has_claim(descriptor, kind="interface", name="netcdf-groups", namespace="org.unidata")
+    assert has_facet(descriptor, kind="netcdf", name="groups", namespace="org.unidata")
+
+
+def test_csv_example_can_be_read_with_pandas_when_available(tmp_path: Path) -> None:
+    """The CSV example should align with pandas when that optional stack is present."""
+    pandas = pytest.importorskip("pandas")
+    path = tmp_path / "example.csv"
+    path.write_text("time,value\n2026-01-01,1.0\n", encoding="utf-8")
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[DataTypeClaim("csv", namespace="iana.media-types"), InterfaceClaim("table")],
+    )
+
+    frame = pandas.read_csv(path)
+
+    assert list(frame.columns) == ["time", "value"]
+    assert has_claim(descriptor, kind="interface", name="table")
+
+
+def test_zarr_example_can_be_opened_with_xarray_when_available(tmp_path: Path) -> None:
+    """The Zarr example should align with xarray/zarr when that optional stack is present."""
+    xarray = pytest.importorskip("xarray")
+    pytest.importorskip("zarr")
+    store = tmp_path / "example.zarr"
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim("directory"),
+            DataTypeClaim("zarr", namespace="zarr.dev"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray"),
+        ],
+    )
+
+    dataset = xarray.Dataset({"value": ("time", [1.0, 2.0])})
+    try:
+        dataset.to_zarr(store)
+        opened = xarray.open_zarr(store)
+    except Exception as exc:
+        pytest.skip(f"xarray/zarr stack cannot write and open a tiny Zarr store: {exc}")
+
+    assert "value" in opened
+    assert has_claim(descriptor, kind="data_type", name="zarr", namespace="zarr.dev")
+
+
+def test_single_netcdf_example_can_be_opened_with_xarray_when_available(tmp_path: Path) -> None:
+    """The NetCDF example should align with xarray when a NetCDF backend is present."""
+    xarray = pytest.importorskip("xarray")
+    engine = _available_netcdf_engine()
+    path = tmp_path / "example.nc"
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            DataTypeClaim("netcdf", namespace="org.unidata"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray"),
+        ],
+    )
+
+    dataset = xarray.Dataset({"co2": ("time", [400.0, 401.0])})
+    try:
+        dataset.to_netcdf(path, engine=engine)
+        opened = xarray.open_dataset(path, engine=engine)
+    except Exception as exc:
+        pytest.skip(f"xarray/{engine} stack cannot write and open a tiny NetCDF file: {exc}")
+
+    assert "co2" in opened
+    assert has_claim(descriptor, kind="interface", name="xarray-dataset", namespace="pydata.xarray")
+
+
+def test_grouped_netcdf_example_can_be_opened_when_backend_supports_groups(tmp_path: Path) -> None:
+    """The grouped NetCDF example should align with xarray backends that support groups."""
+    xarray = pytest.importorskip("xarray")
+    engine = _available_grouped_netcdf_engine()
+    path = tmp_path / "grouped.nc"
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[InterfaceClaim("netcdf-groups", namespace="org.unidata")],
+        facets=[
+            ArtifactFacet(
+                kind="netcdf",
+                name="groups",
+                namespace="org.unidata",
+                metadata={"groups": ["/", "/observations"]},
+            )
+        ],
+    )
+
+    dataset = xarray.Dataset({"co2": ("time", [400.0])})
+    try:
+        dataset.to_netcdf(path, engine=engine)
+        dataset.to_netcdf(path, engine=engine, mode="a", group="observations")
+        opened = xarray.open_dataset(path, engine=engine, group="observations")
+    except Exception as exc:
+        pytest.skip(f"xarray/{engine} stack cannot write and open a grouped NetCDF file: {exc}")
+
+    assert "co2" in opened
+    assert has_facet(descriptor, kind="netcdf", name="groups", namespace="org.unidata")
+
+
+def _available_netcdf_engine() -> str:
+    """Return a usable xarray NetCDF engine or skip the optional integration test."""
+    if importlib.util.find_spec("h5netcdf") is not None:
+        return "h5netcdf"
+    if importlib.util.find_spec("netCDF4") is not None:
+        return "netcdf4"
+    pytest.skip("h5netcdf or netCDF4 is required for this optional NetCDF example test")
+
+
+def _available_grouped_netcdf_engine() -> str:
+    """Return a grouped NetCDF-capable xarray engine or skip the optional test."""
+    if importlib.util.find_spec("h5netcdf") is not None:
+        return "h5netcdf"
+    if importlib.util.find_spec("netCDF4") is not None:
+        return "netcdf4"
+    pytest.skip("h5netcdf or netCDF4 is required for this optional grouped NetCDF example test")

--- a/tests/test_artifact_claim_helpers.py
+++ b/tests/test_artifact_claim_helpers.py
@@ -1,0 +1,90 @@
+"""Artifact claim and facet helper tests."""
+
+from __future__ import annotations
+
+from ogcat import (
+    ArtifactDescriptor,
+    ArtifactFacet,
+    DataTypeClaim,
+    InterfaceClaim,
+    claim_key,
+    facet_key,
+    has_claim,
+    has_facet,
+    iter_claims,
+    iter_facets,
+)
+
+
+def test_iter_claims_filters_by_kind_name_namespace_and_version() -> None:
+    """Claim helpers should return normalized claims matching all supplied filters."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            InterfaceClaim("bytes"),
+            DataTypeClaim("zarr", namespace="zarr.dev", evidence="inferred"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray", version="2026.4"),
+        ],
+    )
+
+    assert [claim["name"] for claim in iter_claims(descriptor, kind="interface")] == [
+        "bytes",
+        "xarray-dataset",
+    ]
+    assert list(
+        iter_claims(
+            descriptor,
+            kind="interface",
+            name="xarray-dataset",
+            namespace="pydata.xarray",
+            version="2026.4",
+        )
+    ) == [
+        {
+            "kind": "interface",
+            "name": "xarray-dataset",
+            "namespace": "pydata.xarray",
+            "version": "2026.4",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {},
+        }
+    ]
+
+
+def test_has_claim_and_claim_key_normalize_raw_dicts() -> None:
+    """Claim helpers should work with descriptor-normalized legacy dictionaries."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[{"kind": "representation", "name": "directory"}],
+    )
+    claim = next(iter_claims(descriptor))
+
+    assert has_claim(descriptor, kind="representation", name="directory")
+    assert not has_claim(descriptor, kind="interface", name="directory")
+    assert claim_key(claim) == ("ogcat.core", "representation", "directory", "1")
+
+
+def test_iter_facets_filters_and_keys_facets() -> None:
+    """Facet helpers should return normalized facets and stable registry keys."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        facets=[
+            ArtifactFacet(
+                kind="collection",
+                name="members",
+                evidence="declared",
+                metadata={"pattern": "*.nc", "member_format": "netcdf"},
+            ),
+            {"kind": "suffix", "name": "suffixes", "suffixes": [".zarr"]},
+        ],
+    )
+
+    collection_facets = list(iter_facets(descriptor, kind="collection"))
+
+    assert has_facet(descriptor, kind="suffix", name="suffixes")
+    assert collection_facets[0]["metadata"] == {"pattern": "*.nc", "member_format": "netcdf"}
+    assert facet_key(collection_facets[0]) == ("ogcat.core", "collection", "members", "1")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -8,7 +8,15 @@ from pathlib import Path
 
 import pytest
 
-from ogcat.models import ArtifactDescriptor, ArtifactLocator, CatalogRecord
+from ogcat.models import (
+    ArtifactDescriptor,
+    ArtifactFacet,
+    ArtifactLocator,
+    CatalogRecord,
+    DataTypeClaim,
+    InterfaceClaim,
+    RepresentationClaim,
+)
 from ogcat.tinydb_repository import TinyDbCatalogRepository
 
 
@@ -216,6 +224,220 @@ def test_record_round_trips_with_data_and_preview_artifacts() -> None:
     assert isinstance(artifacts_payload[1], dict)
     assert artifacts_payload[1]["role"] == "preview"
     assert reloaded == record
+
+
+def test_artifact_descriptor_round_trips_claim_and_facet_objects() -> None:
+    """Claim and facet helper objects should persist as JSON-compatible dictionaries."""
+    record = CatalogRecord(
+        id="rec_000105",
+        catalog="fluxes",
+        time_added="2026-04-23T12:00:00Z",
+        locator=ArtifactLocator.path("/tmp/catalog/files/example.nc"),
+        artifacts=[
+            ArtifactDescriptor(
+                id="data",
+                role="data_artifact",
+                locator=ArtifactLocator.path("/tmp/catalog/files/example.nc"),
+                claims=[
+                    InterfaceClaim(
+                        "bytes",
+                        evidence="validated",
+                        metadata={"media_type": "application/octet-stream"},
+                    ),
+                    DataTypeClaim(
+                        "netcdf",
+                        namespace="org.unidata",
+                        evidence="declared",
+                        metadata={"source": "writer"},
+                    ),
+                ],
+                facets=[
+                    ArtifactFacet(
+                        kind="stat",
+                        name="size",
+                        evidence="probed",
+                        confidence="validated",
+                        metadata={"bytes": 128},
+                    )
+                ],
+            )
+        ],
+    )
+
+    payload = record.to_dict()
+    reloaded = CatalogRecord.from_dict(payload)
+
+    artifacts = payload["artifacts"]
+    assert isinstance(artifacts, list)
+    assert isinstance(artifacts[0], dict)
+    assert artifacts[0]["claims"] == [
+        {
+            "kind": "interface",
+            "name": "bytes",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "validated",
+            "confidence": "validated",
+            "metadata": {"media_type": "application/octet-stream"},
+        },
+        {
+            "kind": "data_type",
+            "name": "netcdf",
+            "namespace": "org.unidata",
+            "version": "1",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {"source": "writer"},
+        },
+    ]
+    assert artifacts[0]["facets"] == [
+        {
+            "kind": "stat",
+            "name": "size",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "probed",
+            "confidence": "validated",
+            "metadata": {"bytes": 128},
+        }
+    ]
+    assert reloaded.to_dict() == payload
+
+
+def test_raw_claim_and_facet_dicts_are_normalized_for_compatibility() -> None:
+    """Existing raw dict claim and facet payloads should remain readable."""
+    descriptor = ArtifactDescriptor(
+        id="preview",
+        role="preview",
+        claims=[{"kind": "representation", "name": "png"}],
+        facets=[{"kind": "image", "format": "png"}],
+    )
+
+    assert descriptor.claims == [
+        {
+            "kind": "representation",
+            "name": "png",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {},
+        }
+    ]
+    assert descriptor.facets == [
+        {
+            "kind": "image",
+            "name": "image",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {"format": "png"},
+        }
+    ]
+
+
+def test_suffix_only_detection_can_be_represented_as_inferred_evidence() -> None:
+    """Suffix-based artifact facts should be expressible without claiming validation."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            RepresentationClaim(
+                "netcdf",
+                evidence="inferred",
+                confidence="inferred",
+                metadata={"source": "suffix", "suffixes": [".nc"]},
+            )
+        ],
+        facets=[
+            ArtifactFacet(
+                kind="suffix",
+                name="suffixes",
+                evidence="inferred",
+                confidence="inferred",
+                metadata={"suffixes": [".nc"]},
+            )
+        ],
+    )
+
+    payload = descriptor.to_dict()
+    claims = payload["claims"]
+    facets = payload["facets"]
+    assert isinstance(claims, list)
+    assert isinstance(claims[0], dict)
+    assert isinstance(facets, list)
+    assert isinstance(facets[0], dict)
+    assert claims[0]["evidence"] == "inferred"
+    assert claims[0]["confidence"] == "inferred"
+    assert claims[0]["metadata"] == {"source": "suffix", "suffixes": [".nc"]}
+    assert facets[0]["evidence"] == "inferred"
+
+
+def test_artifact_descriptor_accepts_multiple_interfaces_without_optional_imports() -> None:
+    """One artifact can carry multiple capability claims without importing readers."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[
+            InterfaceClaim("bytes"),
+            DataTypeClaim("netcdf", namespace="org.unidata", evidence="inferred"),
+            InterfaceClaim("xarray-dataset", namespace="pydata.xarray", evidence="declared"),
+        ],
+    )
+
+    claims = descriptor.to_dict()["claims"]
+    assert isinstance(claims, list)
+    claim_keys = [
+        (claim["kind"], claim["namespace"], claim["name"]) for claim in claims if isinstance(claim, dict)
+    ]
+    assert claim_keys == [
+        ("interface", "ogcat.core", "bytes"),
+        ("data_type", "org.unidata", "netcdf"),
+        ("interface", "pydata.xarray", "xarray-dataset"),
+    ]
+
+
+def test_invalid_artifact_claim_shapes_raise_helpful_errors() -> None:
+    """Invalid claim and facet shapes should fail during descriptor construction."""
+    with pytest.raises(ValueError, match="claims\\[0\\] is missing required key: name"):
+        ArtifactDescriptor(id="data", role="data_artifact", claims=[{"kind": "representation"}])
+
+    with pytest.raises(ValueError, match="evidence must be one of"):
+        ArtifactDescriptor(
+            id="data",
+            role="data_artifact",
+            claims=[{"kind": "representation", "name": "netcdf", "evidence": "guessed"}],
+        )
+
+    with pytest.raises(TypeError, match="facets\\[0\\]\\.metadata must be a dictionary"):
+        ArtifactDescriptor(
+            id="data",
+            role="data_artifact",
+            facets=[{"kind": "stat", "name": "size", "metadata": ["not", "a", "dict"]}],
+        )
+
+
+def test_repository_load_rejects_invalid_artifact_claim_shape(tmp_path: Path) -> None:
+    """Repository reads should surface invalid persisted claim shapes."""
+    repository = TinyDbCatalogRepository(tmp_path / "db.json")
+    repository._db.insert(
+        {
+            "catalog": "fluxes",
+            "time_added": "2026-04-23T12:00:00Z",
+            "artifacts": [
+                {
+                    "id": "data",
+                    "role": "data_artifact",
+                    "claims": [{"kind": "representation", "name": "netcdf", "confidence": "guessed"}],
+                    "facets": [],
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="confidence must be one of"):
+        repository.get("1")
 
 
 def test_data_artifact_locator_refreshes_compatibility_path_fields() -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 from pathlib import Path
+from typing import get_args, get_type_hints
 
 import pytest
 
 from ogcat.models import (
+    ArtifactClaim,
     ArtifactDescriptor,
     ArtifactFacet,
     ArtifactLocator,
@@ -335,6 +337,16 @@ def test_raw_claim_and_facet_dicts_are_normalized_for_compatibility() -> None:
             "metadata": {"format": "png"},
         }
     ]
+
+
+def test_artifact_descriptor_claim_facet_type_hints_resolve_runtime_aliases() -> None:
+    """Runtime type-hint consumers should see concrete claim and facet input aliases."""
+    hints = get_type_hints(ArtifactDescriptor)
+    claim_input = get_args(hints["claims"])[0]
+    facet_input = get_args(hints["facets"])[0]
+
+    assert ArtifactClaim in get_args(claim_input)
+    assert ArtifactFacet in get_args(facet_input)
 
 
 def test_suffix_only_detection_can_be_represented_as_inferred_evidence() -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -403,6 +403,15 @@ def test_invalid_artifact_claim_shapes_raise_helpful_errors() -> None:
     with pytest.raises(ValueError, match="claims\\[0\\] is missing required key: name"):
         ArtifactDescriptor(id="data", role="data_artifact", claims=[{"kind": "representation"}])
 
+    with pytest.raises(ValueError, match="claims\\[0\\]\\.kind cannot be None"):
+        ArtifactDescriptor(id="data", role="data_artifact", claims=[{"kind": None, "name": "netcdf"}])
+
+    with pytest.raises(TypeError, match="claims\\[0\\]\\.name must be a string"):
+        ArtifactDescriptor(id="data", role="data_artifact", claims=[{"kind": "representation", "name": 123}])
+
+    with pytest.raises(TypeError, match="facets\\[0\\]\\.kind must be a string"):
+        ArtifactDescriptor(id="data", role="data_artifact", facets=[{"kind": 123, "name": "size"}])
+
     with pytest.raises(ValueError, match="evidence must be one of"):
         ArtifactDescriptor(
             id="data",


### PR DESCRIPTION
## Summary
- Added explicit JSON-compatible models for artifact claims and facets in `src/ogcat/models.py`
- Supported core claim types for data type, representation, and interface while keeping namespaces open for plugins
- Normalized existing raw dict payloads and kept legacy catalog records readable
- Documented the schema choice and the relationship to `derived_metadata.classification`
- Added repository tests covering round-trips, inferred suffix evidence, invalid shapes, and multiple interface claims

Closes #116 

## Testing
- `uv run pytest tests/test_repository.py -q`
- `uv run pytest tests/test_add.py -q`
- `uv run pytest tests/test_secondary_artifacts.py -q`
- `uv run pytest`
- `uv run ruff check src/ogcat/models.py src/ogcat/__init__.py tests/test_repository.py`
- `uv run ruff format --check src/ogcat/models.py src/ogcat/__init__.py tests/test_repository.py`
- `uv run pyright`
- `uv run sphinx-build -b html docs /private/tmp/ogcat-docs-build`