### PR TITLE
Create reader, writer, and converter capability registry

### DIFF
--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -239,6 +239,18 @@ Plugin or optional-extra responsibilities:
   external storage integrations.
 - Domain validation and source-specific versioning rules.
 
+Implementation clarification for #119: the first capability registry slice is a
+registration and lookup layer only. Selection starts from explicit caller
+requests for input and output claims or interfaces and matches those requests
+against `ArtifactDescriptor` claims and facets. It must not dispatch from
+`record_type`. If one artifact advertises several interfaces, such as bytes,
+text, table, and JSON, selection should report ambiguity until the caller asks
+for a specific enough interface. Public read-handle lifecycle APIs remain #118,
+and catalog merge of writer-produced artifact claims/facets remains #117.
+Bundled examples such as bytes, text-with-encoding, CSV/table, JSON, and an
+emoticon-to-emoji converter should register through the same plugin-style route
+as external capabilities.
+
 ## Handle Lifetime
 
 Operations should own cleanup for handles they open. Internally, this should

--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -249,9 +249,12 @@ for a specific enough interface. Public read-handle lifecycle APIs remain #118,
 and catalog merge of writer-produced artifact claims/facets remains #117.
 Bundled examples such as bytes, text-with-encoding, CSV/table, JSON, and an
 emoticon-to-emoji converter should register through the same plugin-style route
-as external capabilities. A text-to-text converter can be selected for a
-CSV-like artifact only when the caller requests text input and text output; it
-should not satisfy requests for CSV/table output claims.
+as external capabilities. Because the bundled implementations are local-path
+backed, their descriptors declare a path locator facet; selection should reject
+remote or otherwise non-path descriptors before runtime. A text-to-text
+converter can be selected for a CSV-like artifact only when the caller requests
+text input and text output; it should not satisfy requests for CSV/table output
+claims.
 
 ## Handle Lifetime
 

--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -249,7 +249,9 @@ for a specific enough interface. Public read-handle lifecycle APIs remain #118,
 and catalog merge of writer-produced artifact claims/facets remains #117.
 Bundled examples such as bytes, text-with-encoding, CSV/table, JSON, and an
 emoticon-to-emoji converter should register through the same plugin-style route
-as external capabilities.
+as external capabilities. A text-to-text converter can be selected for a
+CSV-like artifact only when the caller requests text input and text output; it
+should not satisfy requests for CSV/table output claims.
 
 ## Handle Lifetime
 

--- a/docs/api/capabilities.rst
+++ b/docs/api/capabilities.rst
@@ -43,6 +43,12 @@ does not dispatch by ``CatalogRecord.record_type``. If a descriptor advertises
 several interfaces, callers should request the exact desired interface through
 ``input_claims`` and/or ``output_claims``.
 
+Claim matching uses the claim namespace/kind/name/version envelope only; claim
+metadata is descriptive. Facet matching uses the facet envelope plus required
+metadata as a subset, so values that must influence dispatch, such as text
+encodings, table delimiters, member identifiers, or local path requirements,
+belong in facets.
+
 Errors
 ------
 

--- a/docs/api/capabilities.rst
+++ b/docs/api/capabilities.rst
@@ -61,6 +61,11 @@ Errors
    :member-order: bysource
    :no-show-inheritance:
 
+.. autoclass:: ogcat.InvalidCapabilityLookupError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
 .. autoclass:: ogcat.MissingCapabilityError
    :members:
    :member-order: bysource

--- a/docs/api/capabilities.rst
+++ b/docs/api/capabilities.rst
@@ -1,0 +1,77 @@
+Capabilities
+============
+
+.. module:: ogcat.capabilities
+
+The capability API is the public surface for #119 reader, writer, and converter
+registration and lookup. It is a registry layer: it records typed
+declarations and returns matching declarations with optional opaque
+implementation objects. Public read handles, ``open_artifact()``, and catalog
+writer-result merge are separate follow-up APIs.
+
+Registry
+--------
+
+.. autoclass:: ogcat.CapabilityRegistry
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+Capability declarations
+-----------------------
+
+.. autoclass:: ogcat.ArtifactCapability
+   :members:
+   :member-order: bysource
+   :exclude-members: kind, name, namespace, version, input_claims, output_claims, required_facets, options, metadata, implementation
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.CapabilityKind
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+Lookup behavior
+---------------
+
+``CapabilityRegistry.find(...)`` returns all matching
+``ArtifactCapability`` objects in registration order. ``select(...)`` returns
+exactly one match or raises a lookup error.
+
+Artifact lookup uses :class:`ogcat.ArtifactDescriptor` claims and facets. It
+does not dispatch by ``CatalogRecord.record_type``. If a descriptor advertises
+several interfaces, callers should request the exact desired interface through
+``input_claims`` and/or ``output_claims``.
+
+Errors
+------
+
+.. autoclass:: ogcat.CapabilityError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.CapabilityRegistrationError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.CapabilityLookupError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.MissingCapabilityError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.UnsupportedInterfaceError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:
+
+.. autoclass:: ogcat.AmbiguousCapabilityError
+   :members:
+   :member-order: bysource
+   :no-show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -22,6 +22,7 @@ Public API
    storage
    replicas
    hooks
+   capabilities
    validation
    writers-transactions
 

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -158,6 +158,12 @@ member facets, and collection readers can use member-pattern facets. These
 facts are plugin-readable metadata; they do not require core to import optional
 scientific libraries.
 
+Capability selection treats claim metadata as descriptive. Claims match by
+their namespace/kind/name/version envelope. Facets match by the same envelope
+plus required metadata as a subset, so dispatch-significant details such as
+encoding values, delimiters, archive members, or local path requirements should
+be modeled as facets.
+
 ## Worked Examples
 
 These examples are design targets for writers, inspectors, and future readers.

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -138,6 +138,26 @@ slice without duplicating normalization logic: ``iter_claims()``,
 ``has_claim()``, ``claim_key()``, ``iter_facets()``, ``has_facet()``, and
 ``facet_key()``.
 
+## Relationship To Capability Selection
+
+The #119 capability registry uses these claims and facets as dispatch facts.
+It should inspect the ``ArtifactDescriptor`` attached to the artifact being
+read, written, or converted; it should not use ``CatalogRecord.record_type`` as
+an I/O dispatch key.
+
+Selection is explicit. A single artifact may legitimately advertise several
+interfaces at the same time, for example bytes, text, table, and JSON. A caller
+that asks only to "read" such an artifact has not supplied enough information.
+The registry should raise an ambiguity error until the caller requests a
+specific interface or output claim such as ``interface=text`` or
+``interface=table``.
+
+Facets make otherwise similar claims precise. Text readers can use encoding
+facets, delimited-table readers can use dialect facets, archive readers can use
+member facets, and collection readers can use member-pattern facets. These
+facts are plugin-readable metadata; they do not require core to import optional
+scientific libraries.
+
 ## Worked Examples
 
 These examples are design targets for writers, inspectors, and future readers.

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -117,8 +117,8 @@ once. For example, a CSV artifact may advertise:
 - `interface=table`;
 - `data_type=csv`;
 - `representation=text`;
-- `encoding/charset=utf-8`;
-- `delimiter/value=,`.
+- `encoding/charset` with metadata `{"encoding": "utf-8"}`;
+- `format/delimited-text` with metadata `{"delimiter": ","}`.
 
 That descriptor is intentionally ambiguous if the caller asks only to "read"
 it. The caller must request a specific input interface such as

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -44,7 +44,10 @@ Each declaration needs stable identity and typed input/output requirements:
 - `version`: declaration contract version.
 - `input_claims`: exact claims or claim patterns the capability can accept.
 - `output_claims`: exact claims or claim patterns the capability can produce.
-- `required_facets`: optional structured facts required for lookup.
+- `required_facets`: optional structured facts required for lookup. Matching
+  uses the facet namespace/kind/name/version envelope plus required metadata as
+  a subset, so `encoding=utf-8` and `encoding=ascii` can be distinguished even
+  when the discriminating value lives in `facet.metadata`.
 - `metadata`: optional structured facts the capability promises or records
   about produced outputs.
 - `options`: optional plugin-owned JSON-compatible option metadata.
@@ -122,6 +125,14 @@ it. The caller must request a specific input interface such as
 `interface=bytes`, `interface=text`, or `interface=table`. `select()` should
 raise an ambiguity error until the request is specific enough.
 
+Facet requirements are metadata-aware. A capability that requires an
+`encoding/charset` facet with metadata `{"encoding": "utf-8"}` should match a
+descriptor facet with the same envelope and at least that metadata, but it
+should not match a descriptor that declares `{"encoding": "ascii"}`.
+If a capability can use any declared value for that facet, it should require
+the facet envelope with empty metadata and then interpret the actual descriptor
+metadata at runtime.
+
 Writers and converters use the same rule. A caller requests exact input and
 output claims or interfaces:
 
@@ -138,7 +149,8 @@ The registry may return candidate matches through a `find()` method and a
 single match through `select()`. Missing, unsupported, and ambiguous matches
 should raise distinct errors so callers can explain whether a plugin is absent,
 the artifact lacks required claims/facets, or the request needs a more exact
-interface.
+interface. Malformed lookup filters should raise a lookup-domain validation
+error rather than leaking raw schema normalization exceptions.
 
 ## Dispatch Inputs
 

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -1,0 +1,235 @@
+# Design Note: Capability Registry
+
+This note records the #119 documentation slice for reader, writer, and
+converter capability registration and lookup. It follows ADR 0002 and the
+artifact claim/facet schema note.
+
+The scope is deliberately narrow:
+
+- define how capabilities are declared, registered, and selected;
+- dispatch by `ArtifactDescriptor` claims and facets, not by `record_type`;
+- explain how bundled and external plugins use the same route;
+- preserve room for future typed reader handles and writer-result merging.
+
+This slice does not define the public `open_artifact()` API, read-handle
+lifecycle, shell-like pipeline syntax, or catalog merge of writer-returned
+artifact descriptors. Those remain separate work items.
+
+## Core Idea
+
+A capability is a typed declaration, optionally paired with an opaque runtime
+implementation object. The declaration says what the implementation can accept
+and produce. The registry stores those declarations and answers lookup
+questions. Core does not infer behavior from a Python object alone.
+
+The three initial capability kinds are:
+
+- `reader`: opens an artifact or source through one requested interface;
+- `writer`: materializes one requested output artifact shape or interface;
+- `converter`: converts one runtime interface to another.
+
+Capability declarations are data. Implementations are opaque to the registry.
+An implementation may be a function, object, class instance, protocol
+implementation, or plugin-owned adapter. The registry may return it, but this
+slice does not make core invoke it implicitly.
+
+## Declaration Shape
+
+Each declaration needs stable identity and typed input/output requirements:
+
+- `kind`: `reader`, `writer`, or `converter`.
+- `name`: namespace-local capability name.
+- `namespace`: owner namespace such as `ogcat.core`, a package name, plugin id,
+  or reverse-DNS name.
+- `version`: declaration contract version.
+- `input_claims`: exact claims or claim patterns the capability can accept.
+- `output_claims`: exact claims or claim patterns the capability can produce.
+- `required_facets`: optional structured facts required for lookup.
+- `metadata`: optional structured facts the capability promises or records
+  about produced outputs.
+- `options`: optional plugin-owned JSON-compatible option metadata.
+- `implementation`: optional opaque runtime object registered with the
+  declaration.
+
+The registry validates the common envelope and JSON-compatible declaration
+metadata. Plugin-owned option schemas and implementation objects remain
+plugin-owned. Core should not import pandas, xarray, Zarr, Intake, or
+OpenGHG-specific packages to validate declarations for those domains.
+
+## Registration
+
+Core, bundled plugins, and external plugins register through the same route:
+
+```python
+from ogcat.capabilities import ArtifactCapability, CapabilityKind, CapabilityRegistry
+
+
+registry = CapabilityRegistry()
+registry.register(
+    ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="utf8-text-reader",
+        namespace="ogcat.stdlib",
+        input_claims=[
+            {"kind": "interface", "name": "text"},
+            {"kind": "representation", "name": "text"},
+        ],
+        output_claims=[
+            {"kind": "interface", "name": "text"},
+        ],
+        required_facets=[
+            {"kind": "encoding", "name": "charset", "metadata": {"encoding": "utf-8"}},
+        ],
+        implementation=object(),
+    ),
+)
+```
+
+Registration is additive. If a plugin wants to replace or shadow a capability,
+it should do so explicitly by name/version or through a caller-supplied registry
+composition policy. `find()` returns matches in registration order for
+diagnostics and UI display, but `select()` does not use registration order to
+pick a winner from ambiguous matches.
+
+## Lookup And Selection
+
+Lookup starts from a request, not from `record_type`. The request names the
+kind of capability and the exact interface or output the caller wants. For
+artifact reads, the input facts come from an `ArtifactDescriptor`:
+
+```python
+match = registry.select(
+    kind="reader",
+    descriptor=descriptor,
+    input_claims=[{"kind": "interface", "name": "table"}],
+)
+```
+
+The selector compares the request against the artifact's claims/facets and the
+registered capability declarations. A descriptor can claim many interfaces at
+once. For example, a CSV artifact may advertise:
+
+- `interface=bytes`;
+- `interface=text`;
+- `interface=table`;
+- `data_type=csv`;
+- `representation=text`;
+- `encoding/charset=utf-8`;
+- `delimiter/value=,`.
+
+That descriptor is intentionally ambiguous if the caller asks only to "read"
+it. The caller must request a specific input interface such as
+`interface=bytes`, `interface=text`, or `interface=table`. `select()` should
+raise an ambiguity error until the request is specific enough.
+
+Writers and converters use the same rule. A caller requests exact input and
+output claims or interfaces:
+
+```python
+emoji_converter = registry.select(
+    kind=CapabilityKind.CONVERTER,
+    name="emoticon-to-emoji",
+    input_claims=[{"kind": "interface", "name": "text"}],
+    output_claims=[{"kind": "interface", "name": "text"}],
+)
+```
+
+The registry may return candidate matches through a `find()` method and a
+single match through `select()`. Missing, unsupported, and ambiguous matches
+should raise distinct errors so callers can explain whether a plugin is absent,
+the artifact lacks required claims/facets, or the request needs a more exact
+interface.
+
+## Dispatch Inputs
+
+Dispatch uses `ArtifactDescriptor` facts:
+
+- claims: data type, representation, and interface contracts;
+- facets: encoding, suffixes, table dialect, archive members, collection
+  members, validation state, and plugin-owned structured facts;
+- optional caller request details: output interface, namespace/version, options,
+  trust policy, and desired materialization behavior.
+
+Dispatch must not use `CatalogRecord.record_type` as an I/O key. `record_type`
+remains logical/schema metadata for validation, naming, and search. Two records
+with different `record_type` values may point at artifacts with the same
+capabilities. One record may also own several artifacts with different
+capabilities.
+
+## Relationship To PluginRegistry
+
+`PluginRegistry` remains the lifecycle hook registry. It owns objects that
+participate in operation hooks such as `before_validate_metadata`,
+`extract_metadata`, and `after_commit`.
+
+The capability registry owns typed declarations for readers, writers, and
+converters. A plugin object may contribute both lifecycle hooks and capability
+declarations, but those are different extension points:
+
+- hooks observe or mutate catalog operations at lifecycle points;
+- capabilities declare typed artifact access, materialization, or conversion
+  contracts;
+- implementations may need `OperationContext` later, but registration and
+  lookup do not require a hook method;
+- core, bundled plugins, and external plugins all register capability
+  declarations through the same capability route.
+
+One practical shape is for `PluginRegistry` to expose or feed a
+`CapabilityRegistry` during catalog setup. That keeps user ergonomics close to
+today's plugin registration while preserving the design boundary between hooks
+and typed capabilities.
+
+## Bundled Stdlib Examples
+
+The first examples should stay dependency-light and use only the Python
+standard library. They should live in bundled plugin-style submodules and be
+registered like external plugin capabilities, not as special cases hard-coded
+into core dispatch.
+
+Useful examples:
+
+- bytes reader/writer declarations for file-like artifacts;
+- text reader/writer declarations with encoding facets such as UTF-8 and ASCII;
+- CSV and other delimited table readers using `csv`, with bytes, text, and
+  table interfaces advertised separately;
+- JSON reader/writer declarations using `json`, with `interface=json`;
+- an emoticon-to-emoji text converter that maps ASCII emoticons such as `:)` to
+  Unicode emoji.
+
+These examples are meant to exercise the registry design. They must not bend
+core matching rules to make toy examples pass, and they must not introduce
+optional scientific dependencies. NetCDF, HDF5, Zarr, xarray, pandas, Intake,
+and OpenGHG-specific behavior remain optional plugin territory.
+
+## Preserved Testing Request
+
+When #119 moves from documentation into implementation, preserve this testing
+scope:
+
+- implement complete examples for text, CSV and other delimited tables, and
+  JSON using built-in libraries;
+- keep example reader, writer, and converter code in bundled plugin-style
+  submodules and register it the same way an external plugin would register;
+- use facets for text encodings;
+- include a regression test that converts ASCII emoticons such as `:)` to
+  Unicode emoji, saves the result with correct text claims and encoding facets,
+  and then selects an appropriate text reader;
+- show that CSV-like data can be read in multiple ways, including bytes, text,
+  and table;
+- avoid bending the core registry design to make examples work;
+- where appropriate, demonstrate claim/facet-based reader selection for data
+  that is not catalogued;
+- allow the registry to store and return runtime implementation objects, but do
+  not make core invoke them implicitly;
+- keep reader handle APIs for #118 and catalog writer-result merge for #117.
+
+## Deferred
+
+This note intentionally leaves several choices to implementation:
+
+- exact ranking rules beyond "specific request beats ambiguous request";
+- trust and authentication policy for third-party plugin declarations;
+- how `PluginRegistry` exposes capability contribution methods;
+- the read-handle API that consumes selected reader implementations;
+- the writer-result model that persists produced claims/facets;
+- optional integration with Intake pipelines or other external registries.

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -55,9 +55,14 @@ Each declaration needs stable identity and typed input/output requirements:
   declaration.
 
 The registry validates the common envelope and JSON-compatible declaration
-metadata. Plugin-owned option schemas and implementation objects remain
-plugin-owned. Core should not import pandas, xarray, Zarr, Intake, or
-OpenGHG-specific packages to validate declarations for those domains.
+metadata. Claim matching is envelope-only: claim metadata is descriptive and is
+not dispatch-significant in this slice. Facet metadata is dispatch-significant
+through subset matching, so plugin authors should put values such as encodings,
+delimiters, member names, or locator requirements in facets rather than claim
+metadata when selection must inspect them. Plugin-owned option schemas and
+implementation objects remain plugin-owned. Core should not import pandas,
+xarray, Zarr, Intake, or OpenGHG-specific packages to validate declarations for
+those domains.
 
 ## Registration
 
@@ -116,6 +121,8 @@ once. For example, a CSV artifact may advertise:
 - `interface=text`;
 - `interface=table`;
 - `data_type=csv`;
+- `representation=file` or a plugin-owned `locator/path` facet for a local
+  path-backed implementation;
 - `representation=text`;
 - `encoding/charset` with metadata `{"encoding": "utf-8"}`;
 - `format/delimited-text` with metadata `{"delimiter": ","}`.
@@ -131,7 +138,9 @@ descriptor facet with the same envelope and at least that metadata, but it
 should not match a descriptor that declares `{"encoding": "ascii"}`.
 If a capability can use any declared value for that facet, it should require
 the facet envelope with empty metadata and then interpret the actual descriptor
-metadata at runtime.
+metadata at runtime. Runtime helpers should consume the same namespaced
+facet/version that the capability declares, so unrelated plugins cannot change
+behavior by using the same facet kind/name in their own namespace.
 
 Writers and converters use the same rule. A caller requests exact input and
 output claims or interfaces:
@@ -200,8 +209,11 @@ into core dispatch.
 
 Useful examples:
 
-- bytes reader/writer declarations for file-like artifacts;
-- text reader/writer declarations with encoding facets such as UTF-8 and ASCII;
+- bytes reader/writer declarations for local path-backed artifacts, using a
+  path locator facet rather than relying on `ArtifactLocator.kind` during
+  registry matching;
+- text reader/writer declarations with path locator and encoding facets such as
+  UTF-8 and ASCII;
 - CSV and other delimited table readers using `csv`, with bytes, text, and
   table interfaces advertised separately;
 - JSON reader/writer declarations using `json`, with `interface=json`;

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -194,12 +194,19 @@ Useful examples:
   table interfaces advertised separately;
 - JSON reader/writer declarations using `json`, with `interface=json`;
 - an emoticon-to-emoji text converter that maps ASCII emoticons such as `:)` to
-  Unicode emoji.
+  Unicode emoji;
+- a Pig Latin text converter that shows CSV-like descriptors can be routed as
+  text when text input and text output are requested, but the same converter
+  must not be selected when the requested output is CSV or a table.
 
 These examples are meant to exercise the registry design. They must not bend
 core matching rules to make toy examples pass, and they must not introduce
 optional scientific dependencies. NetCDF, HDF5, Zarr, xarray, pandas, Intake,
 and OpenGHG-specific behavior remain optional plugin territory.
+The bundled converter implementations call the bundled text reader and writer
+directly only to keep this slice executable without the future handle API. That
+is useful as a plugin-style pressure test, but it is not the intended long-term
+pipeline executor.
 
 ## Preserved Testing Request
 
@@ -233,3 +240,6 @@ This note intentionally leaves several choices to implementation:
 - the read-handle API that consumes selected reader implementations;
 - the writer-result model that persists produced claims/facets;
 - optional integration with Intake pipelines or other external registries.
+- a converter orchestration layer that passes opened handles or runtime values
+  between readers, filters, and writers so chained conversions do not repeat
+  reader/writer boilerplate.

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -4,6 +4,12 @@
 `ogcat` core. A plugin is just a Python object with one or more hook methods registered on a
 `PluginRegistry` or `HookManager`.
 
+Capability registration is a separate extension point. Lifecycle hooks observe
+or mutate catalog operations; capability declarations describe typed readers,
+writers, and converters that can be selected from artifact claims and facets.
+A single plugin object may provide both, but the capability registry remains a
+registration and lookup layer rather than another hook lifecycle.
+
 Hooks are called in registration order. Most hook failures fail the catalog operation and use the
 normal transaction rollback path. `after_commit` is different: it runs after the catalog operation
 has already committed, so failures are reported as Python warnings rather than changing a successful
@@ -245,3 +251,24 @@ The context includes the catalog root, operation id, operation type, record type
 derived metadata, planned locators, source information, storage mode, and rollback registration.
 `context.source_path` and `context.source_descriptor` remain compatibility shims over
 `context.source.path` and `context.source.descriptor`.
+
+## Relationship To Capability Declarations
+
+The #119 capability registry builds on the plugin ergonomics described here
+without merging lifecycle hooks and typed artifact access. `PluginRegistry`
+continues to collect hook objects for operation lifecycle points. A
+`CapabilityRegistry` collects declarations for readers, writers, and
+converters: what input claims or interfaces they accept, what output claims or
+interfaces they produce, and any plugin-owned option metadata.
+
+Bundled capabilities and external capabilities should register the same way.
+For example, dependency-light bundled examples for bytes, text with encoding
+facets, CSV/table access, JSON access, and an emoticon-to-emoji converter can
+ship as plugin-style modules. Scientific readers such as xarray, pandas, Zarr,
+NetCDF, HDF5, Intake, or OpenGHG-specific integrations stay optional and should
+not become core imports merely because the registry can describe them.
+
+Capability lookup dispatches by `ArtifactDescriptor` claims and facets, not by
+`record_type`. It also requires explicit selection: if an artifact can be read
+as bytes, text, and table, callers must ask for the desired interface before
+the registry returns one selected capability.

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -264,9 +264,12 @@ interfaces they produce, and any plugin-owned option metadata.
 Bundled capabilities and external capabilities should register the same way.
 For example, dependency-light bundled examples for bytes, text with encoding
 facets, CSV/table access, JSON access, and an emoticon-to-emoji converter can
-ship as plugin-style modules. Scientific readers such as xarray, pandas, Zarr,
-NetCDF, HDF5, Intake, or OpenGHG-specific integrations stay optional and should
-not become core imports merely because the registry can describe them.
+ship as plugin-style modules. A playful text-to-text converter such as Pig
+Latin can also exercise the boundary: a CSV-like artifact may be selected as
+text input, but that converter still cannot advertise CSV/table output.
+Scientific readers such as xarray, pandas, Zarr, NetCDF, HDF5, Intake, or
+OpenGHG-specific integrations stay optional and should not become core imports
+merely because the registry can describe them.
 
 Capability lookup dispatches by `ArtifactDescriptor` claims and facets, not by
 `record_type`. It also requires explicit selection: if an artifact can be read

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ searching records.
    design-note-artifact-locators
    design-note-artifact-descriptors
    design-note-artifact-claims-and-facets
+   design-note-capability-registry
    design-note-hooks-plugins
    design-note-virtual-artifact-filesystem-research
    ogcat_long_term_plan

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -2,6 +2,17 @@
 
 from ogcat.artifact_claims import claim_key, facet_key, has_claim, has_facet, iter_claims, iter_facets
 from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events
+from ogcat.capabilities import (
+    AmbiguousCapabilityError,
+    ArtifactCapability,
+    CapabilityError,
+    CapabilityKind,
+    CapabilityLookupError,
+    CapabilityRegistrationError,
+    CapabilityRegistry,
+    MissingCapabilityError,
+    UnsupportedInterfaceError,
+)
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
@@ -66,6 +77,8 @@ from ogcat.writers import (
 )
 
 __all__ = [
+    "AmbiguousCapabilityError",
+    "ArtifactCapability",
     "ArtifactLocator",
     "ArtifactClaim",
     "ArtifactDescriptor",
@@ -73,6 +86,11 @@ __all__ = [
     "ArtifactWriter",
     "AuditEvent",
     "AuditSink",
+    "CapabilityError",
+    "CapabilityKind",
+    "CapabilityLookupError",
+    "CapabilityRegistrationError",
+    "CapabilityRegistry",
     "Catalog",
     "CatalogRecord",
     "CatalogRecordSet",
@@ -96,6 +114,7 @@ __all__ = [
     "JsonlAuditSink",
     "LocalStorageAdapter",
     "MetadataFieldDescription",
+    "MissingCapabilityError",
     "MoveArtifactWriter",
     "OperationState",
     "OperationContext",
@@ -119,6 +138,7 @@ __all__ = [
     "UnitOfWork",
     "UnzipArtifactWriter",
     "UnzipSingleFileArtifactWriter",
+    "UnsupportedInterfaceError",
     "ValidationIssue",
     "ValidationReport",
     "validate_metadata",

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -1,4 +1,10 @@
-"""Public package interface for ogcat."""
+"""Public package interface for ogcat.
+
+The top-level namespace re-exports the catalog APIs, descriptor and locator
+models, artifact claim/facet helpers, lifecycle hook plumbing, storage helpers,
+writers, validation, search, replicas, and the capability registry models used
+for reader, writer, and converter discovery.
+"""
 
 from ogcat.artifact_claims import claim_key, facet_key, has_claim, has_facet, iter_claims, iter_facets
 from ogcat.audit import AuditEvent, AuditSink, JsonlAuditSink, read_audit_events

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -10,6 +10,7 @@ from ogcat.capabilities import (
     CapabilityLookupError,
     CapabilityRegistrationError,
     CapabilityRegistry,
+    InvalidCapabilityLookupError,
     MissingCapabilityError,
     UnsupportedInterfaceError,
 )
@@ -91,6 +92,7 @@ __all__ = [
     "CapabilityLookupError",
     "CapabilityRegistrationError",
     "CapabilityRegistry",
+    "InvalidCapabilityLookupError",
     "Catalog",
     "CatalogRecord",
     "CatalogRecordSet",

--- a/src/ogcat/bundled_plugins/__init__.py
+++ b/src/ogcat/bundled_plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Bundled plugin examples shipped with ogcat."""
+
+from ogcat.bundled_plugins.stdlib_io import register_stdlib_capabilities, stdlib_capabilities
+
+__all__ = ["register_stdlib_capabilities", "stdlib_capabilities"]

--- a/src/ogcat/bundled_plugins/__init__.py
+++ b/src/ogcat/bundled_plugins/__init__.py
@@ -1,4 +1,9 @@
-"""Bundled plugin examples shipped with ogcat."""
+"""Bundled plugin registration helpers shipped with ogcat.
+
+The bundled namespace contains dependency-light examples that register through
+the same extension points as external plugins. The current implementation
+exports the stdlib I/O capability examples for tests and documentation.
+"""
 
 from ogcat.bundled_plugins.stdlib_io import register_stdlib_capabilities, stdlib_capabilities
 

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -1,4 +1,18 @@
-"""Dependency-free stdlib reader, writer, and converter capability examples."""
+"""Dependency-free stdlib reader, writer, and converter examples.
+
+This bundled module is intentionally shaped like a plugin: it declares
+``ArtifactCapability`` objects, stores opaque implementation instances on those
+declarations, and registers through the same capability registry route that an
+external package would use. The implementations are small stdlib examples for
+tests and documentation, not privileged core behavior.
+
+All implementations in this module are local-path backed. Their declarations
+therefore require the stdlib ``locator/path`` facet in addition to interface and
+format claims. Text, table, and JSON examples also require stdlib-owned facets
+for encoding and delimiter information. Runtime helpers consume only facets from
+this module's namespace/version so plugin-owned facts with the same kind/name do
+not silently alter stdlib behavior.
+"""
 
 from __future__ import annotations
 
@@ -40,7 +54,18 @@ class BytesReader:
     """Read path-backed artifacts as raw bytes."""
 
     def read(self, descriptor: ArtifactDescriptor) -> bytes:
-        """Read bytes from the descriptor's path locator."""
+        """Read bytes from the descriptor's path locator.
+
+        Args:
+            descriptor: Path-backed artifact descriptor to read.
+
+        Returns:
+            Raw bytes stored at the descriptor path.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be read.
+        """
         return _descriptor_path(descriptor).read_bytes()
 
 
@@ -48,11 +73,24 @@ class BytesWriter:
     """Write path-backed artifacts as raw bytes."""
 
     def write(self, descriptor: ArtifactDescriptor, data: bytes) -> ArtifactDescriptor:
-        """Write bytes to the descriptor's path locator and return descriptor metadata."""
+        """Write bytes to the descriptor's path locator.
+
+        Args:
+            descriptor: Path-backed output descriptor.
+            data: Bytes to write.
+
+        Returns:
+            Descriptor metadata with bytes/file claims and path locator facet.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be written.
+        """
         _descriptor_path(descriptor).write_bytes(data)
         return descriptor_with_claims(
             descriptor,
             claims=(InterfaceClaim("bytes"), RepresentationClaim("file")),
+            facets=(path_locator_facet(),),
         )
 
 
@@ -60,7 +98,20 @@ class TextReader:
     """Read path-backed artifacts as text using descriptor encoding facets."""
 
     def read(self, descriptor: ArtifactDescriptor) -> str:
-        """Read text from the descriptor's path locator."""
+        """Read text from the descriptor's path locator.
+
+        Args:
+            descriptor: Path-backed descriptor with a stdlib encoding facet.
+
+        Returns:
+            Decoded text content.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be read.
+            UnicodeError: If the file cannot be decoded with the declared
+                encoding.
+        """
         return _descriptor_path(descriptor).read_text(
             encoding=encoding_from_descriptor(descriptor),
         )
@@ -76,13 +127,30 @@ class TextWriter:
         *,
         encoding: str | None = None,
     ) -> ArtifactDescriptor:
-        """Write text and return descriptor metadata with an encoding facet."""
+        """Write text and return descriptor metadata with an encoding facet.
+
+        Args:
+            descriptor: Path-backed output descriptor.
+            text: Text to write.
+            encoding: Optional encoding override. When omitted, the descriptor's
+                stdlib encoding facet is used, falling back to UTF-8.
+
+        Returns:
+            Descriptor metadata with text claims, path locator facet, and the
+            resolved encoding facet.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be written.
+            UnicodeError: If the text cannot be encoded with the resolved
+                encoding.
+        """
         resolved_encoding = encoding or encoding_from_descriptor(descriptor)
         _descriptor_path(descriptor).write_text(text, encoding=resolved_encoding)
         return descriptor_with_claims(
             descriptor,
             claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            facets=(encoding_facet(resolved_encoding),),
+            facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
         )
 
 
@@ -95,7 +163,24 @@ class DelimitedTableReader:
         *,
         delimiter: str | None = None,
     ) -> TableRows:
-        """Read a delimited table using ``csv.DictReader``."""
+        """Read a delimited table using ``csv.DictReader``.
+
+        Args:
+            descriptor: Path-backed descriptor with stdlib encoding and
+                delimiter facets.
+            delimiter: Optional delimiter override. When omitted, the descriptor
+                delimiter facet is used, falling back to a comma.
+
+        Returns:
+            Rows as dictionaries with string keys and string values.
+
+        Raises:
+            ValueError: If the descriptor is not path-backed or if a row has
+                extra columns without headers.
+            OSError: If the path cannot be read.
+            UnicodeError: If the file cannot be decoded with the declared
+                encoding.
+        """
         resolved_delimiter = delimiter or delimiter_from_descriptor(descriptor)
         with _descriptor_path(descriptor).open(
             newline="",
@@ -122,7 +207,28 @@ class DelimitedTableWriter:
         delimiter: str | None = None,
         encoding: str | None = None,
     ) -> ArtifactDescriptor:
-        """Write a delimited table using ``csv.DictWriter``."""
+        """Write a delimited table using ``csv.DictWriter``.
+
+        Args:
+            descriptor: Path-backed output descriptor.
+            rows: Row mappings to write.
+            fieldnames: Optional explicit field order. When omitted, field names
+                are collected from row keys in first-seen order.
+            delimiter: Optional delimiter override. When omitted, the descriptor
+                delimiter facet is used, falling back to a comma.
+            encoding: Optional encoding override. When omitted, the descriptor's
+                stdlib encoding facet is used, falling back to UTF-8.
+
+        Returns:
+            Descriptor metadata with text/table claims plus path, encoding, and
+            delimiter facets.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be written.
+            UnicodeError: If table text cannot be encoded with the resolved
+                encoding.
+        """
         row_list = [dict(row) for row in rows]
         resolved_fieldnames = list(fieldnames or _fieldnames_from_rows(row_list))
         resolved_delimiter = delimiter or delimiter_from_descriptor(descriptor)
@@ -143,6 +249,7 @@ class DelimitedTableWriter:
                 InterfaceClaim("table"),
             ),
             facets=(
+                path_locator_facet(),
                 encoding_facet(resolved_encoding),
                 delimiter_facet(resolved_delimiter),
             ),
@@ -153,7 +260,22 @@ class JsonReader:
     """Read JSON text artifacts with the stdlib ``json`` module."""
 
     def read(self, descriptor: ArtifactDescriptor) -> JsonDocument:
-        """Read JSON from the descriptor's path locator."""
+        """Read JSON from the descriptor's path locator.
+
+        Args:
+            descriptor: Path-backed JSON descriptor with a stdlib encoding
+                facet.
+
+        Returns:
+            JSON-compatible document loaded from the file.
+
+        Raises:
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be read.
+            json.JSONDecodeError: If the file does not contain valid JSON.
+            UnicodeError: If the file cannot be decoded with the declared
+                encoding.
+        """
         with _descriptor_path(descriptor).open(encoding=encoding_from_descriptor(descriptor)) as stream:
             return cast(JsonDocument, json.load(stream))
 
@@ -169,7 +291,25 @@ class JsonWriter:
         indent: int | None = 2,
         encoding: str | None = None,
     ) -> ArtifactDescriptor:
-        """Write JSON and return descriptor metadata with JSON claims."""
+        """Write JSON and return descriptor metadata with JSON claims.
+
+        Args:
+            descriptor: Path-backed output descriptor.
+            document: JSON-compatible document to serialize.
+            indent: Indentation passed to ``json.dump``.
+            encoding: Optional encoding override. When omitted, the descriptor's
+                stdlib encoding facet is used, falling back to UTF-8.
+
+        Returns:
+            Descriptor metadata with JSON/text claims plus path and encoding
+            facets.
+
+        Raises:
+            TypeError: If ``document`` contains values that ``json.dump`` cannot
+                serialize.
+            ValueError: If the descriptor has no local path locator.
+            OSError: If the path cannot be written.
+        """
         resolved_encoding = encoding or encoding_from_descriptor(descriptor)
         with _descriptor_path(descriptor).open("w", encoding=resolved_encoding) as stream:
             json.dump(document, stream, ensure_ascii=False, indent=indent)
@@ -182,7 +322,7 @@ class JsonWriter:
                 InterfaceClaim("text"),
                 InterfaceClaim("json"),
             ),
-            facets=(encoding_facet(resolved_encoding),),
+            facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
         )
 
 
@@ -203,7 +343,16 @@ class EmoticonEmojiTextConverter:
         source_descriptor: ArtifactDescriptor,
         output_descriptor: ArtifactDescriptor,
     ) -> ArtifactDescriptor:
-        """Read ASCII-compatible text and write UTF-8 emoji text output."""
+        """Read ASCII-compatible text and write UTF-8 emoji text output.
+
+        Args:
+            source_descriptor: Path-backed text descriptor to read.
+            output_descriptor: Path-backed descriptor to write.
+
+        Returns:
+            Output descriptor with text claims, UTF-8 encoding, path facet, and
+            relationship metadata linking the source.
+        """
         source_text = TextReader().read(source_descriptor)
         converted = source_text
         for emoticon, emoji in self.emoticons.items():
@@ -229,7 +378,16 @@ class PigLatinTextConverter:
         source_descriptor: ArtifactDescriptor,
         output_descriptor: ArtifactDescriptor,
     ) -> ArtifactDescriptor:
-        """Read text and write UTF-8 Pig Latin text output."""
+        """Read text and write UTF-8 Pig Latin text output.
+
+        Args:
+            source_descriptor: Path-backed text descriptor to read.
+            output_descriptor: Path-backed descriptor to write.
+
+        Returns:
+            Output descriptor with text claims, UTF-8 encoding, path facet, and
+            relationship metadata linking the source.
+        """
         converted = _pig_latin_text(TextReader().read(source_descriptor))
         output = descriptor_with_claims(
             output_descriptor,
@@ -244,7 +402,14 @@ class PigLatinTextConverter:
 
 
 def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
-    """Create bundled stdlib capability examples."""
+    """Create bundled stdlib capability examples.
+
+    Returns:
+        Capability declarations for the local path-backed stdlib examples. Each
+        declaration uses the same ``ArtifactCapability`` model as external
+        plugins and stores an opaque implementation object for tests and
+        documentation examples.
+    """
     return (
         _capability(
             name="bytes-reader",
@@ -252,6 +417,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=BytesReader(),
             input_claims=(InterfaceClaim("bytes"),),
             output_claims=(InterfaceClaim("bytes"),),
+            required_facets=(path_locator_facet_requirement(),),
             description="Read local path artifacts with Path.read_bytes.",
         ),
         _capability(
@@ -259,6 +425,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             kind=CapabilityKind.WRITER,
             implementation=BytesWriter(),
             output_claims=(RepresentationClaim("file"), InterfaceClaim("bytes")),
+            required_facets=(path_locator_facet_requirement(),),
             description="Write local path artifacts with Path.write_bytes.",
         ),
         _capability(
@@ -267,7 +434,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=TextReader(),
             input_claims=(InterfaceClaim("text"),),
             output_claims=(InterfaceClaim("text"),),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Read local path artifacts as text using encoding facets.",
         ),
         _capability(
@@ -275,7 +442,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             kind=CapabilityKind.WRITER,
             implementation=TextWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Write local path artifacts as text.",
         ),
         _capability(
@@ -284,7 +451,11 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=DelimitedTableReader(),
             input_claims=(InterfaceClaim("table"),),
             output_claims=(InterfaceClaim("table"),),
-            required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
+            required_facets=(
+                path_locator_facet_requirement(),
+                encoding_facet_requirement(),
+                delimiter_facet_requirement(),
+            ),
             description="Read delimited text tables with csv.DictReader.",
         ),
         _capability(
@@ -292,7 +463,11 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             kind=CapabilityKind.WRITER,
             implementation=DelimitedTableWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text"), InterfaceClaim("table")),
-            required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
+            required_facets=(
+                path_locator_facet_requirement(),
+                encoding_facet_requirement(),
+                delimiter_facet_requirement(),
+            ),
             description="Write delimited text tables with csv.DictWriter.",
         ),
         _capability(
@@ -301,7 +476,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=JsonReader(),
             input_claims=(InterfaceClaim("json"),),
             output_claims=(InterfaceClaim("json"),),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Read JSON artifacts with json.load.",
         ),
         _capability(
@@ -314,7 +489,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
                 InterfaceClaim("text"),
                 InterfaceClaim("json"),
             ),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Write JSON artifacts with json.dump.",
         ),
         _capability(
@@ -323,7 +498,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=EmoticonEmojiTextConverter(),
             input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
         ),
         _capability(
@@ -332,7 +507,7 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=PigLatinTextConverter(),
             input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet_requirement(),),
+            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Convert text artifacts to Pig Latin text.",
         ),
     )
@@ -356,12 +531,21 @@ def register_stdlib_capabilities(registry: Any) -> Any:
 
 
 def bytes_artifact_descriptor(path: str | Path, *, id: str = "data") -> ArtifactDescriptor:
-    """Build a path-backed descriptor selectable as bytes."""
+    """Build a path-backed descriptor selectable as bytes.
+
+    Args:
+        path: Local filesystem path.
+        id: Descriptor identifier.
+
+    Returns:
+        Artifact descriptor with bytes/file claims and stdlib path facet.
+    """
     return ArtifactDescriptor(
         id=id,
         role="data_artifact",
         locator=ArtifactLocator.path(path),
         claims=[RepresentationClaim("file"), InterfaceClaim("bytes")],
+        facets=[path_locator_facet()],
     )
 
 
@@ -371,13 +555,23 @@ def text_artifact_descriptor(
     id: str = "data",
     encoding: str = DEFAULT_TEXT_ENCODING,
 ) -> ArtifactDescriptor:
-    """Build a path-backed descriptor selectable as text."""
+    """Build a path-backed descriptor selectable as text.
+
+    Args:
+        path: Local filesystem path.
+        id: Descriptor identifier.
+        encoding: Text encoding recorded in the stdlib encoding facet.
+
+    Returns:
+        Artifact descriptor with text interface claims plus path and encoding
+        facets.
+    """
     return ArtifactDescriptor(
         id=id,
         role="data_artifact",
         locator=ArtifactLocator.path(path),
         claims=[RepresentationClaim("text"), InterfaceClaim("text")],
-        facets=[encoding_facet(encoding)],
+        facets=[path_locator_facet(), encoding_facet(encoding)],
     )
 
 
@@ -389,19 +583,32 @@ def delimited_table_artifact_descriptor(
     encoding: str = DEFAULT_TEXT_ENCODING,
     data_type: str = "csv",
 ) -> ArtifactDescriptor:
-    """Build a descriptor selectable as bytes, text, or a delimited table."""
+    """Build a descriptor selectable as bytes, text, or a delimited table.
+
+    Args:
+        path: Local filesystem path.
+        id: Descriptor identifier.
+        delimiter: Delimiter recorded in the stdlib delimited-text facet.
+        encoding: Text encoding recorded in the stdlib encoding facet.
+        data_type: IANA media type data-type claim name.
+
+    Returns:
+        Artifact descriptor with bytes/text/table interfaces plus path,
+        encoding, and delimiter facets.
+    """
     return ArtifactDescriptor(
         id=id,
         role="data_artifact",
         locator=ArtifactLocator.path(path),
         claims=[
+            RepresentationClaim("file"),
             RepresentationClaim("text"),
             DataTypeClaim(data_type, namespace="iana.media-types"),
             InterfaceClaim("bytes"),
             InterfaceClaim("text"),
             InterfaceClaim("table"),
         ],
-        facets=[encoding_facet(encoding), delimiter_facet(delimiter)],
+        facets=[path_locator_facet(), encoding_facet(encoding), delimiter_facet(delimiter)],
     )
 
 
@@ -411,18 +618,29 @@ def json_artifact_descriptor(
     id: str = "data",
     encoding: str = DEFAULT_TEXT_ENCODING,
 ) -> ArtifactDescriptor:
-    """Build a path-backed descriptor selectable as JSON text."""
+    """Build a path-backed descriptor selectable as JSON text.
+
+    Args:
+        path: Local filesystem path.
+        id: Descriptor identifier.
+        encoding: Text encoding recorded in the stdlib encoding facet.
+
+    Returns:
+        Artifact descriptor with JSON/text interface claims plus path and
+        encoding facets.
+    """
     return ArtifactDescriptor(
         id=id,
         role="data_artifact",
         locator=ArtifactLocator.path(path),
         claims=[
+            RepresentationClaim("file"),
             RepresentationClaim("text"),
             DataTypeClaim("json", namespace="iana.media-types"),
             InterfaceClaim("text"),
             InterfaceClaim("json"),
         ],
-        facets=[encoding_facet(encoding)],
+        facets=[path_locator_facet(), encoding_facet(encoding)],
     )
 
 
@@ -432,52 +650,113 @@ def temporary_text_artifact_descriptor(
     id: str = "temporary-output",
     encoding: str = DEFAULT_TEXT_ENCODING,
 ) -> ArtifactDescriptor:
-    """Build a non-catalog output descriptor suitable for capability selection."""
+    """Build a non-catalog output descriptor suitable for capability selection.
+
+    Args:
+        path: Local filesystem path for temporary output.
+        id: Descriptor identifier.
+        encoding: Text encoding recorded in the stdlib encoding facet.
+
+    Returns:
+        Derived artifact descriptor marked as temporary/non-catalogued with text
+        claims plus path and encoding facets.
+    """
     return ArtifactDescriptor(
         id=id,
         role="derived_artifact",
         locator=ArtifactLocator.path(path),
         relationship={"catalogued": False, "temporary": True},
         claims=[RepresentationClaim("text"), InterfaceClaim("text")],
-        facets=[encoding_facet(encoding)],
+        facets=[path_locator_facet(), encoding_facet(encoding)],
     )
 
 
+def path_locator_facet() -> ArtifactFacet:
+    """Build the stdlib facet declaring a local path-backed descriptor.
+
+    Returns:
+        Facet whose namespace/version belongs to the bundled stdlib examples.
+    """
+    return ArtifactFacet(
+        kind="locator",
+        name="path",
+        namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
+    )
+
+
+def path_locator_facet_requirement() -> ArtifactFacet:
+    """Build a requirement for the stdlib local path locator facet.
+
+    Returns:
+        Facet requirement used by path-backed stdlib capabilities.
+    """
+    return path_locator_facet()
+
+
 def encoding_facet(encoding: str) -> ArtifactFacet:
-    """Build the stdlib text encoding facet."""
+    """Build the stdlib text encoding facet.
+
+    Args:
+        encoding: Text encoding name.
+
+    Returns:
+        Namespaced facet containing the encoding metadata consumed by stdlib
+        text implementations.
+    """
     return ArtifactFacet(
         kind="encoding",
         name="charset",
         namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
         metadata={"encoding": encoding},
     )
 
 
 def encoding_facet_requirement() -> ArtifactFacet:
-    """Build a requirement for a declared text encoding facet."""
+    """Build a requirement for a declared text encoding facet.
+
+    Returns:
+        Facet requirement that accepts any stdlib charset metadata value.
+    """
     return ArtifactFacet(
         kind="encoding",
         name="charset",
         namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
     )
 
 
 def delimiter_facet(delimiter: str) -> ArtifactFacet:
-    """Build the stdlib delimited text facet."""
+    """Build the stdlib delimited text facet.
+
+    Args:
+        delimiter: Delimiter string used by ``csv`` readers/writers.
+
+    Returns:
+        Namespaced facet containing the delimiter metadata consumed by stdlib
+        delimited-table implementations.
+    """
     return ArtifactFacet(
         kind="format",
         name="delimited-text",
         namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
         metadata={"delimiter": delimiter},
     )
 
 
 def delimiter_facet_requirement() -> ArtifactFacet:
-    """Build a requirement for a declared delimited-text facet."""
+    """Build a requirement for a declared delimited-text facet.
+
+    Returns:
+        Facet requirement that accepts any stdlib delimiter metadata value.
+    """
     return ArtifactFacet(
         kind="format",
         name="delimited-text",
         namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
     )
 
 
@@ -486,9 +765,19 @@ def encoding_from_descriptor(
     *,
     default: str = DEFAULT_TEXT_ENCODING,
 ) -> str:
-    """Return a descriptor encoding from facets, falling back to an explicit default."""
+    """Return a descriptor encoding from stdlib facets.
+
+    Args:
+        descriptor: Descriptor whose facets should be inspected.
+        default: Encoding returned when no stdlib charset facet has encoding
+            metadata.
+
+    Returns:
+        Encoding declared by the stdlib ``encoding/charset`` facet, or
+        ``default`` when absent.
+    """
     for facet in iter_facets(descriptor):
-        if facet["kind"] != "encoding" or facet["name"] != "charset":
+        if not _is_stdlib_facet(facet, kind="encoding", name="charset"):
             continue
         metadata = facet["metadata"]
         if not isinstance(metadata, Mapping):
@@ -500,9 +789,19 @@ def encoding_from_descriptor(
 
 
 def delimiter_from_descriptor(descriptor: ArtifactDescriptor, *, default: str = ",") -> str:
-    """Return a delimited-text delimiter from facets."""
+    """Return a delimited-text delimiter from stdlib facets.
+
+    Args:
+        descriptor: Descriptor whose facets should be inspected.
+        default: Delimiter returned when no stdlib delimited-text facet has
+            delimiter metadata.
+
+    Returns:
+        Delimiter declared by the stdlib ``format/delimited-text`` facet, or
+        ``default`` when absent.
+    """
     for facet in iter_facets(descriptor):
-        if facet["kind"] != "format" or facet["name"] != "delimited-text":
+        if not _is_stdlib_facet(facet, kind="format", name="delimited-text"):
             continue
         metadata = facet["metadata"]
         if not isinstance(metadata, Mapping):
@@ -520,7 +819,20 @@ def descriptor_with_claims(
     facets: Iterable[ArtifactFacet] = (),
     relationship: Mapping[str, object] | None = None,
 ) -> ArtifactDescriptor:
-    """Return a descriptor copy with merged claims, facets, and relationship metadata."""
+    """Return a descriptor copy with merged claims, facets, and relationships.
+
+    Args:
+        descriptor: Source descriptor to copy.
+        claims: Claims to merge by namespace/kind/name/version. Added claims
+            replace existing claims with the same schema envelope.
+        facets: Facets to merge by namespace/kind/name/version. Added facets
+            replace existing facets with the same schema envelope.
+        relationship: Optional relationship metadata to merge over existing
+            descriptor relationship metadata.
+
+    Returns:
+        New descriptor preserving locator and state with merged schema facts.
+    """
     return ArtifactDescriptor(
         id=descriptor.id,
         role=descriptor.role,
@@ -569,6 +881,16 @@ def _descriptor_path(descriptor: ArtifactDescriptor) -> Path:
             f"artifact descriptor {descriptor.id!r} is not path-backed: {descriptor.locator.kind!r}"
         )
     return path
+
+
+def _is_stdlib_facet(facet: Mapping[str, object], *, kind: str, name: str) -> bool:
+    """Return whether a normalized facet belongs to this stdlib schema item."""
+    return (
+        facet.get("namespace") == PLUGIN_NAMESPACE
+        and facet.get("version") == SCHEMA_VERSION
+        and facet.get("kind") == kind
+        and facet.get("name") == name
+    )
 
 
 def _fieldnames_from_rows(rows: Sequence[Mapping[str, object]]) -> list[str]:

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -320,7 +320,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             implementation=TextReader(),
             required_claims=(InterfaceClaim("text"),),
             output_claims=(InterfaceClaim("text"),),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Read local path artifacts as text using encoding facets.",
         ),
         _capability(
@@ -328,7 +328,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             operation="writer",
             implementation=TextWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Write local path artifacts as text.",
         ),
         _capability(
@@ -337,7 +337,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             implementation=DelimitedTableReader(),
             required_claims=(InterfaceClaim("table"),),
             output_claims=(InterfaceClaim("table"),),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING), delimiter_facet(",")),
+            required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
             description="Read delimited text tables with csv.DictReader.",
         ),
         _capability(
@@ -345,7 +345,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             operation="writer",
             implementation=DelimitedTableWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text"), InterfaceClaim("table")),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING), delimiter_facet(",")),
+            required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
             description="Write delimited text tables with csv.DictWriter.",
         ),
         _capability(
@@ -354,7 +354,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             implementation=JsonReader(),
             required_claims=(InterfaceClaim("json"),),
             output_claims=(InterfaceClaim("json"),),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Read JSON artifacts with json.load.",
         ),
         _capability(
@@ -367,7 +367,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
                 InterfaceClaim("text"),
                 InterfaceClaim("json"),
             ),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Write JSON artifacts with json.dump.",
         ),
         _capability(
@@ -376,7 +376,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             implementation=EmoticonEmojiTextConverter(),
             required_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
         ),
         _capability(
@@ -385,7 +385,7 @@ def stdlib_capabilities() -> tuple[object, ...]:
             implementation=PigLatinTextConverter(),
             required_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            required_facets=(encoding_facet_requirement(),),
             description="Convert text artifacts to Pig Latin text.",
         ),
     )
@@ -504,6 +504,15 @@ def encoding_facet(encoding: str) -> ArtifactFacet:
     )
 
 
+def encoding_facet_requirement() -> ArtifactFacet:
+    """Build a requirement for a declared text encoding facet."""
+    return ArtifactFacet(
+        kind="encoding",
+        name="charset",
+        namespace=PLUGIN_NAMESPACE,
+    )
+
+
 def delimiter_facet(delimiter: str) -> ArtifactFacet:
     """Build the stdlib delimited text facet."""
     return ArtifactFacet(
@@ -511,6 +520,15 @@ def delimiter_facet(delimiter: str) -> ArtifactFacet:
         name="delimited-text",
         namespace=PLUGIN_NAMESPACE,
         metadata={"delimiter": delimiter},
+    )
+
+
+def delimiter_facet_requirement() -> ArtifactFacet:
+    """Build a requirement for a declared delimited-text facet."""
+    return ArtifactFacet(
+        kind="format",
+        name="delimited-text",
+        namespace=PLUGIN_NAMESPACE,
     )
 
 

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import csv
-import inspect
 import json
 import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypeAlias, cast
 
-from ogcat.artifact_claims import has_claim, iter_facets
+from ogcat.artifact_claims import iter_facets
+from ogcat.capabilities import ArtifactCapability, CapabilityKind
 from ogcat.models import (
     ArtifactClaim,
     ArtifactClaimInput,
@@ -34,65 +33,6 @@ JsonDocument: TypeAlias = JsonValue
 TableRows: TypeAlias = list[dict[str, str]]
 _WORD_RE = re.compile(r"[A-Za-z]+")
 _VOWELS = frozenset("aeiouAEIOU")
-
-
-@dataclass(frozen=True, slots=True)
-class StdlibCapability:
-    """Small capability object used when the core class is unavailable.
-
-    The public attributes intentionally use plain names so the examples remain
-    easy for the core registry to inspect without special cases.
-    """
-
-    name: str
-    operation: str
-    implementation: object
-    required_claims: tuple[ArtifactClaim, ...] = ()
-    required_facets: tuple[ArtifactFacet, ...] = ()
-    namespace: str = PLUGIN_NAMESPACE
-    version: str = SCHEMA_VERSION
-    description: str = ""
-    priority: int = 0
-    metadata: MetadataDict = field(default_factory=dict)
-
-    @property
-    def kind(self) -> str:
-        """Return the operation name for registries that use ``kind``."""
-        return self.operation
-
-    @property
-    def capability_type(self) -> str:
-        """Return the operation name for registries that use ``capability_type``."""
-        return self.operation
-
-    def matches(
-        self,
-        descriptor: ArtifactDescriptor,
-        *,
-        operation: str | None = None,
-        interface: str | None = None,
-        data_type: str | None = None,
-    ) -> bool:
-        """Return whether this capability can handle a descriptor."""
-        if operation is not None and operation != self.operation:
-            return False
-        if interface is not None and not has_claim(descriptor, kind="interface", name=interface):
-            return False
-        if data_type is not None and not has_claim(descriptor, kind="data_type", name=data_type):
-            return False
-        return all(_descriptor_has_claim(descriptor, claim) for claim in self.required_claims)
-
-    def supports(self, descriptor: ArtifactDescriptor, **criteria: object) -> bool:
-        """Compatibility alias for registries that call ``supports``."""
-        operation = criteria.get("operation")
-        interface = criteria.get("interface")
-        data_type = criteria.get("data_type")
-        return self.matches(
-            descriptor,
-            operation=None if operation is None else str(operation),
-            interface=None if interface is None else str(interface),
-            data_type=None if data_type is None else str(data_type),
-        )
 
 
 class BytesReader:
@@ -296,36 +236,36 @@ class PigLatinTextConverter:
         return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
 
 
-def stdlib_capabilities() -> tuple[object, ...]:
+def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
     """Create bundled stdlib capability examples."""
     return (
         _capability(
             name="bytes-reader",
-            operation="reader",
+            kind=CapabilityKind.READER,
             implementation=BytesReader(),
-            required_claims=(InterfaceClaim("bytes"),),
+            input_claims=(InterfaceClaim("bytes"),),
             output_claims=(InterfaceClaim("bytes"),),
             description="Read local path artifacts with Path.read_bytes.",
         ),
         _capability(
             name="bytes-writer",
-            operation="writer",
+            kind=CapabilityKind.WRITER,
             implementation=BytesWriter(),
             output_claims=(RepresentationClaim("file"), InterfaceClaim("bytes")),
             description="Write local path artifacts with Path.write_bytes.",
         ),
         _capability(
             name="text-reader",
-            operation="reader",
+            kind=CapabilityKind.READER,
             implementation=TextReader(),
-            required_claims=(InterfaceClaim("text"),),
+            input_claims=(InterfaceClaim("text"),),
             output_claims=(InterfaceClaim("text"),),
             required_facets=(encoding_facet_requirement(),),
             description="Read local path artifacts as text using encoding facets.",
         ),
         _capability(
             name="text-writer",
-            operation="writer",
+            kind=CapabilityKind.WRITER,
             implementation=TextWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
             required_facets=(encoding_facet_requirement(),),
@@ -333,16 +273,16 @@ def stdlib_capabilities() -> tuple[object, ...]:
         ),
         _capability(
             name="delimited-table-reader",
-            operation="reader",
+            kind=CapabilityKind.READER,
             implementation=DelimitedTableReader(),
-            required_claims=(InterfaceClaim("table"),),
+            input_claims=(InterfaceClaim("table"),),
             output_claims=(InterfaceClaim("table"),),
             required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
             description="Read delimited text tables with csv.DictReader.",
         ),
         _capability(
             name="delimited-table-writer",
-            operation="writer",
+            kind=CapabilityKind.WRITER,
             implementation=DelimitedTableWriter(),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text"), InterfaceClaim("table")),
             required_facets=(encoding_facet_requirement(), delimiter_facet_requirement()),
@@ -350,16 +290,16 @@ def stdlib_capabilities() -> tuple[object, ...]:
         ),
         _capability(
             name="json-reader",
-            operation="reader",
+            kind=CapabilityKind.READER,
             implementation=JsonReader(),
-            required_claims=(InterfaceClaim("json"),),
+            input_claims=(InterfaceClaim("json"),),
             output_claims=(InterfaceClaim("json"),),
             required_facets=(encoding_facet_requirement(),),
             description="Read JSON artifacts with json.load.",
         ),
         _capability(
             name="json-writer",
-            operation="writer",
+            kind=CapabilityKind.WRITER,
             implementation=JsonWriter(),
             output_claims=(
                 RepresentationClaim("text"),
@@ -372,18 +312,18 @@ def stdlib_capabilities() -> tuple[object, ...]:
         ),
         _capability(
             name="emoticon-to-emoji-text-converter",
-            operation="converter",
+            kind=CapabilityKind.CONVERTER,
             implementation=EmoticonEmojiTextConverter(),
-            required_claims=(InterfaceClaim("text"),),
+            input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
             required_facets=(encoding_facet_requirement(),),
             description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
         ),
         _capability(
             name="pig-latin-text-converter",
-            operation="converter",
+            kind=CapabilityKind.CONVERTER,
             implementation=PigLatinTextConverter(),
-            required_claims=(InterfaceClaim("text"),),
+            input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
             required_facets=(encoding_facet_requirement(),),
             description="Convert text artifacts to Pig Latin text.",
@@ -395,13 +335,15 @@ def register_stdlib_capabilities(registry: Any) -> Any:
     """Register bundled stdlib capabilities with a capability registry.
 
     Args:
-        registry: Registry object with a ``register`` method.
+        registry: Registry object with ``register_capability`` or ``register``.
 
     Returns:
         The registry, to support fluent setup in tests and examples.
     """
+    register = getattr(registry, "register_capability", None)
+    if register is None:
+        register = registry.register
     for capability in stdlib_capabilities():
-        register = getattr(registry, "register_capability", registry.register)
         register(capability)
     return registry
 
@@ -589,76 +531,25 @@ def descriptor_with_claims(
 def _capability(
     *,
     name: str,
-    operation: str,
+    kind: CapabilityKind,
     implementation: object,
     description: str,
-    required_claims: tuple[ArtifactClaim, ...] = (),
+    input_claims: tuple[ArtifactClaim, ...] = (),
     output_claims: tuple[ArtifactClaim, ...] = (),
     required_facets: tuple[ArtifactFacet, ...] = (),
-) -> object:
-    """Build a core ArtifactCapability when available, otherwise a local object."""
-    fallback = StdlibCapability(
+) -> ArtifactCapability:
+    """Build a bundled stdlib artifact capability."""
+    return ArtifactCapability(
+        kind=kind,
         name=name,
-        operation=operation,
-        implementation=implementation,
-        required_claims=required_claims,
+        namespace=PLUGIN_NAMESPACE,
+        version=SCHEMA_VERSION,
+        input_claims=input_claims,
+        output_claims=output_claims,
         required_facets=required_facets,
-        description=description,
+        metadata={"description": description, "plugin": "stdlib_io"},
+        implementation=implementation,
     )
-    try:
-        from ogcat.capabilities import ArtifactCapability
-    except ImportError:
-        return fallback
-    capability_factory = cast(Any, ArtifactCapability)
-
-    metadata: MetadataDict = {"plugin": "stdlib_io"}
-    values: dict[str, object] = {
-        "name": name,
-        "namespace": PLUGIN_NAMESPACE,
-        "version": SCHEMA_VERSION,
-        "operation": operation,
-        "kind": operation,
-        "capability_type": operation,
-        "implementation": implementation,
-        "handler": implementation,
-        "input_claims": required_claims,
-        "output_claims": output_claims,
-        "required_claims": required_claims,
-        "claims": required_claims,
-        "required_facets": required_facets,
-        "facets": required_facets,
-        "description": description,
-        "priority": 0,
-        "metadata": metadata,
-    }
-    try:
-        parameters = inspect.signature(capability_factory).parameters
-    except (TypeError, ValueError):
-        parameters = {}
-    kwargs = {name: values[name] for name in parameters if name in values}
-    if kwargs:
-        try:
-            return capability_factory(**kwargs)
-        except TypeError:
-            pass
-
-    for kwargs in (
-        {
-            "name": name,
-            "operation": operation,
-            "implementation": implementation,
-            "required_claims": required_claims,
-            "description": description,
-            "metadata": metadata,
-        },
-        {"name": name, "kind": operation, "implementation": implementation},
-        {"name": name, "implementation": implementation},
-    ):
-        try:
-            return capability_factory(**kwargs)
-        except TypeError:
-            continue
-    return fallback
 
 
 def _descriptor_path(descriptor: ArtifactDescriptor) -> Path:
@@ -671,17 +562,6 @@ def _descriptor_path(descriptor: ArtifactDescriptor) -> Path:
             f"artifact descriptor {descriptor.id!r} is not path-backed: {descriptor.locator.kind!r}"
         )
     return path
-
-
-def _descriptor_has_claim(descriptor: ArtifactDescriptor, claim: ArtifactClaim) -> bool:
-    """Return whether a descriptor has a matching claim envelope."""
-    return has_claim(
-        descriptor,
-        kind=claim.kind,
-        name=claim.name,
-        namespace=claim.namespace,
-        version=claim.version,
-    )
 
 
 def _fieldnames_from_rows(rows: Sequence[Mapping[str, object]]) -> list[str]:

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -1,0 +1,685 @@
+"""Dependency-free stdlib reader, writer, and converter capability examples."""
+
+from __future__ import annotations
+
+import csv
+import inspect
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias, cast
+
+from ogcat.artifact_claims import has_claim, iter_facets
+from ogcat.models import (
+    ArtifactClaim,
+    ArtifactClaimInput,
+    ArtifactDescriptor,
+    ArtifactFacet,
+    ArtifactFacetInput,
+    ArtifactLocator,
+    DataTypeClaim,
+    InterfaceClaim,
+    JsonValue,
+    MetadataDict,
+    RepresentationClaim,
+)
+
+PLUGIN_NAMESPACE = "ogcat.stdlib"
+SCHEMA_VERSION = "1"
+DEFAULT_TEXT_ENCODING = "utf-8"
+
+JsonDocument: TypeAlias = JsonValue
+TableRows: TypeAlias = list[dict[str, str]]
+
+
+@dataclass(frozen=True, slots=True)
+class StdlibCapability:
+    """Small capability object used when the core class is unavailable.
+
+    The public attributes intentionally use plain names so the examples remain
+    easy for the core registry to inspect without special cases.
+    """
+
+    name: str
+    operation: str
+    implementation: object
+    required_claims: tuple[ArtifactClaim, ...] = ()
+    required_facets: tuple[ArtifactFacet, ...] = ()
+    namespace: str = PLUGIN_NAMESPACE
+    version: str = SCHEMA_VERSION
+    description: str = ""
+    priority: int = 0
+    metadata: MetadataDict = field(default_factory=dict)
+
+    @property
+    def kind(self) -> str:
+        """Return the operation name for registries that use ``kind``."""
+        return self.operation
+
+    @property
+    def capability_type(self) -> str:
+        """Return the operation name for registries that use ``capability_type``."""
+        return self.operation
+
+    def matches(
+        self,
+        descriptor: ArtifactDescriptor,
+        *,
+        operation: str | None = None,
+        interface: str | None = None,
+        data_type: str | None = None,
+    ) -> bool:
+        """Return whether this capability can handle a descriptor."""
+        if operation is not None and operation != self.operation:
+            return False
+        if interface is not None and not has_claim(descriptor, kind="interface", name=interface):
+            return False
+        if data_type is not None and not has_claim(descriptor, kind="data_type", name=data_type):
+            return False
+        return all(_descriptor_has_claim(descriptor, claim) for claim in self.required_claims)
+
+    def supports(self, descriptor: ArtifactDescriptor, **criteria: object) -> bool:
+        """Compatibility alias for registries that call ``supports``."""
+        operation = criteria.get("operation")
+        interface = criteria.get("interface")
+        data_type = criteria.get("data_type")
+        return self.matches(
+            descriptor,
+            operation=None if operation is None else str(operation),
+            interface=None if interface is None else str(interface),
+            data_type=None if data_type is None else str(data_type),
+        )
+
+
+class BytesReader:
+    """Read path-backed artifacts as raw bytes."""
+
+    def read(self, descriptor: ArtifactDescriptor) -> bytes:
+        """Read bytes from the descriptor's path locator."""
+        return _descriptor_path(descriptor).read_bytes()
+
+
+class BytesWriter:
+    """Write path-backed artifacts as raw bytes."""
+
+    def write(self, descriptor: ArtifactDescriptor, data: bytes) -> ArtifactDescriptor:
+        """Write bytes to the descriptor's path locator and return descriptor metadata."""
+        _descriptor_path(descriptor).write_bytes(data)
+        return descriptor_with_claims(
+            descriptor,
+            claims=(InterfaceClaim("bytes"), RepresentationClaim("file")),
+        )
+
+
+class TextReader:
+    """Read path-backed artifacts as text using descriptor encoding facets."""
+
+    def read(self, descriptor: ArtifactDescriptor) -> str:
+        """Read text from the descriptor's path locator."""
+        return _descriptor_path(descriptor).read_text(
+            encoding=encoding_from_descriptor(descriptor),
+        )
+
+
+class TextWriter:
+    """Write path-backed artifacts as text."""
+
+    def write(
+        self,
+        descriptor: ArtifactDescriptor,
+        text: str,
+        *,
+        encoding: str | None = None,
+    ) -> ArtifactDescriptor:
+        """Write text and return descriptor metadata with an encoding facet."""
+        resolved_encoding = encoding or encoding_from_descriptor(descriptor)
+        _descriptor_path(descriptor).write_text(text, encoding=resolved_encoding)
+        return descriptor_with_claims(
+            descriptor,
+            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            facets=(encoding_facet(resolved_encoding),),
+        )
+
+
+class DelimitedTableReader:
+    """Read delimited text artifacts as rows of dictionaries."""
+
+    def read(
+        self,
+        descriptor: ArtifactDescriptor,
+        *,
+        delimiter: str | None = None,
+    ) -> TableRows:
+        """Read a delimited table using ``csv.DictReader``."""
+        resolved_delimiter = delimiter or delimiter_from_descriptor(descriptor)
+        with _descriptor_path(descriptor).open(
+            newline="",
+            encoding=encoding_from_descriptor(descriptor),
+        ) as stream:
+            return [dict(row) for row in csv.DictReader(stream, delimiter=resolved_delimiter)]
+
+
+class DelimitedTableWriter:
+    """Write rows of dictionaries as delimited text artifacts."""
+
+    def write(
+        self,
+        descriptor: ArtifactDescriptor,
+        rows: Iterable[Mapping[str, object]],
+        *,
+        fieldnames: Sequence[str] | None = None,
+        delimiter: str | None = None,
+        encoding: str | None = None,
+    ) -> ArtifactDescriptor:
+        """Write a delimited table using ``csv.DictWriter``."""
+        row_list = [dict(row) for row in rows]
+        resolved_fieldnames = list(fieldnames or _fieldnames_from_rows(row_list))
+        resolved_delimiter = delimiter or delimiter_from_descriptor(descriptor)
+        resolved_encoding = encoding or encoding_from_descriptor(descriptor)
+        with _descriptor_path(descriptor).open("w", newline="", encoding=resolved_encoding) as stream:
+            writer = csv.DictWriter(
+                stream,
+                fieldnames=resolved_fieldnames,
+                delimiter=resolved_delimiter,
+            )
+            writer.writeheader()
+            writer.writerows(row_list)
+        return descriptor_with_claims(
+            descriptor,
+            claims=(
+                RepresentationClaim("text"),
+                InterfaceClaim("text"),
+                InterfaceClaim("table"),
+            ),
+            facets=(
+                encoding_facet(resolved_encoding),
+                delimiter_facet(resolved_delimiter),
+            ),
+        )
+
+
+class JsonReader:
+    """Read JSON text artifacts with the stdlib ``json`` module."""
+
+    def read(self, descriptor: ArtifactDescriptor) -> JsonDocument:
+        """Read JSON from the descriptor's path locator."""
+        with _descriptor_path(descriptor).open(encoding=encoding_from_descriptor(descriptor)) as stream:
+            return cast(JsonDocument, json.load(stream))
+
+
+class JsonWriter:
+    """Write JSON text artifacts with the stdlib ``json`` module."""
+
+    def write(
+        self,
+        descriptor: ArtifactDescriptor,
+        document: JsonDocument,
+        *,
+        indent: int | None = 2,
+        encoding: str | None = None,
+    ) -> ArtifactDescriptor:
+        """Write JSON and return descriptor metadata with JSON claims."""
+        resolved_encoding = encoding or encoding_from_descriptor(descriptor)
+        with _descriptor_path(descriptor).open("w", encoding=resolved_encoding) as stream:
+            json.dump(document, stream, ensure_ascii=False, indent=indent)
+            stream.write("\n")
+        return descriptor_with_claims(
+            descriptor,
+            claims=(
+                RepresentationClaim("text"),
+                DataTypeClaim("json", namespace="iana.media-types"),
+                InterfaceClaim("text"),
+                InterfaceClaim("json"),
+            ),
+            facets=(encoding_facet(resolved_encoding),),
+        )
+
+
+class EmoticonEmojiTextConverter:
+    """Convert ASCII emoticons in text artifacts to Unicode emoji."""
+
+    emoticons: Mapping[str, str] = {
+        ":)": "🙂",
+        ":-)": "🙂",
+        ":(": "🙁",
+        ":-(": "🙁",
+        ";)": "😉",
+        ";-)": "😉",
+    }
+
+    def convert(
+        self,
+        source_descriptor: ArtifactDescriptor,
+        output_descriptor: ArtifactDescriptor,
+    ) -> ArtifactDescriptor:
+        """Read ASCII-compatible text and write UTF-8 emoji text output."""
+        source_text = TextReader().read(source_descriptor)
+        converted = source_text
+        for emoticon, emoji in self.emoticons.items():
+            converted = converted.replace(emoticon, emoji)
+
+        output = descriptor_with_claims(
+            output_descriptor,
+            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            relationship={
+                "generated_by": "ogcat.stdlib.emoticon_to_emoji",
+                "source_artifact_id": source_descriptor.id,
+            },
+        )
+        return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
+
+
+def stdlib_capabilities() -> tuple[object, ...]:
+    """Create bundled stdlib capability examples."""
+    return (
+        _capability(
+            name="bytes-reader",
+            operation="reader",
+            implementation=BytesReader(),
+            required_claims=(InterfaceClaim("bytes"),),
+            output_claims=(InterfaceClaim("bytes"),),
+            description="Read local path artifacts with Path.read_bytes.",
+        ),
+        _capability(
+            name="bytes-writer",
+            operation="writer",
+            implementation=BytesWriter(),
+            output_claims=(RepresentationClaim("file"), InterfaceClaim("bytes")),
+            description="Write local path artifacts with Path.write_bytes.",
+        ),
+        _capability(
+            name="text-reader",
+            operation="reader",
+            implementation=TextReader(),
+            required_claims=(InterfaceClaim("text"),),
+            output_claims=(InterfaceClaim("text"),),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Read local path artifacts as text using encoding facets.",
+        ),
+        _capability(
+            name="text-writer",
+            operation="writer",
+            implementation=TextWriter(),
+            output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Write local path artifacts as text.",
+        ),
+        _capability(
+            name="delimited-table-reader",
+            operation="reader",
+            implementation=DelimitedTableReader(),
+            required_claims=(InterfaceClaim("table"),),
+            output_claims=(InterfaceClaim("table"),),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING), delimiter_facet(",")),
+            description="Read delimited text tables with csv.DictReader.",
+        ),
+        _capability(
+            name="delimited-table-writer",
+            operation="writer",
+            implementation=DelimitedTableWriter(),
+            output_claims=(RepresentationClaim("text"), InterfaceClaim("text"), InterfaceClaim("table")),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING), delimiter_facet(",")),
+            description="Write delimited text tables with csv.DictWriter.",
+        ),
+        _capability(
+            name="json-reader",
+            operation="reader",
+            implementation=JsonReader(),
+            required_claims=(InterfaceClaim("json"),),
+            output_claims=(InterfaceClaim("json"),),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Read JSON artifacts with json.load.",
+        ),
+        _capability(
+            name="json-writer",
+            operation="writer",
+            implementation=JsonWriter(),
+            output_claims=(
+                RepresentationClaim("text"),
+                DataTypeClaim("json", namespace="iana.media-types"),
+                InterfaceClaim("text"),
+                InterfaceClaim("json"),
+            ),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Write JSON artifacts with json.dump.",
+        ),
+        _capability(
+            name="emoticon-to-emoji-text-converter",
+            operation="converter",
+            implementation=EmoticonEmojiTextConverter(),
+            required_claims=(InterfaceClaim("text"),),
+            output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
+        ),
+    )
+
+
+def register_stdlib_capabilities(registry: Any) -> Any:
+    """Register bundled stdlib capabilities with a capability registry.
+
+    Args:
+        registry: Registry object with a ``register`` method.
+
+    Returns:
+        The registry, to support fluent setup in tests and examples.
+    """
+    for capability in stdlib_capabilities():
+        register = getattr(registry, "register_capability", registry.register)
+        register(capability)
+    return registry
+
+
+def bytes_artifact_descriptor(path: str | Path, *, id: str = "data") -> ArtifactDescriptor:
+    """Build a path-backed descriptor selectable as bytes."""
+    return ArtifactDescriptor(
+        id=id,
+        role="data_artifact",
+        locator=ArtifactLocator.path(path),
+        claims=[RepresentationClaim("file"), InterfaceClaim("bytes")],
+    )
+
+
+def text_artifact_descriptor(
+    path: str | Path,
+    *,
+    id: str = "data",
+    encoding: str = DEFAULT_TEXT_ENCODING,
+) -> ArtifactDescriptor:
+    """Build a path-backed descriptor selectable as text."""
+    return ArtifactDescriptor(
+        id=id,
+        role="data_artifact",
+        locator=ArtifactLocator.path(path),
+        claims=[RepresentationClaim("text"), InterfaceClaim("text")],
+        facets=[encoding_facet(encoding)],
+    )
+
+
+def delimited_table_artifact_descriptor(
+    path: str | Path,
+    *,
+    id: str = "data",
+    delimiter: str = ",",
+    encoding: str = DEFAULT_TEXT_ENCODING,
+    data_type: str = "csv",
+) -> ArtifactDescriptor:
+    """Build a descriptor selectable as bytes, text, or a delimited table."""
+    return ArtifactDescriptor(
+        id=id,
+        role="data_artifact",
+        locator=ArtifactLocator.path(path),
+        claims=[
+            RepresentationClaim("text"),
+            DataTypeClaim(data_type, namespace="iana.media-types"),
+            InterfaceClaim("bytes"),
+            InterfaceClaim("text"),
+            InterfaceClaim("table"),
+        ],
+        facets=[encoding_facet(encoding), delimiter_facet(delimiter)],
+    )
+
+
+def json_artifact_descriptor(
+    path: str | Path,
+    *,
+    id: str = "data",
+    encoding: str = DEFAULT_TEXT_ENCODING,
+) -> ArtifactDescriptor:
+    """Build a path-backed descriptor selectable as JSON text."""
+    return ArtifactDescriptor(
+        id=id,
+        role="data_artifact",
+        locator=ArtifactLocator.path(path),
+        claims=[
+            RepresentationClaim("text"),
+            DataTypeClaim("json", namespace="iana.media-types"),
+            InterfaceClaim("text"),
+            InterfaceClaim("json"),
+        ],
+        facets=[encoding_facet(encoding)],
+    )
+
+
+def temporary_text_artifact_descriptor(
+    path: str | Path,
+    *,
+    id: str = "temporary-output",
+    encoding: str = DEFAULT_TEXT_ENCODING,
+) -> ArtifactDescriptor:
+    """Build a non-catalog output descriptor suitable for capability selection."""
+    return ArtifactDescriptor(
+        id=id,
+        role="derived_artifact",
+        locator=ArtifactLocator.path(path),
+        relationship={"catalogued": False, "temporary": True},
+        claims=[RepresentationClaim("text"), InterfaceClaim("text")],
+        facets=[encoding_facet(encoding)],
+    )
+
+
+def encoding_facet(encoding: str) -> ArtifactFacet:
+    """Build the stdlib text encoding facet."""
+    return ArtifactFacet(
+        kind="encoding",
+        name="charset",
+        namespace=PLUGIN_NAMESPACE,
+        metadata={"encoding": encoding},
+    )
+
+
+def delimiter_facet(delimiter: str) -> ArtifactFacet:
+    """Build the stdlib delimited text facet."""
+    return ArtifactFacet(
+        kind="format",
+        name="delimited-text",
+        namespace=PLUGIN_NAMESPACE,
+        metadata={"delimiter": delimiter},
+    )
+
+
+def encoding_from_descriptor(
+    descriptor: ArtifactDescriptor,
+    *,
+    default: str = DEFAULT_TEXT_ENCODING,
+) -> str:
+    """Return a descriptor encoding from facets, falling back to an explicit default."""
+    for facet in iter_facets(descriptor):
+        if facet["kind"] != "encoding" or facet["name"] != "charset":
+            continue
+        metadata = facet["metadata"]
+        if not isinstance(metadata, Mapping):
+            continue
+        value = metadata.get("encoding") or metadata.get("charset")
+        if value is not None:
+            return str(value)
+    return default
+
+
+def delimiter_from_descriptor(descriptor: ArtifactDescriptor, *, default: str = ",") -> str:
+    """Return a delimited-text delimiter from facets."""
+    for facet in iter_facets(descriptor):
+        if facet["kind"] != "format" or facet["name"] != "delimited-text":
+            continue
+        metadata = facet["metadata"]
+        if not isinstance(metadata, Mapping):
+            continue
+        value = metadata.get("delimiter")
+        if value is not None:
+            return str(value)
+    return default
+
+
+def descriptor_with_claims(
+    descriptor: ArtifactDescriptor,
+    *,
+    claims: Iterable[ArtifactClaim] = (),
+    facets: Iterable[ArtifactFacet] = (),
+    relationship: Mapping[str, object] | None = None,
+) -> ArtifactDescriptor:
+    """Return a descriptor copy with merged claims, facets, and relationship metadata."""
+    return ArtifactDescriptor(
+        id=descriptor.id,
+        role=descriptor.role,
+        locator=descriptor.locator,
+        state=descriptor.state,
+        relationship={
+            **descriptor.relationship,
+            **({} if relationship is None else cast(MetadataDict, dict(relationship))),
+        },
+        claims=_merge_claim_items(descriptor.claims, claims),
+        facets=_merge_facet_items(descriptor.facets, facets),
+    )
+
+
+def _capability(
+    *,
+    name: str,
+    operation: str,
+    implementation: object,
+    description: str,
+    required_claims: tuple[ArtifactClaim, ...] = (),
+    output_claims: tuple[ArtifactClaim, ...] = (),
+    required_facets: tuple[ArtifactFacet, ...] = (),
+) -> object:
+    """Build a core ArtifactCapability when available, otherwise a local object."""
+    fallback = StdlibCapability(
+        name=name,
+        operation=operation,
+        implementation=implementation,
+        required_claims=required_claims,
+        required_facets=required_facets,
+        description=description,
+    )
+    try:
+        from ogcat.capabilities import ArtifactCapability
+    except ImportError:
+        return fallback
+    capability_factory = cast(Any, ArtifactCapability)
+
+    metadata: MetadataDict = {"plugin": "stdlib_io"}
+    values: dict[str, object] = {
+        "name": name,
+        "namespace": PLUGIN_NAMESPACE,
+        "version": SCHEMA_VERSION,
+        "operation": operation,
+        "kind": operation,
+        "capability_type": operation,
+        "implementation": implementation,
+        "handler": implementation,
+        "input_claims": required_claims,
+        "output_claims": output_claims,
+        "required_claims": required_claims,
+        "claims": required_claims,
+        "required_facets": required_facets,
+        "facets": required_facets,
+        "description": description,
+        "priority": 0,
+        "metadata": metadata,
+    }
+    try:
+        parameters = inspect.signature(capability_factory).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    kwargs = {name: values[name] for name in parameters if name in values}
+    if kwargs:
+        try:
+            return capability_factory(**kwargs)
+        except TypeError:
+            pass
+
+    for kwargs in (
+        {
+            "name": name,
+            "operation": operation,
+            "implementation": implementation,
+            "required_claims": required_claims,
+            "description": description,
+            "metadata": metadata,
+        },
+        {"name": name, "kind": operation, "implementation": implementation},
+        {"name": name, "implementation": implementation},
+    ):
+        try:
+            return capability_factory(**kwargs)
+        except TypeError:
+            continue
+    return fallback
+
+
+def _descriptor_path(descriptor: ArtifactDescriptor) -> Path:
+    """Return a local path from a descriptor or raise a clear error."""
+    if descriptor.locator is None:
+        raise ValueError(f"artifact descriptor {descriptor.id!r} has no locator")
+    path = descriptor.locator.as_path()
+    if path is None:
+        raise ValueError(
+            f"artifact descriptor {descriptor.id!r} is not path-backed: {descriptor.locator.kind!r}"
+        )
+    return path
+
+
+def _descriptor_has_claim(descriptor: ArtifactDescriptor, claim: ArtifactClaim) -> bool:
+    """Return whether a descriptor has a matching claim envelope."""
+    return has_claim(
+        descriptor,
+        kind=claim.kind,
+        name=claim.name,
+        namespace=claim.namespace,
+        version=claim.version,
+    )
+
+
+def _fieldnames_from_rows(rows: Sequence[Mapping[str, object]]) -> list[str]:
+    """Return stable CSV field names from row keys."""
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(str(key))
+    return fieldnames
+
+
+def _merge_claim_items(
+    existing: Iterable[ArtifactClaimInput],
+    added: Iterable[ArtifactClaim],
+) -> list[ArtifactClaimInput]:
+    """Merge claim schema items by namespace envelope."""
+    return cast(list[ArtifactClaimInput], _merge_schema_items(existing, added))
+
+
+def _merge_facet_items(
+    existing: Iterable[ArtifactFacetInput],
+    added: Iterable[ArtifactFacet],
+) -> list[ArtifactFacetInput]:
+    """Merge facet schema items by namespace envelope."""
+    return cast(list[ArtifactFacetInput], _merge_schema_items(existing, added))
+
+
+def _merge_schema_items(existing: Iterable[object], added: Iterable[object]) -> list[object]:
+    """Merge claim or facet-like schema items by namespace envelope."""
+    items: list[object] = []
+    keys: set[tuple[str, str, str, str]] = set()
+    for item in [*existing, *added]:
+        key = _schema_item_key(item)
+        if key in keys:
+            continue
+        keys.add(key)
+        items.append(item)
+    return items
+
+
+def _schema_item_key(item: object) -> tuple[str, str, str, str]:
+    """Return a schema item key from a claim or facet object."""
+    if isinstance(item, ArtifactClaim | ArtifactFacet):
+        return (item.namespace, item.kind, item.name, item.version)
+    if isinstance(item, Mapping):
+        return (
+            str(item.get("namespace", "ogcat.core")),
+            str(item.get("kind", "")),
+            str(item.get("name", item.get("kind", ""))),
+            str(item.get("version", "1")),
+        )
+    return (type(item).__module__, type(item).__name__, repr(item), "")

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -28,6 +28,7 @@ from ogcat.models import (
 PLUGIN_NAMESPACE = "ogcat.stdlib"
 SCHEMA_VERSION = "1"
 DEFAULT_TEXT_ENCODING = "utf-8"
+_EXTRA_COLUMNS_KEY = "__ogcat_extra_columns__"
 
 JsonDocument: TypeAlias = JsonValue
 TableRows: TypeAlias = list[dict[str, str]]
@@ -100,7 +101,13 @@ class DelimitedTableReader:
             newline="",
             encoding=encoding_from_descriptor(descriptor),
         ) as stream:
-            return [dict(row) for row in csv.DictReader(stream, delimiter=resolved_delimiter)]
+            reader = csv.DictReader(
+                stream,
+                delimiter=resolved_delimiter,
+                restkey=_EXTRA_COLUMNS_KEY,
+                restval="",
+            )
+            return [_normalize_table_row(row, row_number=index) for index, row in enumerate(reader, start=2)]
 
 
 class DelimitedTableWriter:
@@ -574,6 +581,22 @@ def _fieldnames_from_rows(rows: Sequence[Mapping[str, object]]) -> list[str]:
     return fieldnames
 
 
+def _normalize_table_row(row: Mapping[Any, Any], *, row_number: int) -> dict[str, str]:
+    """Return a csv row normalized to string keys and values."""
+    extra_columns = row.get(_EXTRA_COLUMNS_KEY)
+    if isinstance(extra_columns, list):
+        raise ValueError(f"delimited table row {row_number} has more columns than the header")
+
+    normalized: dict[str, str] = {}
+    for key, value in row.items():
+        if key is None:
+            raise ValueError(f"delimited table row {row_number} contains a column without a header")
+        if isinstance(value, list):
+            raise ValueError(f"delimited table row {row_number} contains a non-scalar value")
+        normalized[str(key)] = "" if value is None else str(value)
+    return normalized
+
+
 def _pig_latin_text(text: str) -> str:
     """Return text with ASCII words converted to Pig Latin."""
     return _WORD_RE.sub(lambda match: _pig_latin_word(match.group(0)), text)
@@ -606,16 +629,11 @@ def _merge_facet_items(
 
 
 def _merge_schema_items(existing: Iterable[object], added: Iterable[object]) -> list[object]:
-    """Merge claim or facet-like schema items by namespace envelope."""
-    items: list[object] = []
-    keys: set[tuple[str, str, str, str]] = set()
+    """Merge claim or facet-like schema items, letting added items replace existing ones."""
+    items_by_key: dict[tuple[str, str, str, str], object] = {}
     for item in [*existing, *added]:
-        key = _schema_item_key(item)
-        if key in keys:
-            continue
-        keys.add(key)
-        items.append(item)
-    return items
+        items_by_key[_schema_item_key(item)] = item
+    return list(items_by_key.values())
 
 
 def _schema_item_key(item: object) -> tuple[str, str, str, str]:

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import inspect
 import json
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -31,6 +32,8 @@ DEFAULT_TEXT_ENCODING = "utf-8"
 
 JsonDocument: TypeAlias = JsonValue
 TableRows: TypeAlias = list[dict[str, str]]
+_WORD_RE = re.compile(r"[A-Za-z]+")
+_VOWELS = frozenset("aeiouAEIOU")
 
 
 @dataclass(frozen=True, slots=True)
@@ -271,6 +274,28 @@ class EmoticonEmojiTextConverter:
         return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
 
 
+class PigLatinTextConverter:
+    """Convert text artifacts to Pig Latin text."""
+
+    def convert(
+        self,
+        source_descriptor: ArtifactDescriptor,
+        output_descriptor: ArtifactDescriptor,
+    ) -> ArtifactDescriptor:
+        """Read text and write UTF-8 Pig Latin text output."""
+        converted = _pig_latin_text(TextReader().read(source_descriptor))
+        output = descriptor_with_claims(
+            output_descriptor,
+            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            relationship={
+                "generated_by": "ogcat.stdlib.pig_latin",
+                "source_artifact_id": source_descriptor.id,
+            },
+        )
+        return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
+
+
 def stdlib_capabilities() -> tuple[object, ...]:
     """Create bundled stdlib capability examples."""
     return (
@@ -353,6 +378,15 @@ def stdlib_capabilities() -> tuple[object, ...]:
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
             required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
             description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
+        ),
+        _capability(
+            name="pig-latin-text-converter",
+            operation="converter",
+            implementation=PigLatinTextConverter(),
+            required_claims=(InterfaceClaim("text"),),
+            output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+            required_facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
+            description="Convert text artifacts to Pig Latin text.",
         ),
     )
 
@@ -640,6 +674,21 @@ def _fieldnames_from_rows(rows: Sequence[Mapping[str, object]]) -> list[str]:
             if key not in fieldnames:
                 fieldnames.append(str(key))
     return fieldnames
+
+
+def _pig_latin_text(text: str) -> str:
+    """Return text with ASCII words converted to Pig Latin."""
+    return _WORD_RE.sub(lambda match: _pig_latin_word(match.group(0)), text)
+
+
+def _pig_latin_word(word: str) -> str:
+    """Return one ASCII word converted to Pig Latin."""
+    first_vowel = next((index for index, char in enumerate(word) if char in _VOWELS), -1)
+    if first_vowel == 0:
+        return f"{word}way"
+    if first_vowel > 0:
+        return f"{word[first_vowel:]}{word[:first_vowel]}ay"
+    return f"{word}ay"
 
 
 def _merge_claim_items(

--- a/src/ogcat/capabilities.py
+++ b/src/ogcat/capabilities.py
@@ -45,6 +45,10 @@ class CapabilityLookupError(CapabilityError):
     """Base class for capability lookup errors."""
 
 
+class InvalidCapabilityLookupError(CapabilityLookupError):
+    """Raised when lookup filters contain malformed claims, facets, or kinds."""
+
+
 class MissingCapabilityError(CapabilityLookupError):
     """Raised when no registered capability satisfies a supported request."""
 
@@ -202,33 +206,39 @@ class CapabilityRegistry:
 
         Returns:
             Matching capabilities in registration order.
-        """
-        kind_filter = None if kind is None else _kind_text(kind, field_name="kind")
-        input_keys = _claim_keys(input_claims, field_name="input_claims")
-        output_keys = _claim_keys(output_claims, field_name="output_claims")
-        required_facet_keys = _facet_keys(required_facets, field_name="required_facets")
-        descriptor_claim_keys: frozenset[ArtifactSchemaKey] | None = None
-        descriptor_facet_keys: frozenset[ArtifactSchemaKey] | None = None
-        if descriptor is not None:
-            descriptor_claim_keys = frozenset(claim_key(claim) for claim in iter_claims(descriptor))
-            descriptor_facet_keys = frozenset(facet_key(facet) for facet in iter_facets(descriptor))
 
-        return tuple(
-            capability
-            for capability in self._capabilities.values()
-            if _capability_matches(
-                capability,
-                kind=kind_filter,
-                name=name,
-                namespace=namespace,
-                version=version,
-                descriptor_claim_keys=descriptor_claim_keys,
-                descriptor_facet_keys=descriptor_facet_keys,
-                input_keys=input_keys,
-                output_keys=output_keys,
-                required_facet_keys=required_facet_keys,
+        Raises:
+            InvalidCapabilityLookupError: If lookup claim or facet filters are malformed.
+        """
+        try:
+            kind_filter = None if kind is None else _kind_text(kind, field_name="kind")
+            input_keys = _claim_keys(input_claims, field_name="input_claims")
+            output_keys = _claim_keys(output_claims, field_name="output_claims")
+            required_facet_filters = _normalize_facets(required_facets, field_name="required_facets")
+            descriptor_claim_keys: frozenset[ArtifactSchemaKey] | None = None
+            descriptor_facets: tuple[MetadataDict, ...] | None = None
+            if descriptor is not None:
+                descriptor_claim_keys = frozenset(claim_key(claim) for claim in iter_claims(descriptor))
+                descriptor_facets = tuple(iter_facets(descriptor))
+
+            return tuple(
+                capability
+                for capability in self._capabilities.values()
+                if _capability_matches(
+                    capability,
+                    kind=kind_filter,
+                    name=name,
+                    namespace=namespace,
+                    version=version,
+                    descriptor_claim_keys=descriptor_claim_keys,
+                    descriptor_facets=descriptor_facets,
+                    input_keys=input_keys,
+                    output_keys=output_keys,
+                    required_facet_filters=required_facet_filters,
+                )
             )
-        )
+        except (TypeError, ValueError) as exc:
+            raise InvalidCapabilityLookupError(f"Invalid capability lookup request: {exc}") from exc
 
     def select(
         self,
@@ -250,10 +260,14 @@ class CapabilityRegistry:
             MissingCapabilityError: If no capability supports the request.
             AmbiguousCapabilityError: If more than one capability supports the
                 request.
+            InvalidCapabilityLookupError: If lookup claim or facet filters are malformed.
         """
-        normalized_input_claims = _normalize_claims(input_claims, field_name="input_claims")
-        if descriptor is not None:
-            _require_requested_interfaces(descriptor, normalized_input_claims)
+        try:
+            normalized_input_claims = _normalize_claims(input_claims, field_name="input_claims")
+            if descriptor is not None:
+                _require_requested_interfaces(descriptor, normalized_input_claims)
+        except (TypeError, ValueError) as exc:
+            raise InvalidCapabilityLookupError(f"Invalid capability lookup request: {exc}") from exc
 
         matches = self.find(
             kind=kind,
@@ -280,15 +294,15 @@ def _capability_matches(
     namespace: str | None,
     version: str | None,
     descriptor_claim_keys: frozenset[ArtifactSchemaKey] | None,
-    descriptor_facet_keys: frozenset[ArtifactSchemaKey] | None,
+    descriptor_facets: tuple[MetadataDict, ...] | None,
     input_keys: frozenset[ArtifactSchemaKey],
     output_keys: frozenset[ArtifactSchemaKey],
-    required_facet_keys: frozenset[ArtifactSchemaKey],
+    required_facet_filters: tuple[MetadataDict, ...],
 ) -> bool:
     """Return whether a capability satisfies registry filters."""
     capability_input_keys = _claim_keys(capability.input_claims, field_name="capability.input_claims")
     capability_output_keys = _claim_keys(capability.output_claims, field_name="capability.output_claims")
-    capability_required_facet_keys = _facet_keys(
+    capability_required_facets = _normalize_facets(
         capability.required_facets,
         field_name="capability.required_facets",
     )
@@ -304,11 +318,13 @@ def _capability_matches(
         return False
     if not output_keys.issubset(capability_output_keys):
         return False
-    if not required_facet_keys.issubset(capability_required_facet_keys):
+    if not _facets_satisfy(required_facet_filters, candidates=capability_required_facets):
         return False
     if descriptor_claim_keys is not None and not capability_input_keys.issubset(descriptor_claim_keys):
         return False
-    return descriptor_facet_keys is None or capability_required_facet_keys.issubset(descriptor_facet_keys)
+    return descriptor_facets is None or _facets_satisfy(
+        capability_required_facets, candidates=descriptor_facets
+    )
 
 
 def _validate_capability_contract(capability: ArtifactCapability) -> None:
@@ -430,6 +446,47 @@ def _facet_keys(
     return frozenset(facet_key(facet) for facet in _normalize_facets(facets, field_name=field_name))
 
 
+def _facets_satisfy(
+    requirements: Iterable[MetadataDict],
+    *,
+    candidates: Iterable[MetadataDict],
+) -> bool:
+    """Return whether candidates cover all required facet envelopes and metadata."""
+    candidate_tuple = tuple(candidates)
+    return all(
+        any(_facet_satisfies(requirement, candidate) for candidate in candidate_tuple)
+        for requirement in requirements
+    )
+
+
+def _facet_satisfies(requirement: MetadataDict, candidate: MetadataDict) -> bool:
+    """Return whether a candidate facet satisfies one required facet."""
+    if facet_key(requirement) != facet_key(candidate):
+        return False
+    required_metadata = requirement.get("metadata", {})
+    candidate_metadata = candidate.get("metadata", {})
+    if not isinstance(required_metadata, Mapping) or not isinstance(candidate_metadata, Mapping):
+        return candidate_metadata == required_metadata
+    return _metadata_contains(candidate_metadata, required_metadata)
+
+
+def _metadata_contains(candidate: Mapping[str, object], required: Mapping[str, object]) -> bool:
+    """Return whether candidate metadata contains the required metadata subset."""
+    for key, required_value in required.items():
+        if key not in candidate:
+            return False
+        if not _metadata_value_satisfies(candidate[key], required_value):
+            return False
+    return True
+
+
+def _metadata_value_satisfies(candidate_value: object, required_value: object) -> bool:
+    """Return whether one candidate metadata value satisfies one required value."""
+    if isinstance(candidate_value, Mapping) and isinstance(required_value, Mapping):
+        return _metadata_contains(candidate_value, required_value)
+    return candidate_value == required_value
+
+
 def _reject_duplicate_schema_keys(
     keys: Iterable[ArtifactSchemaKey],
     *,
@@ -492,6 +549,7 @@ __all__ = [
     "CapabilityLookupError",
     "CapabilityRegistrationError",
     "CapabilityRegistry",
+    "InvalidCapabilityLookupError",
     "MissingCapabilityError",
     "UnsupportedInterfaceError",
 ]

--- a/src/ogcat/capabilities.py
+++ b/src/ogcat/capabilities.py
@@ -1,4 +1,19 @@
-"""Artifact capability registration and lookup."""
+"""Artifact capability registration and lookup.
+
+The capability registry is the #119 dispatch surface for readers, writers, and
+converters. It stores typed declarations and optional opaque implementation
+objects, then answers discovery and selection requests from
+``ArtifactDescriptor`` claims and facets. Core does not invoke implementations
+or dispatch by ``CatalogRecord.record_type``.
+
+Matching treats claim identity as the namespace/kind/name/version envelope.
+Claim metadata is descriptive and is not used for dispatch. Facets use the same
+envelope plus metadata-subset matching, so plugin declarations can require
+facts such as a text encoding, delimiter, or local path locator without making
+those values part of a claim key. Lookup errors stay in the capability error
+hierarchy, with separate missing, unsupported-interface, ambiguous, and invalid
+request failures.
+"""
 
 from __future__ import annotations
 
@@ -75,9 +90,15 @@ class ArtifactCapability:
         name: Namespace-local capability name.
         namespace: Stable namespace that owns the capability.
         version: Version of the capability contract.
-        input_claims: Claims required on input descriptors.
-        output_claims: Claims produced by the capability.
-        required_facets: Facets required on input descriptors.
+        input_claims: Claims required on input descriptors. Inputs may be
+            ``ArtifactClaim`` instances or normalized claim dictionaries and are
+            stored as normalized dictionaries.
+        output_claims: Claims produced by the capability. Inputs may be
+            ``ArtifactClaim`` instances or normalized claim dictionaries and are
+            stored as normalized dictionaries.
+        required_facets: Facets required on descriptors used for lookup. Facets
+            may be ``ArtifactFacet`` instances or normalized facet dictionaries
+            and are stored as normalized dictionaries.
         options: JSON-compatible capability option metadata.
         metadata: JSON-compatible descriptive metadata.
         implementation: Opaque implementation object stored by the registry.
@@ -253,6 +274,19 @@ class CapabilityRegistry:
         required_facets: Iterable[ArtifactFacetInput] = (),
     ) -> ArtifactCapability:
         """Select exactly one capability for an explicit request.
+
+        Args:
+            kind: Optional capability kind filter.
+            name: Optional capability name filter.
+            namespace: Optional capability namespace filter.
+            version: Optional capability version filter.
+            descriptor: Optional artifact descriptor capabilities must support.
+            input_claims: Input claims the capability must require.
+            output_claims: Output claims the capability must produce.
+            required_facets: Required facets the capability must declare.
+
+        Returns:
+            The single selected capability.
 
         Raises:
             UnsupportedInterfaceError: If a requested interface claim is absent

--- a/src/ogcat/capabilities.py
+++ b/src/ogcat/capabilities.py
@@ -1,0 +1,497 @@
+"""Artifact capability registration and lookup."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TypeAlias
+
+from ogcat.artifact_claims import claim_key, facet_key, iter_claims, iter_facets
+from ogcat.models import (
+    ARTIFACT_SCHEMA_VERSION,
+    CORE_ARTIFACT_NAMESPACE,
+    INTERFACE_CLAIM_KIND,
+    ArtifactClaim,
+    ArtifactDescriptor,
+    ArtifactFacet,
+    MetadataDict,
+    normalize_metadata,
+)
+
+ArtifactClaimInput: TypeAlias = ArtifactClaim | Mapping[str, object]
+ArtifactFacetInput: TypeAlias = ArtifactFacet | Mapping[str, object]
+ArtifactSchemaKey: TypeAlias = tuple[str, str, str, str]
+CapabilityKey: TypeAlias = tuple[str, str, str, str]
+
+
+class CapabilityKind(StrEnum):
+    """Standard capability kinds recognized by the core registry."""
+
+    READER = "reader"
+    WRITER = "writer"
+    CONVERTER = "converter"
+
+
+class CapabilityError(Exception):
+    """Base class for capability registry errors."""
+
+
+class CapabilityRegistrationError(CapabilityError):
+    """Raised when a capability cannot be registered."""
+
+
+class CapabilityLookupError(CapabilityError):
+    """Base class for capability lookup errors."""
+
+
+class MissingCapabilityError(CapabilityLookupError):
+    """Raised when no registered capability satisfies a supported request."""
+
+
+class UnsupportedInterfaceError(CapabilityLookupError):
+    """Raised when a descriptor does not expose a requested interface claim."""
+
+
+class AmbiguousCapabilityError(CapabilityLookupError):
+    """Raised when a lookup request matches more than one capability."""
+
+    def __init__(self, candidates: Iterable[str]) -> None:
+        """Create an ambiguity error with deterministic candidate names."""
+        self.candidates = tuple(sorted(candidates))
+        super().__init__("Multiple capabilities match the request: " + ", ".join(self.candidates))
+
+
+@dataclass(slots=True)
+class ArtifactCapability:
+    """Descriptor for an artifact capability implementation.
+
+    Args:
+        kind: Capability category, such as ``CapabilityKind.READER``.
+        name: Namespace-local capability name.
+        namespace: Stable namespace that owns the capability.
+        version: Version of the capability contract.
+        input_claims: Claims required on input descriptors.
+        output_claims: Claims produced by the capability.
+        required_facets: Facets required on input descriptors.
+        options: JSON-compatible capability option metadata.
+        metadata: JSON-compatible descriptive metadata.
+        implementation: Opaque implementation object stored by the registry.
+    """
+
+    kind: CapabilityKind | str
+    name: str
+    namespace: str = CORE_ARTIFACT_NAMESPACE
+    version: str = ARTIFACT_SCHEMA_VERSION
+    input_claims: Iterable[ArtifactClaimInput] = field(default_factory=tuple)
+    output_claims: Iterable[ArtifactClaimInput] = field(default_factory=tuple)
+    required_facets: Iterable[ArtifactFacetInput] = field(default_factory=tuple)
+    options: Mapping[str, object] = field(default_factory=dict)
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    implementation: object | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize fields used by registry matching."""
+        self.kind = _coerce_kind(self.kind)
+        self.name = _coerce_required_text(self.name, field_name="capability.name")
+        self.namespace = _coerce_required_text(
+            self.namespace,
+            field_name=f"capability[{self.kind}:{self.name}].namespace",
+        )
+        self.version = _coerce_required_text(
+            self.version,
+            field_name=f"capability[{self.kind}:{self.name}].version",
+        )
+        self.input_claims = _normalize_claims(
+            self.input_claims,
+            field_name=f"capability[{self.kind}:{self.name}].input_claims",
+        )
+        self.output_claims = _normalize_claims(
+            self.output_claims,
+            field_name=f"capability[{self.kind}:{self.name}].output_claims",
+        )
+        self.required_facets = _normalize_facets(
+            self.required_facets,
+            field_name=f"capability[{self.kind}:{self.name}].required_facets",
+        )
+        self.options = normalize_metadata(
+            self.options,
+            field_name=f"capability[{self.kind}:{self.name}].options",
+            label="capability options",
+        )
+        self.metadata = normalize_metadata(
+            self.metadata,
+            field_name=f"capability[{self.kind}:{self.name}].metadata",
+            label="capability metadata",
+        )
+
+    @property
+    def key(self) -> CapabilityKey:
+        """Return the stable registry key for this capability."""
+        return (self.namespace, _kind_value(self.kind), self.name, self.version)
+
+    @property
+    def display_name(self) -> str:
+        """Return a deterministic user-facing capability identifier."""
+        return f"{self.namespace}:{_kind_value(self.kind)}:{self.name}@{self.version}"
+
+
+class CapabilityRegistry:
+    """In-memory registry for artifact capabilities."""
+
+    def __init__(self, capabilities: Iterable[ArtifactCapability] = ()) -> None:
+        """Create a registry and register initial capabilities.
+
+        Args:
+            capabilities: Capabilities to register in lookup order.
+        """
+        self._capabilities: dict[CapabilityKey, ArtifactCapability] = {}
+        for capability in capabilities:
+            self.register(capability)
+
+    def register(self, capability: ArtifactCapability) -> ArtifactCapability:
+        """Register a capability and return it for decorator-style usage.
+
+        Args:
+            capability: Capability descriptor to register.
+
+        Returns:
+            The registered capability.
+
+        Raises:
+            CapabilityRegistrationError: If the capability is invalid or duplicated.
+        """
+        if not isinstance(capability, ArtifactCapability):
+            raise CapabilityRegistrationError(
+                f"capability must be an ArtifactCapability, got {type(capability).__name__}"
+            )
+
+        _validate_capability_contract(capability)
+        if capability.key in self._capabilities:
+            raise CapabilityRegistrationError(f"capability is already registered: {capability.display_name}")
+        self._capabilities[capability.key] = capability
+        return capability
+
+    def list(self) -> tuple[ArtifactCapability, ...]:
+        """Return registered capabilities in insertion order."""
+        return tuple(self._capabilities.values())
+
+    def find(
+        self,
+        *,
+        kind: CapabilityKind | str | None = None,
+        name: str | None = None,
+        namespace: str | None = None,
+        version: str | None = None,
+        descriptor: ArtifactDescriptor | None = None,
+        input_claims: Iterable[ArtifactClaimInput] = (),
+        output_claims: Iterable[ArtifactClaimInput] = (),
+        required_facets: Iterable[ArtifactFacetInput] = (),
+    ) -> tuple[ArtifactCapability, ...]:
+        """Find capabilities matching the supplied filters.
+
+        Args:
+            kind: Optional capability kind filter.
+            name: Optional capability name filter.
+            namespace: Optional capability namespace filter.
+            version: Optional capability version filter.
+            descriptor: Optional artifact descriptor capabilities must support.
+            input_claims: Input claims the capability must require.
+            output_claims: Output claims the capability must produce.
+            required_facets: Required facets the capability must declare.
+
+        Returns:
+            Matching capabilities in registration order.
+        """
+        kind_filter = None if kind is None else _kind_text(kind, field_name="kind")
+        input_keys = _claim_keys(input_claims, field_name="input_claims")
+        output_keys = _claim_keys(output_claims, field_name="output_claims")
+        required_facet_keys = _facet_keys(required_facets, field_name="required_facets")
+        descriptor_claim_keys: frozenset[ArtifactSchemaKey] | None = None
+        descriptor_facet_keys: frozenset[ArtifactSchemaKey] | None = None
+        if descriptor is not None:
+            descriptor_claim_keys = frozenset(claim_key(claim) for claim in iter_claims(descriptor))
+            descriptor_facet_keys = frozenset(facet_key(facet) for facet in iter_facets(descriptor))
+
+        return tuple(
+            capability
+            for capability in self._capabilities.values()
+            if _capability_matches(
+                capability,
+                kind=kind_filter,
+                name=name,
+                namespace=namespace,
+                version=version,
+                descriptor_claim_keys=descriptor_claim_keys,
+                descriptor_facet_keys=descriptor_facet_keys,
+                input_keys=input_keys,
+                output_keys=output_keys,
+                required_facet_keys=required_facet_keys,
+            )
+        )
+
+    def select(
+        self,
+        *,
+        kind: CapabilityKind | str | None = None,
+        name: str | None = None,
+        namespace: str | None = None,
+        version: str | None = None,
+        descriptor: ArtifactDescriptor | None = None,
+        input_claims: Iterable[ArtifactClaimInput] = (),
+        output_claims: Iterable[ArtifactClaimInput] = (),
+        required_facets: Iterable[ArtifactFacetInput] = (),
+    ) -> ArtifactCapability:
+        """Select exactly one capability for an explicit request.
+
+        Raises:
+            UnsupportedInterfaceError: If a requested interface claim is absent
+                from ``descriptor``.
+            MissingCapabilityError: If no capability supports the request.
+            AmbiguousCapabilityError: If more than one capability supports the
+                request.
+        """
+        normalized_input_claims = _normalize_claims(input_claims, field_name="input_claims")
+        if descriptor is not None:
+            _require_requested_interfaces(descriptor, normalized_input_claims)
+
+        matches = self.find(
+            kind=kind,
+            name=name,
+            namespace=namespace,
+            version=version,
+            descriptor=descriptor,
+            input_claims=normalized_input_claims,
+            output_claims=output_claims,
+            required_facets=required_facets,
+        )
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise MissingCapabilityError("No capability matches the request.")
+        raise AmbiguousCapabilityError(capability.display_name for capability in matches)
+
+
+def _capability_matches(
+    capability: ArtifactCapability,
+    *,
+    kind: str | None,
+    name: str | None,
+    namespace: str | None,
+    version: str | None,
+    descriptor_claim_keys: frozenset[ArtifactSchemaKey] | None,
+    descriptor_facet_keys: frozenset[ArtifactSchemaKey] | None,
+    input_keys: frozenset[ArtifactSchemaKey],
+    output_keys: frozenset[ArtifactSchemaKey],
+    required_facet_keys: frozenset[ArtifactSchemaKey],
+) -> bool:
+    """Return whether a capability satisfies registry filters."""
+    capability_input_keys = _claim_keys(capability.input_claims, field_name="capability.input_claims")
+    capability_output_keys = _claim_keys(capability.output_claims, field_name="capability.output_claims")
+    capability_required_facet_keys = _facet_keys(
+        capability.required_facets,
+        field_name="capability.required_facets",
+    )
+    if kind is not None and _kind_value(capability.kind) != kind:
+        return False
+    if name is not None and capability.name != name:
+        return False
+    if namespace is not None and capability.namespace != namespace:
+        return False
+    if version is not None and capability.version != version:
+        return False
+    if not input_keys.issubset(capability_input_keys):
+        return False
+    if not output_keys.issubset(capability_output_keys):
+        return False
+    if not required_facet_keys.issubset(capability_required_facet_keys):
+        return False
+    if descriptor_claim_keys is not None and not capability_input_keys.issubset(descriptor_claim_keys):
+        return False
+    return descriptor_facet_keys is None or capability_required_facet_keys.issubset(descriptor_facet_keys)
+
+
+def _validate_capability_contract(capability: ArtifactCapability) -> None:
+    """Validate kind-specific capability declaration requirements."""
+    kind = _kind_value(capability.kind)
+    if kind not in {member.value for member in CapabilityKind}:
+        raise CapabilityRegistrationError(
+            f"capability kind must be one of reader, writer, converter; got {kind!r}"
+        )
+
+    input_keys = _claim_keys(capability.input_claims, field_name="capability.input_claims")
+    output_keys = _claim_keys(capability.output_claims, field_name="capability.output_claims")
+    if kind == CapabilityKind.READER.value and not _has_interface_key(input_keys):
+        raise CapabilityRegistrationError(
+            f"reader capability {capability.display_name} must declare at least one input interface claim"
+        )
+    if kind == CapabilityKind.WRITER.value and not output_keys:
+        raise CapabilityRegistrationError(
+            f"writer capability {capability.display_name} must declare at least one output claim"
+        )
+    if kind == CapabilityKind.CONVERTER.value:
+        if not input_keys:
+            raise CapabilityRegistrationError(
+                f"converter capability {capability.display_name} must declare at least one input claim"
+            )
+        if not output_keys:
+            raise CapabilityRegistrationError(
+                f"converter capability {capability.display_name} must declare at least one output claim"
+            )
+
+
+def _has_interface_key(keys: Iterable[ArtifactSchemaKey]) -> bool:
+    """Return whether any schema key is an interface claim key."""
+    return any(kind == INTERFACE_CLAIM_KIND for _, kind, _, _ in keys)
+
+
+def _require_requested_interfaces(
+    descriptor: ArtifactDescriptor,
+    input_claims: tuple[MetadataDict, ...],
+) -> None:
+    """Raise when explicitly requested interface claims are absent."""
+    requested = tuple(claim for claim in input_claims if claim["kind"] == INTERFACE_CLAIM_KIND)
+    if not requested:
+        return
+    descriptor_claim_keys = frozenset(claim_key(claim) for claim in iter_claims(descriptor))
+    for claim in requested:
+        if claim_key(claim) not in descriptor_claim_keys:
+            raise UnsupportedInterfaceError(
+                "Descriptor does not expose requested interface claim: "
+                + _schema_display_name(claim_key(claim))
+            )
+
+
+def _normalize_claims(
+    claims: Iterable[ArtifactClaimInput],
+    *,
+    field_name: str,
+) -> tuple[MetadataDict, ...]:
+    """Normalize claim inputs through ``ArtifactClaim``."""
+    normalized = tuple(
+        _normalize_claim(claim, field_name=f"{field_name}[{index}]") for index, claim in enumerate(claims)
+    )
+    _reject_duplicate_schema_keys(
+        (claim_key(claim) for claim in normalized),
+        field_name=field_name,
+    )
+    return normalized
+
+
+def _normalize_claim(claim: ArtifactClaimInput, *, field_name: str) -> MetadataDict:
+    """Normalize one claim input through ``ArtifactClaim``."""
+    if isinstance(claim, ArtifactClaim):
+        return claim.to_dict()
+    if isinstance(claim, Mapping):
+        return ArtifactClaim.from_dict(claim, field_name=field_name).to_dict()
+    raise TypeError(f"{field_name} must be an ArtifactClaim or dictionary, got {type(claim).__name__}")
+
+
+def _normalize_facets(
+    facets: Iterable[ArtifactFacetInput],
+    *,
+    field_name: str,
+) -> tuple[MetadataDict, ...]:
+    """Normalize facet inputs through ``ArtifactFacet``."""
+    normalized = tuple(
+        _normalize_facet(facet, field_name=f"{field_name}[{index}]") for index, facet in enumerate(facets)
+    )
+    _reject_duplicate_schema_keys(
+        (facet_key(facet) for facet in normalized),
+        field_name=field_name,
+    )
+    return normalized
+
+
+def _normalize_facet(facet: ArtifactFacetInput, *, field_name: str) -> MetadataDict:
+    """Normalize one facet input through ``ArtifactFacet``."""
+    if isinstance(facet, ArtifactFacet):
+        return facet.to_dict()
+    if isinstance(facet, Mapping):
+        return ArtifactFacet.from_dict(facet, field_name=field_name).to_dict()
+    raise TypeError(f"{field_name} must be an ArtifactFacet or dictionary, got {type(facet).__name__}")
+
+
+def _claim_keys(
+    claims: Iterable[ArtifactClaimInput],
+    *,
+    field_name: str,
+) -> frozenset[ArtifactSchemaKey]:
+    """Return normalized lookup keys for claim inputs."""
+    return frozenset(claim_key(claim) for claim in _normalize_claims(claims, field_name=field_name))
+
+
+def _facet_keys(
+    facets: Iterable[ArtifactFacetInput],
+    *,
+    field_name: str,
+) -> frozenset[ArtifactSchemaKey]:
+    """Return normalized lookup keys for facet inputs."""
+    return frozenset(facet_key(facet) for facet in _normalize_facets(facets, field_name=field_name))
+
+
+def _reject_duplicate_schema_keys(
+    keys: Iterable[ArtifactSchemaKey],
+    *,
+    field_name: str,
+) -> None:
+    """Raise when a claim or facet sequence contains duplicate schema keys."""
+    seen: set[ArtifactSchemaKey] = set()
+    for key in keys:
+        if key in seen:
+            raise ValueError(f"{field_name} contains duplicate schema key: {_schema_display_name(key)}")
+        seen.add(key)
+
+
+def _schema_display_name(key: ArtifactSchemaKey) -> str:
+    """Return a deterministic display name for a claim or facet key."""
+    namespace, kind, name, version = key
+    return f"{namespace}:{kind}:{name}@{version}"
+
+
+def _coerce_kind(kind: CapabilityKind | str) -> CapabilityKind | str:
+    """Normalize known capability kinds to ``CapabilityKind`` members."""
+    kind_text = _kind_text(kind, field_name="capability.kind")
+    try:
+        return CapabilityKind(kind_text)
+    except ValueError:
+        return kind_text
+
+
+def _kind_text(kind: CapabilityKind | str, *, field_name: str) -> str:
+    """Return a non-empty capability kind string."""
+    if isinstance(kind, CapabilityKind):
+        return kind.value
+    return _coerce_required_text(kind, field_name=field_name)
+
+
+def _kind_value(kind: CapabilityKind | str) -> str:
+    """Return the string value for a normalized capability kind."""
+    if isinstance(kind, CapabilityKind):
+        return kind.value
+    return kind
+
+
+def _coerce_required_text(value: object, *, field_name: str) -> str:
+    """Coerce a required string field and reject empty values."""
+    if value is None:
+        raise TypeError(f"{field_name} must not be None")
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value).__name__}")
+    text = value
+    if not text.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+    return text
+
+
+__all__ = [
+    "AmbiguousCapabilityError",
+    "ArtifactCapability",
+    "CapabilityError",
+    "CapabilityKind",
+    "CapabilityLookupError",
+    "CapabilityRegistrationError",
+    "CapabilityRegistry",
+    "MissingCapabilityError",
+    "UnsupportedInterfaceError",
+]

--- a/src/ogcat/plugins.py
+++ b/src/ogcat/plugins.py
@@ -4,18 +4,26 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from ogcat.capabilities import ArtifactCapability, CapabilityRegistry
 from ogcat.hooks import HookManager
 
 
 class PluginRegistry:
-    """Registry for direct Python hook registration.
+    """Registry for direct Python plugin registration.
 
     Args:
         hooks: Hook objects to register in dispatch order.
+        capabilities: Artifact capabilities to register in lookup order.
     """
 
-    def __init__(self, hooks: Iterable[object] = ()) -> None:
+    def __init__(
+        self,
+        hooks: Iterable[object] = (),
+        *,
+        capabilities: Iterable[ArtifactCapability] = (),
+    ) -> None:
         self._hooks: list[object] = list(hooks)
+        self._capabilities = CapabilityRegistry(capabilities)
 
     @property
     def hooks(self) -> tuple[object, ...]:
@@ -30,6 +38,18 @@ class PluginRegistry:
     def hook_manager(self) -> HookManager:
         """Build a hook manager from the currently registered hooks."""
         return HookManager(self._hooks)
+
+    def register_capability(self, capability: ArtifactCapability) -> ArtifactCapability:
+        """Register an artifact capability and return it."""
+        return self._capabilities.register(capability)
+
+    def list_capabilities(self) -> tuple[ArtifactCapability, ...]:
+        """Return registered artifact capabilities in insertion order."""
+        return self._capabilities.list()
+
+    def capability_registry(self) -> CapabilityRegistry:
+        """Return the plugin capability registry."""
+        return self._capabilities
 
 
 __all__ = ["PluginRegistry"]

--- a/src/ogcat/plugins.py
+++ b/src/ogcat/plugins.py
@@ -22,6 +22,12 @@ class PluginRegistry:
         *,
         capabilities: Iterable[ArtifactCapability] = (),
     ) -> None:
+        """Create a plugin registry.
+
+        Args:
+            hooks: Hook objects to register in dispatch order.
+            capabilities: Artifact capabilities to register in lookup order.
+        """
         self._hooks: list[object] = list(hooks)
         self._capabilities = CapabilityRegistry(capabilities)
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from ogcat import (
@@ -12,6 +14,7 @@ from ogcat import (
     CapabilityRegistry,
     DataTypeClaim,
     InterfaceClaim,
+    InvalidCapabilityLookupError,
     MissingCapabilityError,
     PluginRegistry,
     UnsupportedInterfaceError,
@@ -127,6 +130,96 @@ def test_descriptor_lookup_uses_artifact_claims_not_record_type() -> None:
     )
 
 
+def test_descriptor_lookup_matches_required_facet_metadata() -> None:
+    """Descriptor facet metadata should discriminate otherwise identical facet keys."""
+    text_claim = InterfaceClaim("text")
+    utf8_requirement = ArtifactFacet(
+        "encoding",
+        "charset",
+        metadata={"encoding": "utf-8"},
+    )
+    ascii_requirement = ArtifactFacet(
+        "encoding",
+        "charset",
+        metadata={"encoding": "ascii"},
+    )
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[text_claim],
+        facets=[
+            ArtifactFacet(
+                "encoding",
+                "charset",
+                metadata={"encoding": "utf-8", "byte_order_mark": False},
+            )
+        ],
+    )
+    utf8_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="utf8-reader",
+        input_claims=[text_claim],
+        required_facets=[utf8_requirement],
+    )
+    ascii_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="ascii-reader",
+        input_claims=[text_claim],
+        required_facets=[ascii_requirement],
+    )
+    registry = CapabilityRegistry([utf8_reader, ascii_reader])
+
+    assert registry.find(
+        kind=CapabilityKind.READER,
+        descriptor=descriptor,
+        input_claims=[text_claim],
+    ) == (utf8_reader,)
+    assert (
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[text_claim],
+        )
+        is utf8_reader
+    )
+
+
+def test_find_required_facets_matches_metadata() -> None:
+    """Facet filters should include required metadata, not only schema keys."""
+    text_claim = InterfaceClaim("text")
+    utf8_requirement = ArtifactFacet(
+        "encoding",
+        "charset",
+        metadata={"encoding": "utf-8"},
+    )
+    ascii_requirement = ArtifactFacet(
+        "encoding",
+        "charset",
+        metadata={"encoding": "ascii"},
+    )
+    utf8_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="utf8-reader",
+        input_claims=[text_claim],
+        required_facets=[utf8_requirement],
+    )
+    ascii_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="ascii-reader",
+        input_claims=[text_claim],
+        required_facets=[ascii_requirement],
+    )
+    registry = CapabilityRegistry([utf8_reader, ascii_reader])
+
+    assert registry.find(kind=CapabilityKind.READER, required_facets=[utf8_requirement]) == (utf8_reader,)
+    assert registry.find(
+        kind=CapabilityKind.READER, required_facets=[ArtifactFacet("encoding", "charset")]
+    ) == (
+        utf8_reader,
+        ascii_reader,
+    )
+
+
 def test_select_raises_unsupported_interface_when_descriptor_lacks_request() -> None:
     """Requested interface claims must be present on the descriptor."""
     descriptor = ArtifactDescriptor(
@@ -203,6 +296,20 @@ def test_select_raises_ambiguous_with_sorted_candidate_names() -> None:
         "example.alpha:reader:alpha-reader@1",
         "example.beta:reader:beta-reader@1",
     )
+
+
+def test_lookup_rejects_malformed_filters_with_lookup_error() -> None:
+    """Malformed public lookup filters should raise capability lookup errors."""
+    registry = CapabilityRegistry()
+
+    with pytest.raises(InvalidCapabilityLookupError, match="input_claims"):
+        registry.find(input_claims=cast(Any, [object()]))
+
+    with pytest.raises(InvalidCapabilityLookupError, match="required_facets"):
+        registry.find(required_facets=cast(Any, [object()]))
+
+    with pytest.raises(InvalidCapabilityLookupError, match="input_claims"):
+        registry.select(input_claims=cast(Any, [object()]))
 
 
 def test_duplicate_and_invalid_registration_raise_registration_errors() -> None:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,3 +1,5 @@
+"""Tests for artifact capability registration and lookup behavior."""
+
 from __future__ import annotations
 
 from typing import Any, cast

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import pytest
+
+from ogcat import (
+    AmbiguousCapabilityError,
+    ArtifactCapability,
+    ArtifactDescriptor,
+    ArtifactFacet,
+    CapabilityKind,
+    CapabilityRegistrationError,
+    CapabilityRegistry,
+    DataTypeClaim,
+    InterfaceClaim,
+    MissingCapabilityError,
+    PluginRegistry,
+    UnsupportedInterfaceError,
+)
+
+
+def test_registry_registers_lists_finds_and_selects_capabilities() -> None:
+    """Registry lookups should use normalized claim and facet keys."""
+    input_claim = InterfaceClaim("bytes")
+    output_claim = InterfaceClaim("table")
+    required_facet = ArtifactFacet("suffix", "csv")
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[input_claim],
+        facets=[required_facet],
+    )
+    capability = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="csv-reader",
+        input_claims=[input_claim],
+        output_claims=[output_claim],
+        required_facets=[required_facet],
+        implementation=object(),
+    )
+    registry = CapabilityRegistry()
+
+    registered = registry.register(capability)
+
+    assert registered is capability
+    assert registry.list() == (capability,)
+    assert registry.find(
+        kind="reader",
+        name="csv-reader",
+        namespace=capability.namespace,
+        version=capability.version,
+        output_claims=[output_claim],
+        required_facets=[required_facet],
+    ) == (capability,)
+    assert (
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[input_claim],
+            output_claims=[output_claim],
+        )
+        is capability
+    )
+
+
+def test_multiple_interface_claims_select_different_reader_capabilities() -> None:
+    """Explicit interface claims should disambiguate reader selection."""
+    bytes_claim = InterfaceClaim("bytes")
+    xarray_claim = InterfaceClaim("xarray-dataset", namespace="pydata.xarray")
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[bytes_claim, xarray_claim],
+    )
+    bytes_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="bytes-reader",
+        input_claims=[bytes_claim],
+    )
+    xarray_reader = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="xarray-reader",
+        input_claims=[xarray_claim],
+    )
+    registry = CapabilityRegistry([bytes_reader, xarray_reader])
+
+    assert (
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[bytes_claim],
+        )
+        is bytes_reader
+    )
+    assert (
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[xarray_claim],
+        )
+        is xarray_reader
+    )
+
+
+def test_descriptor_lookup_uses_artifact_claims_not_record_type() -> None:
+    """Capability lookup should depend on descriptor claims only."""
+    claim = DataTypeClaim("netcdf", namespace="org.unidata")
+    interface = InterfaceClaim("xarray-dataset", namespace="pydata.xarray")
+    descriptor = ArtifactDescriptor(
+        id="sidecar",
+        role="auxiliary_artifact",
+        claims=[claim, interface],
+    )
+    capability = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="netcdf-reader",
+        input_claims=[claim, interface],
+    )
+    registry = CapabilityRegistry([capability])
+
+    assert (
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[interface],
+        )
+        is capability
+    )
+
+
+def test_select_raises_unsupported_interface_when_descriptor_lacks_request() -> None:
+    """Requested interface claims must be present on the descriptor."""
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[InterfaceClaim("bytes")],
+    )
+    registry = CapabilityRegistry(
+        [
+            ArtifactCapability(
+                kind=CapabilityKind.READER,
+                name="table-reader",
+                input_claims=[InterfaceClaim("table")],
+            )
+        ]
+    )
+
+    with pytest.raises(UnsupportedInterfaceError, match="interface:table"):
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[InterfaceClaim("table")],
+        )
+
+
+def test_select_raises_missing_when_supported_request_has_no_capability() -> None:
+    """Supported descriptor interfaces without matching capabilities should fail as missing."""
+    table_claim = InterfaceClaim("table")
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[table_claim],
+    )
+    registry = CapabilityRegistry()
+
+    with pytest.raises(MissingCapabilityError):
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[table_claim],
+        )
+
+
+def test_select_raises_ambiguous_with_sorted_candidate_names() -> None:
+    """Multiple matching capabilities should raise deterministic candidates."""
+    claim = InterfaceClaim("bytes")
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[claim],
+    )
+    alpha = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="alpha-reader",
+        namespace="example.alpha",
+        input_claims=[claim],
+    )
+    beta = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="beta-reader",
+        namespace="example.beta",
+        input_claims=[claim],
+    )
+    registry = CapabilityRegistry([beta, alpha])
+
+    with pytest.raises(AmbiguousCapabilityError) as exc_info:
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=descriptor,
+            input_claims=[claim],
+        )
+
+    assert exc_info.value.candidates == (
+        "example.alpha:reader:alpha-reader@1",
+        "example.beta:reader:beta-reader@1",
+    )
+
+
+def test_duplicate_and_invalid_registration_raise_registration_errors() -> None:
+    """Registry registration should reject duplicate keys and invalid objects."""
+    capability = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="bytes-reader",
+        input_claims=[InterfaceClaim("bytes")],
+    )
+    registry = CapabilityRegistry([capability])
+
+    with pytest.raises(CapabilityRegistrationError, match="already registered"):
+        registry.register(
+            ArtifactCapability(
+                kind=CapabilityKind.READER,
+                name="bytes-reader",
+                input_claims=[InterfaceClaim("bytes")],
+                implementation=object(),
+            )
+        )
+
+    with pytest.raises(CapabilityRegistrationError, match="ArtifactCapability"):
+        registry.register(object())  # type: ignore[arg-type]
+
+    with pytest.raises(CapabilityRegistrationError, match="input interface claim"):
+        CapabilityRegistry([ArtifactCapability(kind=CapabilityKind.READER, name="unusable-reader")])
+
+
+def test_plugin_registry_keeps_capabilities_separate_from_hooks() -> None:
+    """PluginRegistry should expose plugin-owned capability namespaces."""
+    calls: list[str] = []
+
+    class Hook:
+        def before_commit(self, context: object) -> None:
+            calls.append("before_commit")
+
+    claim = InterfaceClaim("custom-table", namespace="example.plugin")
+    capability = ArtifactCapability(
+        kind=CapabilityKind.READER,
+        name="custom-reader",
+        namespace="example.plugin",
+        input_claims=[claim],
+    )
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        claims=[claim],
+    )
+    plugins = PluginRegistry([Hook()])
+
+    assert plugins.register_capability(capability) is capability
+
+    assert len(plugins.hooks) == 1
+    assert calls == []
+    assert plugins.list_capabilities() == (capability,)
+    assert (
+        plugins.capability_registry().select(
+            kind=CapabilityKind.READER,
+            namespace="example.plugin",
+            descriptor=descriptor,
+            input_claims=[claim],
+        )
+        is capability
+    )

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -1,0 +1,228 @@
+"""Tests for bundled stdlib plugin capability examples."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ogcat.artifact_claims import has_claim, has_facet
+from ogcat.bundled_plugins.stdlib_io import (
+    delimited_table_artifact_descriptor,
+    json_artifact_descriptor,
+    register_stdlib_capabilities,
+    temporary_text_artifact_descriptor,
+    text_artifact_descriptor,
+)
+from ogcat.models import ArtifactDescriptor, ArtifactLocator, InterfaceClaim
+from ogcat.plugins import PluginRegistry
+
+
+def test_bytes_reader_and_writer_examples_round_trip_bytes(tmp_path: Path) -> None:
+    """Bytes capabilities should use Path.read_bytes and Path.write_bytes."""
+    path = tmp_path / "payload.bin"
+    descriptor = ArtifactDescriptor(
+        id="data",
+        role="data_artifact",
+        locator=ArtifactLocator.path(path),
+        claims=[InterfaceClaim("bytes")],
+    )
+    registry = _registry()
+
+    writer = _implementation(_select(registry, descriptor, operation="write", interface="bytes"))
+    result = writer.write(descriptor, b"abc\x00def")
+    reader = _implementation(_select(registry, result, operation="read", interface="bytes"))
+
+    assert path.read_bytes() == b"abc\x00def"
+    assert reader.read(result) == b"abc\x00def"
+
+
+def test_text_reader_and_writer_examples_use_encoding_facets(tmp_path: Path) -> None:
+    """Text capabilities should honor ASCII and UTF-8 encoding facets."""
+    registry = _registry()
+    ascii_descriptor = text_artifact_descriptor(tmp_path / "ascii.txt", encoding="ascii")
+    utf8_descriptor = text_artifact_descriptor(tmp_path / "utf8.txt", encoding="utf-8")
+
+    writer = _implementation(_select(registry, ascii_descriptor, operation="write", interface="text"))
+    ascii_result = writer.write(ascii_descriptor, "plain ascii")
+    utf8_result = writer.write(utf8_descriptor, "hello 🙂")
+    reader = _implementation(_select(registry, utf8_result, operation="read", interface="text"))
+
+    assert (tmp_path / "ascii.txt").read_bytes() == b"plain ascii"
+    assert reader.read(ascii_result) == "plain ascii"
+    assert reader.read(utf8_result) == "hello 🙂"
+    assert has_facet(ascii_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+    assert has_facet(utf8_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+
+
+def test_delimited_table_reader_and_writer_examples_support_csv_and_options(
+    tmp_path: Path,
+) -> None:
+    """Delimited table capabilities should support CSV and alternate delimiters."""
+    registry = _registry()
+    csv_descriptor = delimited_table_artifact_descriptor(tmp_path / "table.csv")
+    pipe_descriptor = delimited_table_artifact_descriptor(tmp_path / "table.psv", delimiter="|")
+    rows = [{"station": "mhd", "value": "410.2"}, {"station": "tac", "value": "419.5"}]
+
+    writer = _implementation(_select(registry, csv_descriptor, operation="write", interface="table"))
+    csv_result = writer.write(csv_descriptor, rows)
+    pipe_result = writer.write(pipe_descriptor, rows, delimiter="|")
+    reader = _implementation(_select(registry, csv_result, operation="read", interface="table"))
+
+    assert reader.read(csv_result) == rows
+    assert reader.read(pipe_result) == rows
+    assert (tmp_path / "table.psv").read_text(encoding="utf-8").splitlines()[0] == "station|value"
+
+
+def test_json_reader_and_writer_examples_round_trip_documents(tmp_path: Path) -> None:
+    """JSON capabilities should use json.dump and json.load."""
+    registry = _registry()
+    descriptor = json_artifact_descriptor(tmp_path / "document.json")
+    document = {"name": "example", "values": [1, 2, 3], "unicode": "🙂"}
+
+    writer = _implementation(_select(registry, descriptor, operation="write", interface="json"))
+    result = writer.write(descriptor, document)
+    reader = _implementation(_select(registry, result, operation="read", interface="json"))
+
+    assert reader.read(result) == document
+    assert has_claim(result, kind="data_type", name="json", namespace="iana.media-types")
+
+
+def test_emoticon_to_emoji_converter_writes_utf8_selectable_text(tmp_path: Path) -> None:
+    """The converter should turn ASCII emoticons into UTF-8 emoji text metadata."""
+    registry = _registry()
+    source = text_artifact_descriptor(tmp_path / "source.txt", encoding="ascii")
+    source_path = source.locator.as_path() if source.locator is not None else None
+    assert source_path is not None
+    source_path.write_text("done :)", encoding="ascii")
+    output = temporary_text_artifact_descriptor(tmp_path / "output.txt")
+
+    converter = _implementation(_select(registry, source, operation="convert", interface="text"))
+    result = converter.convert(source, output)
+    reader = _implementation(_select(registry, result, operation="read", interface="text"))
+
+    assert (tmp_path / "output.txt").read_text(encoding="utf-8") == "done 🙂"
+    assert reader.read(result) == "done 🙂"
+    assert result.relationship["catalogued"] is False
+    assert result.relationship["generated_by"] == "ogcat.stdlib.emoticon_to_emoji"
+    assert has_claim(result, kind="interface", name="text")
+    assert has_facet(result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+
+
+def test_csv_artifact_can_be_selected_as_bytes_text_or_table(tmp_path: Path) -> None:
+    """One CSV descriptor should be readable through bytes, text, and table interfaces."""
+    path = tmp_path / "multi.csv"
+    path.write_text("name,value\nalpha,1\n", encoding="utf-8")
+    descriptor = delimited_table_artifact_descriptor(path)
+    registry = _registry()
+
+    bytes_reader = _implementation(_select(registry, descriptor, operation="read", interface="bytes"))
+    text_reader = _implementation(_select(registry, descriptor, operation="read", interface="text"))
+    table_reader = _implementation(_select(registry, descriptor, operation="read", interface="table"))
+
+    assert bytes_reader.read(descriptor) == b"name,value\nalpha,1\n"
+    assert text_reader.read(descriptor) == "name,value\nalpha,1\n"
+    assert table_reader.read(descriptor) == [{"name": "alpha", "value": "1"}]
+
+
+def test_temporary_artifact_descriptor_can_be_used_for_selection(tmp_path: Path) -> None:
+    """A non-catalog descriptor should still participate in registry selection."""
+    descriptor = temporary_text_artifact_descriptor(tmp_path / "scratch.txt")
+    registry = _registry()
+
+    selected = _select(registry, descriptor, operation="write", interface="text")
+    writer = _implementation(selected)
+    result = writer.write(descriptor, "scratch")
+
+    assert descriptor.relationship == {"catalogued": False, "temporary": True}
+    result_path = result.locator.as_path() if result.locator is not None else None
+    assert result_path is not None
+    assert result_path.read_text(encoding="utf-8") == "scratch"
+
+
+def test_stdlib_capabilities_register_through_plugin_registry(tmp_path: Path) -> None:
+    """Bundled examples should register like external plugin capabilities."""
+    plugins = register_stdlib_capabilities(PluginRegistry())
+    descriptor = text_artifact_descriptor(tmp_path / "plugin-text.txt")
+
+    selected = plugins.capability_registry().select(
+        kind="reader",
+        descriptor=descriptor,
+        input_claims=[InterfaceClaim("text")],
+    )
+
+    assert selected.name == "text-reader"
+    assert plugins.hooks == ()
+
+
+def _registry() -> Any:
+    """Return a registry populated with bundled stdlib capabilities."""
+    capability_module = pytest.importorskip("ogcat.capabilities")
+    return register_stdlib_capabilities(capability_module.CapabilityRegistry())
+
+
+def _select(
+    registry: Any,
+    descriptor: ArtifactDescriptor,
+    *,
+    operation: str,
+    interface: str,
+    name: str | None = None,
+) -> object:
+    """Select a capability across the small expected registry API variants."""
+    select = registry.select
+    capability_kind = {"read": "reader", "write": "writer", "convert": "converter"}[operation]
+    capability_name = name or {("write", "text"): "text-writer"}.get((operation, interface))
+    input_claims = [InterfaceClaim(interface)] if operation in {"read", "convert"} else []
+    output_claims = [InterfaceClaim(interface)] if operation in {"write", "convert"} else []
+    attempts = (
+        lambda: select(
+            kind=capability_kind,
+            name=capability_name,
+            descriptor=descriptor,
+            input_claims=input_claims,
+            output_claims=output_claims,
+        ),
+        lambda: select(kind=capability_kind, descriptor=descriptor),
+        lambda: select(descriptor, operation=operation, interface=interface),
+        lambda: select(descriptor, kind=capability_kind, interface=interface),
+        lambda: select(operation, descriptor, interface=interface),
+        lambda: select(operation=operation, descriptor=descriptor, interface=interface),
+    )
+    errors: list[Exception] = []
+    for attempt in attempts:
+        try:
+            selected = attempt()
+        except TypeError as exc:
+            errors.append(exc)
+            continue
+        if selected is not None:
+            return selected
+
+    find = getattr(registry, "find", None)
+    if find is not None:
+        for kwargs in (
+            {
+                "kind": capability_kind,
+                "name": capability_name,
+                "descriptor": descriptor,
+                "input_claims": input_claims,
+                "output_claims": output_claims,
+            },
+            {"kind": capability_kind, "descriptor": descriptor},
+            {"operation": operation, "interface": interface},
+            {"kind": capability_kind, "interface": interface},
+        ):
+            try:
+                matches = list(find(**kwargs))
+            except TypeError:
+                continue
+            if matches:
+                return matches[0]
+    raise AssertionError(f"no capability selected for {operation}/{interface}: {errors}")
+
+
+def _implementation(capability: object) -> Any:
+    """Return an opaque implementation object from a selected capability."""
+    return getattr(capability, "implementation", getattr(capability, "handler", capability))

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -70,9 +70,10 @@ def test_delimited_table_reader_and_writer_examples_support_csv_and_options(
     csv_result = writer.write(csv_descriptor, rows)
     pipe_result = writer.write(pipe_descriptor, rows, delimiter="|")
     reader = _implementation(_select(registry, csv_result, operation="read", interface="table"))
+    pipe_reader = _implementation(_select(registry, pipe_result, operation="read", interface="table"))
 
     assert reader.read(csv_result) == rows
-    assert reader.read(pipe_result) == rows
+    assert pipe_reader.read(pipe_result) == rows
     assert (tmp_path / "table.psv").read_text(encoding="utf-8").splitlines()[0] == "station|value"
 
 

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -15,7 +15,8 @@ from ogcat.bundled_plugins.stdlib_io import (
     temporary_text_artifact_descriptor,
     text_artifact_descriptor,
 )
-from ogcat.models import ArtifactDescriptor, ArtifactLocator, InterfaceClaim
+from ogcat.capabilities import MissingCapabilityError
+from ogcat.models import ArtifactDescriptor, ArtifactLocator, DataTypeClaim, InterfaceClaim
 from ogcat.plugins import PluginRegistry
 
 
@@ -98,7 +99,15 @@ def test_emoticon_to_emoji_converter_writes_utf8_selectable_text(tmp_path: Path)
     source_path.write_text("done :)", encoding="ascii")
     output = temporary_text_artifact_descriptor(tmp_path / "output.txt")
 
-    converter = _implementation(_select(registry, source, operation="convert", interface="text"))
+    converter = _implementation(
+        _select(
+            registry,
+            source,
+            operation="convert",
+            interface="text",
+            name="emoticon-to-emoji-text-converter",
+        )
+    )
     result = converter.convert(source, output)
     reader = _implementation(_select(registry, result, operation="read", interface="text"))
 
@@ -108,6 +117,69 @@ def test_emoticon_to_emoji_converter_writes_utf8_selectable_text(tmp_path: Path)
     assert result.relationship["generated_by"] == "ogcat.stdlib.emoticon_to_emoji"
     assert has_claim(result, kind="interface", name="text")
     assert has_facet(result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+
+
+def test_pig_latin_converter_writes_utf8_selectable_text(tmp_path: Path) -> None:
+    """The Pig Latin converter should produce normal selectable text output."""
+    registry = _registry()
+    source = text_artifact_descriptor(tmp_path / "plain.txt", encoding="utf-8")
+    source_path = source.locator.as_path() if source.locator is not None else None
+    assert source_path is not None
+    source_path.write_text("hello apple sky", encoding="utf-8")
+    output = temporary_text_artifact_descriptor(tmp_path / "pig.txt")
+
+    converter = _implementation(
+        _select(
+            registry,
+            source,
+            operation="convert",
+            interface="text",
+            name="pig-latin-text-converter",
+        )
+    )
+    result = converter.convert(source, output)
+    reader = _implementation(_select(registry, result, operation="read", interface="text"))
+
+    assert reader.read(result) == "ellohay appleway skyay"
+    assert result.relationship["generated_by"] == "ogcat.stdlib.pig_latin"
+    assert has_claim(result, kind="interface", name="text")
+    assert has_facet(result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+
+
+def test_pig_latin_can_filter_csv_text_but_not_claim_table_output(tmp_path: Path) -> None:
+    """CSV can be treated as text, but Pig Latin does not produce CSV/table output."""
+    registry = _registry()
+    source = delimited_table_artifact_descriptor(tmp_path / "input.csv")
+    source_path = source.locator.as_path() if source.locator is not None else None
+    assert source_path is not None
+    source_path.write_text("name,value\nhello,world\n", encoding="utf-8")
+    output = temporary_text_artifact_descriptor(tmp_path / "pig.csv.txt")
+
+    converter = _implementation(
+        _select(
+            registry,
+            source,
+            operation="convert",
+            interface="text",
+            name="pig-latin-text-converter",
+        )
+    )
+    result = converter.convert(source, output)
+    reader = _implementation(_select(registry, result, operation="read", interface="text"))
+
+    assert reader.read(result) == "amenay,aluevay\nellohay,orldway\n"
+    for unsupported_output in (
+        InterfaceClaim("table"),
+        DataTypeClaim("csv", namespace="iana.media-types"),
+    ):
+        with pytest.raises(MissingCapabilityError):
+            registry.select(
+                kind="converter",
+                name="pig-latin-text-converter",
+                descriptor=source,
+                input_claims=[InterfaceClaim("text")],
+                output_claims=[unsupported_output],
+            )
 
 
 def test_csv_artifact_can_be_selected_as_bytes_text_or_table(tmp_path: Path) -> None:

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -10,6 +10,8 @@ import pytest
 from ogcat.artifact_claims import has_claim, has_facet
 from ogcat.bundled_plugins.stdlib_io import (
     delimited_table_artifact_descriptor,
+    delimiter_from_descriptor,
+    encoding_from_descriptor,
     json_artifact_descriptor,
     register_stdlib_capabilities,
     stdlib_capabilities,
@@ -45,15 +47,19 @@ def test_text_reader_and_writer_examples_use_encoding_facets(tmp_path: Path) -> 
     registry = _registry()
     ascii_descriptor = text_artifact_descriptor(tmp_path / "ascii.txt", encoding="ascii")
     utf8_descriptor = text_artifact_descriptor(tmp_path / "utf8.txt", encoding="utf-8")
+    override_descriptor = text_artifact_descriptor(tmp_path / "override.txt", encoding="ascii")
 
     writer = _implementation(_select(registry, ascii_descriptor, operation="write", interface="text"))
     ascii_result = writer.write(ascii_descriptor, "plain ascii")
     utf8_result = writer.write(utf8_descriptor, "hello 🙂")
+    override_result = writer.write(override_descriptor, "hello 🙂", encoding="utf-8")
     reader = _implementation(_select(registry, utf8_result, operation="read", interface="text"))
 
     assert (tmp_path / "ascii.txt").read_bytes() == b"plain ascii"
     assert reader.read(ascii_result) == "plain ascii"
     assert reader.read(utf8_result) == "hello 🙂"
+    assert reader.read(override_result) == "hello 🙂"
+    assert encoding_from_descriptor(override_result) == "utf-8"
     assert has_facet(ascii_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
     assert has_facet(utf8_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
 
@@ -65,17 +71,50 @@ def test_delimited_table_reader_and_writer_examples_support_csv_and_options(
     registry = _registry()
     csv_descriptor = delimited_table_artifact_descriptor(tmp_path / "table.csv")
     pipe_descriptor = delimited_table_artifact_descriptor(tmp_path / "table.psv", delimiter="|")
+    override_descriptor = delimited_table_artifact_descriptor(tmp_path / "override.psv")
     rows = [{"station": "mhd", "value": "410.2"}, {"station": "tac", "value": "419.5"}]
 
     writer = _implementation(_select(registry, csv_descriptor, operation="write", interface="table"))
     csv_result = writer.write(csv_descriptor, rows)
     pipe_result = writer.write(pipe_descriptor, rows, delimiter="|")
+    override_result = writer.write(override_descriptor, rows, delimiter="|")
     reader = _implementation(_select(registry, csv_result, operation="read", interface="table"))
     pipe_reader = _implementation(_select(registry, pipe_result, operation="read", interface="table"))
+    override_reader = _implementation(_select(registry, override_result, operation="read", interface="table"))
 
     assert reader.read(csv_result) == rows
     assert pipe_reader.read(pipe_result) == rows
+    assert override_reader.read(override_result) == rows
+    assert delimiter_from_descriptor(override_result) == "|"
     assert (tmp_path / "table.psv").read_text(encoding="utf-8").splitlines()[0] == "station|value"
+
+
+def test_delimited_table_reader_rejects_extra_columns_and_normalizes_missing_values(
+    tmp_path: Path,
+) -> None:
+    """Delimited table rows should keep the advertised dict[str, str] shape."""
+    registry = _registry()
+    reader = _implementation(
+        _select(
+            registry,
+            delimited_table_artifact_descriptor(tmp_path / "valid.csv"),
+            operation="read",
+            interface="table",
+        )
+    )
+    missing_descriptor = delimited_table_artifact_descriptor(tmp_path / "missing.csv")
+    missing_path = missing_descriptor.locator.as_path() if missing_descriptor.locator is not None else None
+    assert missing_path is not None
+    missing_path.write_text("name,value\nalpha\n", encoding="utf-8")
+
+    extra_descriptor = delimited_table_artifact_descriptor(tmp_path / "extra.csv")
+    extra_path = extra_descriptor.locator.as_path() if extra_descriptor.locator is not None else None
+    assert extra_path is not None
+    extra_path.write_text("name,value\nalpha,1,unexpected\n", encoding="utf-8")
+
+    assert reader.read(missing_descriptor) == [{"name": "alpha", "value": ""}]
+    with pytest.raises(ValueError, match="more columns"):
+        reader.read(extra_descriptor)
 
 
 def test_json_reader_and_writer_examples_round_trip_documents(tmp_path: Path) -> None:

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -12,10 +12,11 @@ from ogcat.bundled_plugins.stdlib_io import (
     delimited_table_artifact_descriptor,
     json_artifact_descriptor,
     register_stdlib_capabilities,
+    stdlib_capabilities,
     temporary_text_artifact_descriptor,
     text_artifact_descriptor,
 )
-from ogcat.capabilities import MissingCapabilityError
+from ogcat.capabilities import ArtifactCapability, CapabilityKind, CapabilityRegistry, MissingCapabilityError
 from ogcat.models import ArtifactDescriptor, ArtifactLocator, DataTypeClaim, InterfaceClaim
 from ogcat.plugins import PluginRegistry
 
@@ -229,73 +230,73 @@ def test_stdlib_capabilities_register_through_plugin_registry(tmp_path: Path) ->
     assert plugins.hooks == ()
 
 
-def _registry() -> Any:
+def test_stdlib_capabilities_use_core_capability_model() -> None:
+    """Bundled capability examples should use the core capability model directly."""
+    capabilities = stdlib_capabilities()
+
+    assert all(isinstance(capability, ArtifactCapability) for capability in capabilities)
+    assert {capability.kind for capability in capabilities} == {
+        CapabilityKind.READER,
+        CapabilityKind.WRITER,
+        CapabilityKind.CONVERTER,
+    }
+    assert all(capability.namespace == "ogcat.stdlib" for capability in capabilities)
+
+
+def test_stdlib_registration_prefers_capability_method() -> None:
+    """Registration should call register_capability when a registry exposes it."""
+
+    class CapabilityOnlyRegistry:
+        """Minimal registry exposing only the capability registration method."""
+
+        def __init__(self) -> None:
+            self.capabilities: list[ArtifactCapability] = []
+
+        def register_capability(self, capability: ArtifactCapability) -> ArtifactCapability:
+            """Record the registered capability."""
+            self.capabilities.append(capability)
+            return capability
+
+    registry = CapabilityOnlyRegistry()
+
+    assert register_stdlib_capabilities(registry) is registry
+    assert {capability.name for capability in registry.capabilities} == {
+        capability.name for capability in stdlib_capabilities()
+    }
+
+
+def _registry() -> CapabilityRegistry:
     """Return a registry populated with bundled stdlib capabilities."""
-    capability_module = pytest.importorskip("ogcat.capabilities")
-    return register_stdlib_capabilities(capability_module.CapabilityRegistry())
+    return register_stdlib_capabilities(CapabilityRegistry())
 
 
 def _select(
-    registry: Any,
+    registry: CapabilityRegistry,
     descriptor: ArtifactDescriptor,
     *,
     operation: str,
     interface: str,
     name: str | None = None,
-) -> object:
-    """Select a capability across the small expected registry API variants."""
-    select = registry.select
-    capability_kind = {"read": "reader", "write": "writer", "convert": "converter"}[operation]
+) -> ArtifactCapability:
+    """Select a stdlib capability through the core registry API."""
+    capability_kind = {
+        "read": CapabilityKind.READER,
+        "write": CapabilityKind.WRITER,
+        "convert": CapabilityKind.CONVERTER,
+    }[operation]
     capability_name = name or {("write", "text"): "text-writer"}.get((operation, interface))
     input_claims = [InterfaceClaim(interface)] if operation in {"read", "convert"} else []
     output_claims = [InterfaceClaim(interface)] if operation in {"write", "convert"} else []
-    attempts = (
-        lambda: select(
-            kind=capability_kind,
-            name=capability_name,
-            descriptor=descriptor,
-            input_claims=input_claims,
-            output_claims=output_claims,
-        ),
-        lambda: select(kind=capability_kind, descriptor=descriptor),
-        lambda: select(descriptor, operation=operation, interface=interface),
-        lambda: select(descriptor, kind=capability_kind, interface=interface),
-        lambda: select(operation, descriptor, interface=interface),
-        lambda: select(operation=operation, descriptor=descriptor, interface=interface),
+    return registry.select(
+        kind=capability_kind,
+        name=capability_name,
+        descriptor=descriptor,
+        input_claims=input_claims,
+        output_claims=output_claims,
     )
-    errors: list[Exception] = []
-    for attempt in attempts:
-        try:
-            selected = attempt()
-        except TypeError as exc:
-            errors.append(exc)
-            continue
-        if selected is not None:
-            return selected
-
-    find = getattr(registry, "find", None)
-    if find is not None:
-        for kwargs in (
-            {
-                "kind": capability_kind,
-                "name": capability_name,
-                "descriptor": descriptor,
-                "input_claims": input_claims,
-                "output_claims": output_claims,
-            },
-            {"kind": capability_kind, "descriptor": descriptor},
-            {"operation": operation, "interface": interface},
-            {"kind": capability_kind, "interface": interface},
-        ):
-            try:
-                matches = list(find(**kwargs))
-            except TypeError:
-                continue
-            if matches:
-                return matches[0]
-    raise AssertionError(f"no capability selected for {operation}/{interface}: {errors}")
 
 
-def _implementation(capability: object) -> Any:
+def _implementation(capability: ArtifactCapability) -> Any:
     """Return an opaque implementation object from a selected capability."""
-    return getattr(capability, "implementation", getattr(capability, "handler", capability))
+    assert capability.implementation is not None
+    return capability.implementation

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -9,8 +9,10 @@ import pytest
 
 from ogcat.artifact_claims import has_claim, has_facet
 from ogcat.bundled_plugins.stdlib_io import (
+    bytes_artifact_descriptor,
     delimited_table_artifact_descriptor,
     delimiter_from_descriptor,
+    encoding_facet,
     encoding_from_descriptor,
     json_artifact_descriptor,
     register_stdlib_capabilities,
@@ -19,19 +21,14 @@ from ogcat.bundled_plugins.stdlib_io import (
     text_artifact_descriptor,
 )
 from ogcat.capabilities import ArtifactCapability, CapabilityKind, CapabilityRegistry, MissingCapabilityError
-from ogcat.models import ArtifactDescriptor, ArtifactLocator, DataTypeClaim, InterfaceClaim
+from ogcat.models import ArtifactDescriptor, ArtifactFacet, ArtifactLocator, DataTypeClaim, InterfaceClaim
 from ogcat.plugins import PluginRegistry
 
 
 def test_bytes_reader_and_writer_examples_round_trip_bytes(tmp_path: Path) -> None:
     """Bytes capabilities should use Path.read_bytes and Path.write_bytes."""
     path = tmp_path / "payload.bin"
-    descriptor = ArtifactDescriptor(
-        id="data",
-        role="data_artifact",
-        locator=ArtifactLocator.path(path),
-        claims=[InterfaceClaim("bytes")],
-    )
+    descriptor = bytes_artifact_descriptor(path)
     registry = _registry()
 
     writer = _implementation(_select(registry, descriptor, operation="write", interface="bytes"))
@@ -40,6 +37,7 @@ def test_bytes_reader_and_writer_examples_round_trip_bytes(tmp_path: Path) -> No
 
     assert path.read_bytes() == b"abc\x00def"
     assert reader.read(result) == b"abc\x00def"
+    assert has_facet(result, kind="locator", name="path", namespace="ogcat.stdlib")
 
 
 def test_text_reader_and_writer_examples_use_encoding_facets(tmp_path: Path) -> None:
@@ -60,6 +58,7 @@ def test_text_reader_and_writer_examples_use_encoding_facets(tmp_path: Path) -> 
     assert reader.read(utf8_result) == "hello 🙂"
     assert reader.read(override_result) == "hello 🙂"
     assert encoding_from_descriptor(override_result) == "utf-8"
+    assert has_facet(ascii_result, kind="locator", name="path", namespace="ogcat.stdlib")
     assert has_facet(ascii_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
     assert has_facet(utf8_result, kind="encoding", name="charset", namespace="ogcat.stdlib")
 
@@ -86,6 +85,7 @@ def test_delimited_table_reader_and_writer_examples_support_csv_and_options(
     assert pipe_reader.read(pipe_result) == rows
     assert override_reader.read(override_result) == rows
     assert delimiter_from_descriptor(override_result) == "|"
+    assert has_facet(csv_result, kind="locator", name="path", namespace="ogcat.stdlib")
     assert (tmp_path / "table.psv").read_text(encoding="utf-8").splitlines()[0] == "station|value"
 
 
@@ -239,6 +239,80 @@ def test_csv_artifact_can_be_selected_as_bytes_text_or_table(tmp_path: Path) -> 
     assert table_reader.read(descriptor) == [{"name": "alpha", "value": "1"}]
 
 
+def test_stdlib_runtime_helpers_ignore_same_name_facets_from_other_namespaces(tmp_path: Path) -> None:
+    """Runtime helpers should consume the same namespaced facets selection used."""
+    registry = _registry()
+    text_descriptor = text_artifact_descriptor(tmp_path / "utf8.txt", encoding="utf-8")
+    text_descriptor.facets = [
+        ArtifactFacet(
+            "encoding",
+            "charset",
+            namespace="example.plugin",
+            metadata={"encoding": "ascii"},
+        ),
+        *text_descriptor.facets,
+    ]
+    text_path = text_descriptor.locator.as_path() if text_descriptor.locator is not None else None
+    assert text_path is not None
+    text_path.write_text("hello 🙂", encoding="utf-8")
+
+    table_descriptor = delimited_table_artifact_descriptor(tmp_path / "table.csv", delimiter=",")
+    table_descriptor.facets = [
+        ArtifactFacet(
+            "format",
+            "delimited-text",
+            namespace="example.plugin",
+            metadata={"delimiter": "|"},
+        ),
+        *table_descriptor.facets,
+    ]
+    table_path = table_descriptor.locator.as_path() if table_descriptor.locator is not None else None
+    assert table_path is not None
+    table_path.write_text("name,value\nhello,world\n", encoding="utf-8")
+
+    text_reader = _implementation(_select(registry, text_descriptor, operation="read", interface="text"))
+    table_reader = _implementation(_select(registry, table_descriptor, operation="read", interface="table"))
+
+    assert encoding_from_descriptor(text_descriptor) == "utf-8"
+    assert delimiter_from_descriptor(table_descriptor) == ","
+    assert text_reader.read(text_descriptor) == "hello 🙂"
+    assert table_reader.read(table_descriptor) == [{"name": "hello", "value": "world"}]
+
+
+def test_non_path_descriptors_do_not_select_stdlib_path_backed_capabilities() -> None:
+    """Stdlib capabilities should fail selection when the path facet is absent."""
+    registry = _registry()
+    remote_text = ArtifactDescriptor(
+        id="remote-text",
+        role="data_artifact",
+        locator=ArtifactLocator.from_urlpath("s3://example/input.txt"),
+        claims=[InterfaceClaim("text")],
+        facets=[encoding_facet("utf-8")],
+    )
+    remote_output = ArtifactDescriptor(
+        id="remote-output",
+        role="derived_artifact",
+        locator=ArtifactLocator.from_urlpath("s3://example/output.txt"),
+        claims=[InterfaceClaim("text")],
+        facets=[encoding_facet("utf-8")],
+    )
+
+    with pytest.raises(MissingCapabilityError):
+        registry.select(
+            kind=CapabilityKind.READER,
+            descriptor=remote_text,
+            input_claims=[InterfaceClaim("text")],
+        )
+
+    with pytest.raises(MissingCapabilityError):
+        registry.select(
+            kind=CapabilityKind.WRITER,
+            name="text-writer",
+            descriptor=remote_output,
+            output_claims=[InterfaceClaim("text")],
+        )
+
+
 def test_temporary_artifact_descriptor_can_be_used_for_selection(tmp_path: Path) -> None:
     """A non-catalog descriptor should still participate in registry selection."""
     descriptor = temporary_text_artifact_descriptor(tmp_path / "scratch.txt")
@@ -317,7 +391,19 @@ def _select(
     interface: str,
     name: str | None = None,
 ) -> ArtifactCapability:
-    """Select a stdlib capability through the core registry API."""
+    """Select a stdlib capability through the core registry API.
+
+    Args:
+        registry: Registry populated with stdlib capabilities.
+        descriptor: Descriptor used as the source for reads/converts or the
+            desired output shape for writes.
+        operation: One of ``read``, ``write``, or ``convert``.
+        interface: Interface claim name requested for the operation.
+        name: Optional capability name used to disambiguate converters.
+
+    Returns:
+        Selected stdlib capability.
+    """
     capability_kind = {
         "read": CapabilityKind.READER,
         "write": CapabilityKind.WRITER,


### PR DESCRIPTION
## Summary
- Introduce a capability registry and capability-centric APIs for catalog/storage behavior
- Move stdlib I/O storage logic into bundled plugin support and update package exports accordingly
- Refresh ADR, design notes, and API docs to describe the new capability model
- Add and update tests covering capability registration and stdlib I/O capabilities

Closes #119 

## Testing
- Not run (not requested)