### PR TITLE
Implement descriptor-first writer results and refresh architecture docs

### DIFF
--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -13,14 +13,16 @@ fields, and metadata namespaces for user, derived, and naming metadata.
 `add_file()` handles managed local-file ingest. `add_reference()` records an
 existing locator. `add_collection()` records a directory-like logical dataset.
 `add_artifact()` exposes a lower-level operation path with storage plans and
-artifact writers.
+operation materializers.
 
 This works for the current local catalog model, but issue #108 asks for a more
 explicit domain model: `ogcat` should behave like a virtual artifact
 filesystem. Logical catalog objects should be separate from physical storage,
-and artifacts should expose typed access capabilities through readers, writers,
-and converters. The analogy is Unix-like design, not POSIX compatibility:
-dependency inversion through stable interfaces is the important lesson.
+and artifacts should expose typed access capabilities through readers, writer
+capabilities, and converters. The analogy is Unix-like design, not POSIX
+compatibility: artifacts should be openable catalog objects with durable
+descriptors, runtime handles, permissions, leases, locators, and pipe-like
+composition. They do not need to behave exactly like POSIX byte-stream files.
 
 The target model also needs to align with two external design references:
 
@@ -78,6 +80,12 @@ evolve during implementation.
   manifests, previews, logs, derived artifacts, replicas, cache copies, and
   archive copies.
 
+`ArtifactDescriptor`
+: Durable, file-descriptor-like catalog description of one artifact. It is the
+  object that readers, writer capabilities, converters, and operation
+  materializers select against or enrich. It is not the physical artifact
+  itself and it is not an opened runtime handle.
+
 `Locator`
 : Serializable description of where an artifact is or can be resolved. Locators
   may be path, urlpath, URI, opaque identifier, service endpoint, query, or a
@@ -116,13 +124,21 @@ evolve during implementation.
 : Capability that opens an artifact through a declared interface and returns a
   runtime handle or object.
 
-`Writer`
+`WriterCapability`
 : Capability that materializes runtime data, source handles, or operation inputs
   into artifacts and returns structured artifact result metadata.
 
 `Converter`
 : Capability that maps one runtime interface to another, optionally
   materializing a new artifact.
+
+`OperationMaterializer`
+: Operation-scoped adapter that prepares a target artifact, invokes a writer
+  capability or one-off write function, registers rollback, resolves produced
+  descriptor facts, and returns a structured materialization result for catalog
+  merge. This is the role historically served by ``ArtifactWriter`` in
+  ``ogcat.hooks`` and helpers in ``ogcat.writers``. It is distinct from a
+  registry writer capability.
 
 `Handle`
 : Runtime opened object for one artifact through one reader/interface. Handles
@@ -131,8 +147,9 @@ evolve during implementation.
 
 `Operation`
 : Execution envelope for typed pipelines. Operations coordinate reader,
-  writer, and converter invocation; authorization; lock/lease acquisition;
-  validation; staging; rollback; audit; and provenance.
+  writer-capability, converter, and operation-materializer invocation;
+  authorization; lock/lease acquisition; validation; staging; rollback; audit;
+  and provenance.
 
 ## Artifact Roles And Replication
 
@@ -202,23 +219,32 @@ logical collection artifact.
 
 ## Capability Registry And Pipelines
 
-Readers, writers, and converters form a typed pipes-and-filters architecture.
-The pipe is a runtime interface, not necessarily a byte stream.
+Readers, writer capabilities, and converters form a typed pipes-and-filters
+architecture. The pipe is a runtime interface or value, not necessarily a byte
+stream. Readers source values from artifact descriptors; converters are filters
+between runtime interfaces; operation materializers sink final values into
+planned target descriptors and return descriptor facts to merge.
 
 Example:
 
 ```text
 zip artifact
   -> Reader[archive-members]
-  -> Writer[managed directory + collection facets]
+  -> WriterCapability[managed directory + collection facets]
   -> Reader[xarray.Dataset]
   -> Converter[domain boundary-condition dataset]
-  -> Writer[Zarr store artifact]
+  -> WriterCapability[Zarr store artifact]
 ```
 
 Capabilities should be registered through a plugin-facing registry. Core can
 ship or vendor useful capabilities, but they should use the same registration
 route as external plugins.
+
+Following Intake's composition model, a selected reader plus zero or more
+converters can itself be treated as a reader/read plan for the requested output
+interface. Converters remain independent filter primitives, but user-facing
+read APIs should not force callers to manually assemble every converter step
+when the registry can select a compatible plan.
 
 Core responsibilities:
 
@@ -239,6 +265,14 @@ Plugin or optional-extra responsibilities:
   external storage integrations.
 - Domain validation and source-specific versioning rules.
 
+Terminology clarification for #117/#119: the registry owns writer capabilities;
+add/update operations own operation materializers. A materializer may wrap a
+registered writer capability, a converter chain ending in a writer capability,
+or a small one-off write function. It also owns operation concerns such as
+target preparation, rollback registration, audit details, and descriptor-result
+merge. A writer capability by itself only declares and implements typed output
+behavior.
+
 Implementation clarification for #119: the first capability registry slice is a
 registration and lookup layer only. Selection starts from explicit caller
 requests for input and output claims or interfaces and matches those requests
@@ -246,8 +280,8 @@ against `ArtifactDescriptor` claims and facets. It must not dispatch from
 `record_type`. If one artifact advertises several interfaces, such as bytes,
 text, table, and JSON, selection should report ambiguity until the caller asks
 for a specific enough interface. Public read-handle lifecycle APIs remain #118,
-and catalog merge of writer-produced artifact claims/facets is the #117
-writer-result boundary. That boundary is descriptor merge only: it does not
+and catalog merge of operation-materializer-produced artifact claims/facets is
+the #117 result boundary. That boundary is descriptor merge only: it does not
 define read handles, managed collection ergonomics, runtime pipe/value types, or
 durable provenance storage.
 Bundled examples such as bytes, text-with-encoding, CSV/table, JSON, and an
@@ -399,9 +433,9 @@ slices from #108:
 1. First-class artifact descriptor target model.
 2. Claim and facet schemas for data type, representation, interface, and
    evidence/confidence.
-3. Reader, writer, and converter capability registry.
+3. Reader, writer-capability, and converter capability registry.
 4. Managed collections as operation targets, including #109.
-5. Structured writer result model.
+5. Structured operation-materializer result model.
 6. Read-side handles and accessors.
 7. Intake plugin design spike.
 8. Migration and compatibility for one-locator catalogs.

--- a/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
+++ b/docs/adr/0002-virtual-artifact-filesystem-domain-model.md
@@ -246,7 +246,10 @@ against `ArtifactDescriptor` claims and facets. It must not dispatch from
 `record_type`. If one artifact advertises several interfaces, such as bytes,
 text, table, and JSON, selection should report ambiguity until the caller asks
 for a specific enough interface. Public read-handle lifecycle APIs remain #118,
-and catalog merge of writer-produced artifact claims/facets remains #117.
+and catalog merge of writer-produced artifact claims/facets is the #117
+writer-result boundary. That boundary is descriptor merge only: it does not
+define read handles, managed collection ergonomics, runtime pipe/value types, or
+durable provenance storage.
 Bundled examples such as bytes, text-with-encoding, CSV/table, JSON, and an
 emoticon-to-emoji converter should register through the same plugin-style route
 as external capabilities. Because the bundled implementations are local-path

--- a/docs/api/capabilities.rst
+++ b/docs/api/capabilities.rst
@@ -3,11 +3,11 @@ Capabilities
 
 .. module:: ogcat.capabilities
 
-The capability API is the public surface for #119 reader, writer, and converter
-registration and lookup. It is a registry layer: it records typed
+The capability API is the public surface for #119 reader, writer capability,
+and converter registration and lookup. It is a registry layer: it records typed
 declarations and returns matching declarations with optional opaque
-implementation objects. Public read handles, ``open_artifact()``, and catalog
-writer-result merge are separate follow-up APIs.
+implementation objects. Public read handles, ``open_artifact()``, and the
+catalog operation-materializer result merge are separate follow-up APIs.
 
 Registry
 --------

--- a/docs/api/capabilities.rst
+++ b/docs/api/capabilities.rst
@@ -6,8 +6,10 @@ Capabilities
 The capability API is the public surface for #119 reader, writer capability,
 and converter registration and lookup. It is a registry layer: it records typed
 declarations and returns matching declarations with optional opaque
-implementation objects. Public read handles, ``open_artifact()``, and the
-catalog operation-materializer result merge are separate follow-up APIs.
+implementation objects. Public read handles, ``open_artifact()``, and a full
+pipeline executor are separate follow-up APIs. Writer capabilities return
+``ArtifactWriteResult`` values; catalog operations merge those results through
+operation materializers.
 
 Registry
 --------

--- a/docs/api/hooks.rst
+++ b/docs/api/hooks.rst
@@ -22,6 +22,11 @@ registration, and source information.
    :member-order: bysource
    :exclude-members: kind, path, descriptor, metadata, payload
 
+.. autoclass:: ogcat.ArtifactWriteRequest
+   :members:
+   :member-order: bysource
+   :exclude-members: context, source, target, storage_plan
+
 .. autoclass:: ogcat.HookWarning
    :members:
    :member-order: bysource

--- a/docs/api/hooks.rst
+++ b/docs/api/hooks.rst
@@ -27,6 +27,11 @@ registration, and source information.
    :member-order: bysource
    :exclude-members: context, source, target, storage_plan
 
+.. autoclass:: ogcat.ArtifactMaterializer
+   :members:
+   :member-order: bysource
+   :no-index:
+
 .. autoclass:: ogcat.HookWarning
    :members:
    :member-order: bysource

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -19,6 +19,11 @@ Models and specifications
    :exclude-members: id, role, locator, state, relationship, claims, facets
    :member-order: bysource
 
+.. autoclass:: ogcat.ArtifactWriteResult
+   :members:
+   :exclude-members: artifacts, diagnostics, provenance
+   :member-order: bysource
+
 .. autoclass:: ogcat.ArtifactClaim
    :members:
    :exclude-members: kind, name, namespace, version, evidence, confidence, metadata

--- a/docs/api/writers-transactions.rst
+++ b/docs/api/writers-transactions.rst
@@ -9,11 +9,33 @@ Writer protocol
 
 Writer classes do not need to inherit from a concrete base class. They satisfy
 the structural :class:`ogcat.hooks.ArtifactWriter` protocol by providing a
-``write(context, source, target)`` method.
+``write(request)`` method. The request carries the operation context, source,
+planned target descriptor, and storage plan; the method returns an
+:class:`ogcat.ArtifactWriteResult` describing the artifact facts to merge into
+the catalog record.
 
 .. autoclass:: ogcat.hooks.ArtifactWriter
    :members:
    :member-order: bysource
+
+.. autoclass:: ogcat.ArtifactWriteRequest
+   :members:
+   :member-order: bysource
+   :exclude-members: context, source, target, storage_plan
+   :no-index:
+
+.. autoclass:: ogcat.ArtifactWriteResult
+   :members:
+   :member-order: bysource
+   :exclude-members: artifacts, diagnostics, provenance
+   :no-index:
+
+The operation runner creates a planned ``data`` artifact descriptor before
+calling the writer. Writer results may enrich that descriptor with claims,
+facets, relationship metadata, or state. If a writer returns only auxiliary
+artifact descriptors, the planned data descriptor is preserved. Diagnostics and
+provenance are normalized to JSON-compatible shapes and included only in the
+artifact-write audit event.
 
 Writer helpers
 --------------
@@ -42,8 +64,10 @@ Attributes
 
 .. py:attribute:: FunctionArtifactWriter.write_function
 
-   Callable that writes from an ``OperationSource`` to a target path and may
-   return ``MetadataDict`` derived metadata.
+   Callable that writes from an ``OperationSource`` to a target path. It may
+   return ``None``, ``MetadataDict`` derived metadata, an
+   ``ArtifactDescriptor``, or an ``ArtifactWriteResult``; the adapter converts
+   all supported return shapes into an ``ArtifactWriteResult``.
 
 .. py:attribute:: FunctionArtifactWriter.target_kind
 

--- a/docs/api/writers-transactions.rst
+++ b/docs/api/writers-transactions.rst
@@ -1,22 +1,27 @@
-Writers and transactions
-========================
+Materializers and transactions
+==============================
 
 .. automodule:: ogcat.writers
    :no-members:
 
-Writer protocol
----------------
+Operation materializer protocol
+-------------------------------
 
-Writer classes do not need to inherit from a concrete base class. They satisfy
-the structural :class:`ogcat.hooks.ArtifactWriter` protocol by providing a
+Materializer classes do not need to inherit from a concrete base class. They satisfy
+the structural :class:`ogcat.hooks.ArtifactMaterializer` protocol by providing a
 ``write(request)`` method. The request carries the operation context, source,
 planned target descriptor, and storage plan; the method returns an
 :class:`ogcat.ArtifactWriteResult` describing the artifact facts to merge into
 the catalog record.
 
+.. autoclass:: ogcat.hooks.ArtifactMaterializer
+   :members:
+   :member-order: bysource
+
 .. autoclass:: ogcat.hooks.ArtifactWriter
    :members:
    :member-order: bysource
+   :no-index:
 
 .. autoclass:: ogcat.ArtifactWriteRequest
    :members:
@@ -31,14 +36,18 @@ the catalog record.
    :no-index:
 
 The operation runner creates a planned ``data`` artifact descriptor before
-calling the writer. Writer results may enrich that descriptor with claims,
-facets, relationship metadata, or state. If a writer returns only auxiliary
-artifact descriptors, the planned data descriptor is preserved. Diagnostics and
-provenance are normalized to JSON-compatible shapes and included only in the
-artifact-write audit event.
+calling the materializer. Materializer results may enrich that descriptor with
+claims, facets, relationship metadata, or state. If a materializer returns only
+auxiliary artifact descriptors, the planned data descriptor is preserved.
+Diagnostics and provenance are normalized to JSON-compatible shapes and
+included only in the artifact-write audit event.
 
-Writer helpers
---------------
+Materializer helpers
+--------------------
+
+The helpers in ``ogcat.writers`` keep their historical names, but they are
+operation materializers. Registry writer capabilities live under
+``ogcat.capabilities`` and bundled plugin modules such as ``ogcat.bundled_plugins.stdlib_io``.
 
 .. autofunction:: ogcat.writers.memory_source
 

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -129,8 +129,8 @@ Current first-slice roles are ``data_artifact``, ``auxiliary_artifact``,
 Descriptor roles are stored as strings so future ADR or plugin-owned roles can
 be persisted before their lifecycle behavior exists.
 
-``claims`` describe artifact facts that future readers, writers, and converters
-can use for dispatch. Core recognizes the claim kinds ``data_type``,
+``claims`` describe artifact facts that future readers, writer capabilities,
+and converters can use for dispatch. Core recognizes the claim kinds ``data_type``,
 ``representation``, and ``interface``. The vocabulary of claim names remains
 open and namespaced. For example, one artifact can carry an ``interface`` claim
 named ``bytes`` in the ``ogcat.core`` namespace, a ``data_type`` claim named

--- a/docs/concepts/locators-and-storage.md
+++ b/docs/concepts/locators-and-storage.md
@@ -47,9 +47,9 @@ Use the three catalog add methods for different storage responsibilities:
   live under one collection root, such as a directory of monthly NetCDF files or
   a remote prefix. It records one artifact with collection classification
   metadata and does not scan, copy, move, or open member files.
-- ``Catalog.add_artifact(...)`` with a ``StoragePlan`` and an artifact writer is
-  for workflow outputs. ogcat plans and records the artifact, while the writer
-  performs the actual filesystem or storage operation.
+- ``Catalog.add_artifact(...)`` with a ``StoragePlan`` and an operation
+  materializer is for workflow outputs. ogcat plans and records the artifact,
+  while the materializer performs the actual filesystem or storage operation.
 
 ## Managed files
 
@@ -223,10 +223,10 @@ receives neither ``context.planned_locators`` nor ``context.storage_plan``.
 ``resolve_artifact_locator`` receives proposed locators in
 ``context.planned_locators`` and can return the locator that should be used for
 the artifact being added.  After that hook returns, ogcat builds the final
-``StoragePlan`` and exposes it to later hooks and artifact writers as
+``StoragePlan`` and exposes it to later hooks and operation materializers as
 ``context.storage_plan``.  The plan lets domain code materialise a generic
 artifact such as a directory of NetCDF files or a ``.zarr`` store while ogcat
-core only records the locator.  Artifact writers remain responsible for
+core only records the locator.  Operation materializers remain responsible for
 filesystem side effects and rollback registration.
 
 ## External references

--- a/docs/current-architecture-report.md
+++ b/docs/current-architecture-report.md
@@ -1,16 +1,26 @@
 # Current Architecture Report
 
-This report describes the architecture after the #84 refactor train through
-#92. It is a snapshot, not a claim that the structure is final. The main design
-direction is to keep `Catalog`, `CatalogRecordSet`, and the CLI as public
-presentation surfaces while moving orchestration, domain policy, and persistence
-behind clearer internal interfaces.
+This report contains dated architecture snapshots. Each snapshot records the
+state of the code at the time it was written; it is not a claim that the
+structure is final.
 
-The diagrams use GitHub-rendered Mermaid fences. This snapshot is excluded from
+The diagrams use GitHub-rendered Mermaid fences. This report is excluded from
 the Sphinx documentation build until the architecture and docs rendering setup
 are stable enough to publish diagrams in the generated docs site.
 
-## Layer Map
+## Snapshot 1: Post #84-#92 Refactor Train
+
+Date: historical snapshot after #84-#92, before the #117/#119 terminology
+cleanup.
+
+This historical snapshot describes the architecture after the #84 refactor
+train through #92. It predates the #117/#119 terminology cleanup around
+operation materializers, writer capabilities, and structured writer results.
+The main design direction was to keep `Catalog`, `CatalogRecordSet`, and the
+CLI as public presentation surfaces while moving orchestration, domain policy,
+and persistence behind clearer internal interfaces.
+
+### Layer Map
 
 ```mermaid
 flowchart TD
@@ -22,7 +32,7 @@ flowchart TD
   Hooks["HookManager / HookDispatcher"]
   UOW["UnitOfWork"]
   Planning["Storage planning / naming / classification"]
-  Materialization["Materialization targets / writers"]
+  Materialization["Materialization targets / materializers"]
   Secondaries["Secondary artifact operations"]
   Repository["CatalogRepository protocol"]
   TinyDB["TinyDbCatalogRepository"]
@@ -49,9 +59,9 @@ flowchart TD
 | Presentation/API | `Catalog`, `CatalogRecordSet`, CLI | Public Python and command-line workflows, argument coercion, user-facing compatibility |
 | Application/orchestration | `CatalogApplication`, `AddOperationRunner`, operation requests/services, hooks, unit of work | Operation sequencing, rollback boundaries, hook dispatch, audit coordination |
 | Domain/policy | naming, storage planning, materialization intent, classification, validation, replica planning, secondary artifacts | Catalog rules that are independent of the storage backend |
-| Data/infrastructure | repositories, TinyDB implementation, storage adapters, writers, audit sink | Persistence and filesystem or fsspec side effects |
+| Data/infrastructure | repositories, TinyDB implementation, storage adapters, materializers, audit sink | Persistence and filesystem or fsspec side effects |
 
-## Primary Add Flow
+### Primary Add Flow
 
 ```mermaid
 sequenceDiagram
@@ -61,7 +71,7 @@ sequenceDiagram
   participant Runner as AddOperationRunner
   participant Hooks
   participant Planner as Storage planner
-  participant Writer
+  participant Materializer
   participant Repo as Repository
   participant Secondary as Secondary artifacts
   participant Audit
@@ -73,7 +83,7 @@ sequenceDiagram
   Runner->>Hooks: before/after metadata validation
   Runner->>Planner: plan primary locator
   Runner->>Hooks: resolve locator
-  Runner->>Writer: write/copy/move if required
+  Runner->>Materializer: write/copy/move if required
   Runner->>Hooks: extract metadata
   Runner->>Repo: stage CatalogRecord
   Runner->>Secondary: materialize ordered follow-up artifacts
@@ -81,7 +91,164 @@ sequenceDiagram
   Runner->>Audit: operation events
 ```
 
-## CRC Cards
+## Snapshot 2: 2026-05-19 Managed Add File Artifact Flow
+
+Date: 2026-05-19
+
+This section is a focused snapshot of `Catalog.add_file()` after the artifact
+descriptor and `ArtifactWriteResult` work. It intentionally excludes hook
+behavior so the intrinsic data-add roles are visible. Hooks still run in the
+real `AddOperationRunner` lifecycle.
+
+### Process Diagram
+
+```mermaid
+flowchart TD
+  User["User calls Catalog.add_file()"]
+  Catalog["Catalog facade\nargument coercion, schema choice"]
+  App["CatalogApplication.add_file()\nmanaged-file request assembly"]
+  Primary["plan_primary_storage()\nUUID/template primary locator"]
+  Source["OperationSource\ncurrent source envelope"]
+  Intent["MaterializationIntent\nmaterializer + write_mode + target_kind"]
+  RunnerRequest["AddOperationRequest\nrecord inputs + factories"]
+  Runner["AddOperationRunner.run()\nlifecycle owner"]
+  StoragePlan["StoragePlan\nconcrete locator and write policy"]
+  TargetDescriptor["planned ArtifactDescriptor\nid=data, role=data_artifact"]
+  Request["ArtifactWriteRequest\naction context + source + target + storage_plan"]
+  Materializer["operation materializer\ncopy/move/write sink wrapper"]
+  Adapter["StorageAdapter\nlocal/fsspec path effects"]
+  Result["ArtifactWriteResult\nsink-produced descriptor facts"]
+  Merge["descriptor merge\nbase data + returned facts"]
+  Metadata["metadata collection\nclassification + file extractors"]
+  Record["CatalogRecord\nrecord metadata + artifacts"]
+  UOW["UnitOfWork\nstage, rollback, commit"]
+  Repo["CatalogRepository\nTinyDB persistence"]
+  Secondary["SecondaryArtifactOperation\ntemplate link, etc."]
+
+  User --> Catalog --> App
+  App --> Source
+  App --> Primary
+  App --> Intent
+  App --> RunnerRequest --> Runner
+  Runner --> Primary --> StoragePlan
+  Runner --> TargetDescriptor --> Request
+  Source --> Request
+  StoragePlan --> Request
+  Intent --> Materializer --> Adapter
+  Request --> Materializer --> Result --> Merge
+  Merge --> Record
+  Runner --> Metadata --> Record
+  Record --> UOW --> Repo
+  Runner --> Secondary --> UOW
+```
+
+### Intrinsic Stages And Current Owners
+
+| Intrinsic stage | Current code owner | Role in the problem |
+|-----------------|--------------------|---------------------|
+| User intent and API compatibility | `Catalog.add_file()` | Accept a familiar path-oriented call, resolve the source path, choose schema/templates, normalize options, and delegate. |
+| Operation request assembly | `CatalogApplication.add_file()` | Turn public arguments into a managed-file add command: source envelope, storage planning functions, materializer choice, metadata collector, secondary artifacts, and transaction ownership. |
+| Source description | `OperationSource` | Current operation source envelope. It carries path/payload/provenance fields. Its modern replacement should be a source `ArtifactDescriptor` plus selected reader/converter plan; see #127. |
+| Target placement planning | `plan_primary_storage()` and `PrimaryStoragePlanResult` | Decide UUID versus template primary location and compute locator/path metadata. |
+| Materialization intent | `MaterializationIntent` | Record which operation materializer will write, whether the target is file-like or directory-like, and whether this is copy/move/write/reference. |
+| Concrete storage plan | `StoragePlan` | Carry the canonical locator, target shape, write mode, ownership, adapter/profile, and path metadata used by the write. |
+| Planned artifact descriptor | `AddOperationRunner._write_artifact()` | Create the base `ArtifactDescriptor(id="data", role="data_artifact", locator=planned_locator)` before writing. |
+| Data movement / sink | `CopyArtifactWriter`, `MoveArtifactWriter`, directory variants, `FunctionArtifactWriter` | Operation materializers. They perform side effects, register rollback, and return `ArtifactWriteResult`. |
+| Storage side effects | `StorageAdapter`, `LocalStorageAdapter`, `FsspecStorageAdapter` | Implement concrete path/urlpath operations used by materializers. |
+| Sink-produced facts | `ArtifactWriteResult` | Transient result from a writer capability or operation materializer wrapper. It contains produced descriptors plus audit-only diagnostics/provenance. |
+| Descriptor merge | `AddOperationRunner._merge_materializer_artifacts()` | Single catalog merge path for the planned data descriptor plus returned claims, facets, relationship metadata, state, and auxiliary artifacts. |
+| Metadata tracking | `extract_derived_metadata()`, classification helpers, `CatalogRecord` | Track searchable record metadata and durable artifact descriptors. This is separate from runtime values. |
+| Record persistence and rollback | `UnitOfWork`, `CatalogRepository`, `TinyDbCatalogRepository` | Stage the record, register rollback deletion, commit or roll back side effects and persistence together as far as the local backend allows. |
+| Secondary artifacts | `TemplateLinkSecondaryArtifact` | Add view/link artifacts such as template-path symlinks after primary record staging. |
+
+### Class, Role, Collaborators
+
+| Class, function, or module | Role | Main collaborators |
+|----------------------------|------|--------------------|
+| `Catalog.add_file()` | Public facade for managed local-file ingest. | `CatalogApplication`, `RecordSchema`, metadata coercion helpers, transaction factory. |
+| `CatalogApplication` | Application layer for building add-operation commands. | `Catalog`, `plan_primary_storage`, materializers, `AddOperationRequest`, `TemplateLinkSecondaryArtifact`. |
+| `PrimaryStoragePlanningContext` | Input bundle for primary path planning. | `plan_primary_storage`, templates, source path, operation id, metadata. |
+| `PrimaryStoragePlanResult` | Planned primary locator and path metadata. | `CatalogApplication`, `MaterializationTarget`, `StoragePlan`. |
+| `MaterializationIntent` | Compact description of whether/how artifact bytes should be materialized. | Materializers, `StoragePlan`, `AddOperationRequest`. |
+| `MaterializationTarget` / `MaterializationPlan` | Adapter layer from primary planning result to `StoragePlan`. | `PrimaryStoragePlanResult`, `StoragePlan`, `plan_storage`. |
+| `StoragePlan` | Concrete write/reference plan. | Runner, materializers, storage adapters, audit. |
+| `OperationSource` | Current source envelope for operation materializers. | `ArtifactWriteRequest`, convenience source helpers, future source descriptor/read-plan replacement. |
+| `ArtifactWriteRequest` | Operation-facing input to a materializer. | `OperationContext`, `OperationSource`, planned `ArtifactDescriptor`, `StoragePlan`. |
+| `ArtifactDescriptor` | Durable descriptor for catalogued artifact facts. | `CatalogRecord`, capability registry, writer results, descriptor merge. |
+| `ArtifactWriteResult` | Transient writer result. | Writer capabilities, materializers, `AddOperationRunner` merge/audit path. |
+| `CopyArtifactWriter` / `MoveArtifactWriter` | File materializers for managed add-file copy/move. | `ArtifactWriteRequest`, `StorageAdapter`, rollback registrar, `ArtifactWriteResult`. |
+| `CopyDirectoryArtifactWriter` / `MoveDirectoryArtifactWriter` | Directory materializers for managed directory copy/move. | Local path storage, rollback registrar, `ArtifactWriteResult`. |
+| `AddOperationRequest` | Full runner input for one add operation. | `CatalogApplication`, `AddOperationRunner`, storage and locator factories. |
+| `_AddOperationPlan` | Runner-local state after validation/planning. | `OperationContext`, locator, `StoragePlan`, artifacts. |
+| `AddOperationRunner` | Lifecycle owner for add operations. | `OperationServices`, `UnitOfWork`, storage planning factories, materializers, repository, audit. |
+| `UnitOfWork` | Best-effort transaction and rollback coordinator. | Repository, materializers, secondary artifact operations. |
+| `CatalogRepository` / `TinyDbCatalogRepository` | Persistence boundary and TinyDB implementation. | `CatalogRecord`, search, `UnitOfWork`. |
+
+### Materialization And Adapters In The Descriptor Model
+
+Materialization is the bridge between planned descriptor facts and physical
+side effects. The runner creates the planned `data` descriptor before any write.
+The storage plan tells the materializer where and how that descriptor should be
+materialized. The materializer uses storage adapters to perform the side effect
+and returns an `ArtifactWriteResult` describing any facts learned while writing.
+The runner then merges those facts into the planned descriptor and persists the
+merged descriptor on the `CatalogRecord`.
+
+In the desired source/filter/sink model, materializers become operation wrappers
+around a sink writer capability:
+
+```text
+source ArtifactDescriptor
+  -> Reader runtime value
+  -> zero or more Converter runtime values
+  -> WriterCapability(target ArtifactDescriptor, final runtime value)
+  -> ArtifactWriteResult
+  -> AddOperationRunner descriptor merge
+```
+
+The current `writers.py` classes are still operation materializers, not
+registry writer capabilities. They own rollback and local storage effects for
+managed add operations. The stdlib IO plugin examples are closer to future
+capabilities: readers produce runtime values, converters transform runtime
+values, and writer capabilities return `ArtifactWriteResult`.
+
+### Complexity Review
+
+`ArtifactWriteResult` is not the main source of excess indirection. It
+separates post-write artifact facts from pre-write storage planning:
+
+- `StoragePlan` answers "where and how should this write happen?"
+- `ArtifactDescriptor` answers "what durable artifact facts should be stored?"
+- `ArtifactWriteResult` answers "what descriptor facts did the writer produce?"
+
+For simple copy/move materializers, `ArtifactWriteResult.from_artifact(request.target)`
+is mostly an envelope around the planned descriptor. That is acceptable because
+the same envelope also supports claims, facets, relationship metadata,
+auxiliary artifacts, diagnostics, and future writer-capability results.
+
+The more obvious duplication is the planning stack, now tracked in
+[#128](https://github.com/openghg/ogcat/issues/128):
+`PrimaryStoragePlanResult` -> `MaterializationTarget` -> `MaterializationPlan`
+-> `StoragePlan`. For the current single-primary-target add flow,
+`MaterializationTarget` and `MaterializationPlan` are largely forwarding
+adapters. A future simplification should make `StoragePlan` the single concrete
+planning object and keep only a small intent object for materializer/write-mode
+selection.
+
+### Refactoring Candidates
+
+1. Collapse `MaterializationTarget` and `MaterializationPlan` into direct
+   `StoragePlan` construction.
+2. Keep `MaterializationIntent` only if it remains the smallest useful object
+   for `materializer + target_kind + write_mode + ownership`.
+3. Replace `OperationSource.kind`, `source_kind`, and string-based source
+   guards with descriptor-based source/sink declarations tracked in #127.
+4. Introduce runtime value/interface declarations before adding a pipeline
+   helper, so in-memory values can be adapted between converters deliberately.
+5. Rename current operation "writers" toward materializers in future API/docs,
+   while retaining compatibility aliases until the replacement is clear.
+
+## Snapshot 1 Continued: CRC Cards And Responsibility Review
 
 | Class or module | Role | Collaborators |
 |-----------------|------|---------------|
@@ -101,16 +268,16 @@ sequenceDiagram
 | `SearchQuery` and search helpers | Backend-neutral search terms and in-memory matching semantics. | repository, `CatalogRecordSet`, CLI. |
 | Naming module | Template rendering, generated naming context, public versus internal template-field policy. | storage planning, template replicas, replica views. |
 | Storage planning | Primary locator policy for UUID, template, and user-provided targets. | naming, locators, storage roots, `StoragePlan`. |
-| Materialization module | Internal representation of how planned targets become write targets. | operation runner, storage plans, writers. |
-| Storage adapters | Local and fsspec-like target operations. | writers, storage planning, artifact locators. |
-| Writers | Copy, move, unzip, function, and memory/path writer helpers. | `ArtifactWriteRequest`, `ArtifactWriteResult`, descriptor models, storage helpers. |
+| Materialization module | Internal representation of how planned targets become write targets. | operation runner, storage plans, materializers. |
+| Storage adapters | Local and fsspec-like target operations. | materializers, storage planning, artifact locators. |
+| Operation materializer helpers | Copy, move, unzip, function, and memory/path materializer helpers. | `ArtifactWriteRequest`, `ArtifactWriteResult`, descriptor models, storage helpers. |
 | Classification | Cheap artifact and collection classification metadata. | `Catalog.add_collection`, record metadata, docs/examples. |
 | `SecondaryArtifactOperation` | Ordered post-record operations inside the add rollback boundary. | runner, `UnitOfWork`, `CatalogRecord`. |
 | `TemplateLinkSecondaryArtifact` / `template_replicas` | Required human-readable symlink for UUID primary managed files. | naming, transactions, replica link helpers, runner. |
 | `replicas` | Generated local symlink view planning and application for existing records. | `Catalog.plan_view`, `CatalogRecord`, replica context, link helpers. |
 | Audit sink and events | Structured operation logging and CLI failure correlation. | runner, `Catalog`, CLI, `UnitOfWork`. |
 
-## Data Model Sketch
+### Data Model Sketch
 
 ```mermaid
 classDiagram
@@ -150,9 +317,9 @@ classDiagram
   CatalogRepository --> CatalogRecord
 ```
 
-## Current Responsibility Hotspots
+### Current Responsibility Hotspots
 
-### `Catalog`
+#### `Catalog`
 
 `Catalog` has moved toward a facade, but it still has several reasons to
 change:
@@ -168,27 +335,27 @@ change:
 This is the largest single-responsibility concern. The direction is correct,
 but more extraction would make changes less risky.
 
-### `CatalogApplication`
+#### `CatalogApplication`
 
 `CatalogApplication` is the right kind of orchestration boundary, but it still
 depends on a concrete `Catalog` object and reaches through catalog helper
 methods. A smaller services protocol would better satisfy dependency inversion.
 
-### `OperationContext`
+#### `OperationContext`
 
-`OperationContext` is intentionally broad because hooks and writer requests need
-a shared mutable object. That makes it flexible, but phase-specific access is
-not expressed in the type system. Hook authors can see fields that may be
-invalid or not meaningful in the current phase.
+`OperationContext` is intentionally broad because hooks and materializer
+requests need a shared mutable object. That makes it flexible, but
+phase-specific access is not expressed in the type system. Hook authors can
+see fields that may be invalid or not meaningful in the current phase.
 
-### Storage Planning
+#### Storage Planning
 
 Storage planning is function-based and currently branches over UUID, template,
 URL-path, local-root, and user-provided placement. This is readable today, but
 new placement policies may make the module harder to change without strategy
 objects or a planner protocol.
 
-### Metadata And Naming
+#### Metadata And Naming
 
 User metadata, derived metadata, classification metadata, naming metadata, and
 top-level record fields are now distinct, but several modules still need to
@@ -196,7 +363,7 @@ know parts of the resolution policy. The #92 field policy helps by separating
 human-readable naming fields from internal identifiers, but naming remains a
 central domain rule that deserves careful tests.
 
-## SOLID Review
+### SOLID Review
 
 | Principle | Current state |
 |-----------|---------------|
@@ -206,7 +373,7 @@ central domain rule that deserves careful tests.
 | Interface segregation | Good for hook phase protocols and repository. Less strong for `OperationContext` and `CatalogApplication`, which expose broad collaborators. |
 | Dependency inversion | Repository is the strongest example. `CatalogApplication` depending on concrete `Catalog` is the main remaining inversion gap. |
 
-## Suggested Improvements
+### Suggested Improvements
 
 1. Split `Catalog` internals into smaller services:
    schema/spec service, metadata update service, audit adapter, and operation

--- a/docs/current-architecture-report.md
+++ b/docs/current-architecture-report.md
@@ -103,7 +103,7 @@ sequenceDiagram
 | Storage planning | Primary locator policy for UUID, template, and user-provided targets. | naming, locators, storage roots, `StoragePlan`. |
 | Materialization module | Internal representation of how planned targets become write targets. | operation runner, storage plans, writers. |
 | Storage adapters | Local and fsspec-like target operations. | writers, storage planning, artifact locators. |
-| Writers | Copy, move, unzip, function, and memory/path writer helpers. | `OperationContext`, `OperationSource`, `ArtifactLocator`, storage helpers. |
+| Writers | Copy, move, unzip, function, and memory/path writer helpers. | `ArtifactWriteRequest`, `ArtifactWriteResult`, descriptor models, storage helpers. |
 | Classification | Cheap artifact and collection classification metadata. | `Catalog.add_collection`, record metadata, docs/examples. |
 | `SecondaryArtifactOperation` | Ordered post-record operations inside the add rollback boundary. | runner, `UnitOfWork`, `CatalogRecord`. |
 | `TemplateLinkSecondaryArtifact` / `template_replicas` | Required human-readable symlink for UUID primary managed files. | naming, transactions, replica link helpers, runner. |
@@ -176,10 +176,10 @@ methods. A smaller services protocol would better satisfy dependency inversion.
 
 ### `OperationContext`
 
-`OperationContext` is intentionally broad because hooks and writers need a
-shared mutable object. That makes it flexible, but phase-specific access is not
-expressed in the type system. Hook authors can see fields that may be invalid
-or not meaningful in the current phase.
+`OperationContext` is intentionally broad because hooks and writer requests need
+a shared mutable object. That makes it flexible, but phase-specific access is
+not expressed in the type system. Hook authors can see fields that may be
+invalid or not meaningful in the current phase.
 
 ### Storage Planning
 

--- a/docs/current-architecture-report.md
+++ b/docs/current-architecture-report.md
@@ -90,12 +90,12 @@ sequenceDiagram
 | CLI (`cli.py`) | Command-line presentation layer: parse arguments, call `Catalog`, render tables and machine-readable output. | `Catalog`, `CatalogRecordSet`, `SearchQuery`, `RecordSchema`. |
 | `CatalogSpec` / `RecordSchema` | Self-describing catalog configuration and schema defaults stored in `catalog.json`. | `Catalog`, validation, CLI. |
 | `CatalogRecord` / `ArtifactLocator` | Persisted record model and locator abstraction. Keeps compatibility path fields while the locator model becomes primary. | repository, storage planning, search, record sets, validation. |
-| `CatalogApplication` | Internal application service that turns public add requests into runner requests, chooses copy/move writers, and schedules secondary artifacts. | `Catalog`, `AddOperationRunner`, storage planning, writers, `TemplateLinkSecondaryArtifact`. |
-| `AddOperationRunner` | Lifecycle coordinator for add operations: validation, hooks, storage planning, writing, record staging, secondary artifacts, commit, rollback, audit. | `AddOperationRequest`, `OperationServices`, `HookDispatcher`, `UnitOfWork`, writers, repository, audit sink. |
+| `CatalogApplication` | Internal application service that turns public add requests into runner requests, chooses copy/move materializers, and schedules secondary artifacts. | `Catalog`, `AddOperationRunner`, storage planning, materializers, `TemplateLinkSecondaryArtifact`. |
+| `AddOperationRunner` | Lifecycle coordinator for add operations: validation, hooks, storage planning, materializing, record staging, secondary artifacts, commit, rollback, audit. | `AddOperationRequest`, `OperationServices`, `HookDispatcher`, `UnitOfWork`, materializers, repository, audit sink. |
 | `OperationServices` | Bundle of runner dependencies and callbacks. | `Catalog`, hooks, repository, validation, audit. |
-| `OperationContext` | Mutable operation-scoped context shared with hooks and writers. | hooks, writers, runner, storage plans, rollback registrar. |
+| `OperationContext` | Mutable operation-scoped context shared with hooks and materializers. | hooks, materializers, runner, storage plans, rollback registrar. |
 | Hook protocols / `HookDispatcher` | Structural plugin extension points for lifecycle phases. | `OperationContext`, `ValidationReport`, `HookManager`, runner. |
-| `UnitOfWork` | Best-effort rollback coordinator for staged record writes and side-effect cleanup. | repository, writers, secondary artifacts, hooks. |
+| `UnitOfWork` | Best-effort rollback coordinator for staged record writes and side-effect cleanup. | repository, materializers, secondary artifacts, hooks. |
 | `CatalogRepository` | Backend protocol for record persistence and search. | `Catalog`, runner, `TinyDbCatalogRepository`, `CatalogRecord`. |
 | `TinyDbCatalogRepository` | Current TinyDB-backed repository implementation. | TinyDB, search predicates, `CatalogRecord`. |
 | `SearchQuery` and search helpers | Backend-neutral search terms and in-memory matching semantics. | repository, `CatalogRecordSet`, CLI. |
@@ -201,8 +201,8 @@ central domain rule that deserves careful tests.
 | Principle | Current state |
 |-----------|---------------|
 | Single responsibility | Improving. `AddOperationRunner`, storage planning, secondary artifacts, and repository are now clearer. `Catalog` and `OperationContext` remain broad. |
-| Open/closed | Mixed. Hook protocols, writer protocols, repository protocol, and storage adapters support extension. Storage placement still uses branching in functions. |
-| Liskov substitution | Good where protocols are explicit: repository, hooks, writers, secondary artifact operations. Concrete code should keep depending on those protocols where possible. |
+| Open/closed | Mixed. Hook protocols, materializer protocols, repository protocol, and storage adapters support extension. Storage placement still uses branching in functions. |
+| Liskov substitution | Good where protocols are explicit: repository, hooks, materializers, secondary artifact operations. Concrete code should keep depending on those protocols where possible. |
 | Interface segregation | Good for hook phase protocols and repository. Less strong for `OperationContext` and `CatalogApplication`, which expose broad collaborators. |
 | Dependency inversion | Repository is the strongest example. `CatalogApplication` depending on concrete `Catalog` is the main remaining inversion gap. |
 

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -328,14 +328,18 @@ It does not define read handles, ``open_artifact()``, managed collection
 ergonomics, runtime pipe types such as ``str`` or ``xarray.Dataset``, or a
 pipeline value-adapter layer.
 
-Current ``source_kind`` and ``target_kind`` values are legacy operation helper
-shortcuts, not the future dispatch vocabulary. Source identity should migrate
-toward descriptors with claims/facets: for example, ``zip_file`` maps to
+Current ``source_kind`` and ``target_kind`` values are operation helper
+shortcuts, not the future dispatch vocabulary. Follow-up issue
+[#127](https://github.com/openghg/ogcat/issues/127) tracks replacing them with
+descriptor-based source/sink declarations. Source identity should migrate toward
+descriptors with claims/facets: for example, ``zip_file`` maps to
 ``data_type=zip`` plus archive-member interface/facets, text input maps to
 ``interface=text`` plus encoding facets, and local-file input maps to a path
-locator facet plus an appropriate representation claim. ``target_kind`` only
-describes storage shape: ``file`` maps to ``representation=file`` and
-``directory`` maps to ``representation=directory``. Collection-ness belongs in
+locator facet plus an appropriate representation claim. In-memory sources need
+runtime value/interface declarations so a future pipe/read-plan helper can
+adapt values between converters. ``target_kind`` only describes storage shape:
+``file`` maps to ``representation=file`` and ``directory`` maps to
+``representation=directory``. Collection-ness belongs in
 ``interface=collection`` and collection facets, not in ``target_kind``.
 
 ## Relationship To Classification Metadata

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -285,8 +285,8 @@ PR #122 clarified an important ADR distinction. Directory-backed artifacts are
 not automatically collections. A managed ``.zarr`` directory added with
 ``add_file()`` is one dataset artifact whose representation is ``directory``.
 A managed directory of monthly ``.nc`` files is a collection only when a caller,
-writer, or plugin explicitly adds collection claims/facets such as member
-pattern, member format, and member suffixes.
+operation materializer, or plugin explicitly adds collection claims/facets such
+as member pattern, member format, and member suffixes.
 
 This keeps storage shape separate from logical dataset shape:
 
@@ -298,29 +298,29 @@ This keeps storage shape separate from logical dataset shape:
 - collection facets say which members participate and how a reader should
   combine them.
 
-## Writer-Produced Facts
+## Materializer-Produced Facts
 
-Writers are the natural source of produced artifact claims/facets because they
-know what they materialized. Issue #117 adds the merge path: descriptor-first
-writer classes receive an ``ArtifactWriteRequest`` and return an
-``ArtifactWriteResult``. The operation runner builds a planned ``data``
-descriptor first, calls the writer, and merges returned descriptor facts before
-staging the catalog record.
+Operation materializers are the natural source of produced artifact
+claims/facets because they know what they materialized. Issue #117 adds the
+merge path: descriptor-first materializer classes receive an
+``ArtifactWriteRequest`` and return an ``ArtifactWriteResult``. The operation
+runner builds a planned ``data`` descriptor first, calls the materializer, and
+merges returned descriptor facts before staging the catalog record.
 
 The planned data descriptor has id ``data``, role ``data_artifact``, the planned
 locator, and state ``available``. A returned data descriptor may omit the
-locator; if it supplies one, it must equal the planned locator. A writer result
-may also return auxiliary descriptors such as previews, manifests, or logs. If
-the result has only auxiliary descriptors, the planned data descriptor is kept.
-Duplicate artifact ids fail before commit, and only the ``data`` descriptor may
-use role ``data_artifact``.
+locator; if it supplies one, it must equal the planned locator. A materializer
+result may also return auxiliary descriptors such as previews, manifests, or
+logs. If the result has only auxiliary descriptors, the planned data descriptor
+is kept. Duplicate artifact ids fail before commit, and only the ``data``
+descriptor may use role ``data_artifact``.
 
 Claims and facets merge by their envelope key:
-``(namespace, kind, name, version)``. Later writer-produced facts replace
+``(namespace, kind, name, version)``. Later materializer-produced facts replace
 earlier facts with the same envelope deterministically. Relationship metadata
-merges shallowly with writer-result keys winning. Result diagnostics and
-provenance are normalized to JSON-compatible metadata and copied only into the
-artifact-write audit event; durable/queryable provenance remains out of scope.
+merges shallowly with result keys winning. Result diagnostics and provenance are
+normalized to JSON-compatible metadata and copied only into the artifact-write
+audit event; durable/queryable provenance remains out of scope.
 
 This result model describes persisted artifact facts and catalog merge behavior.
 It does not define read handles, ``open_artifact()``, managed collection

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -298,14 +298,34 @@ This keeps storage shape separate from logical dataset shape:
 - collection facets say which members participate and how a reader should
   combine them.
 
-## Writer Result Open Loop
+## Writer-Produced Facts
 
 Writers are the natural source of produced artifact claims/facets because they
-know what they materialized. This branch defines the schema, but it does not
-define the merge path from writer output into descriptors. Issue #117 should
-define that path, preserve existing ``None``-returning writers, and decide how
-writer results interact with ``OperationContext``, rollback, storage plans,
-audit metadata, and derived classification metadata.
+know what they materialized. Issue #117 adds the merge path: descriptor-first
+writer classes receive an ``ArtifactWriteRequest`` and return an
+``ArtifactWriteResult``. The operation runner builds a planned ``data``
+descriptor first, calls the writer, and merges returned descriptor facts before
+staging the catalog record.
+
+The planned data descriptor has id ``data``, role ``data_artifact``, the planned
+locator, and state ``available``. A returned data descriptor may omit the
+locator; if it supplies one, it must equal the planned locator. A writer result
+may also return auxiliary descriptors such as previews, manifests, or logs. If
+the result has only auxiliary descriptors, the planned data descriptor is kept.
+Duplicate artifact ids fail before commit, and only the ``data`` descriptor may
+use role ``data_artifact``.
+
+Claims and facets merge by their envelope key:
+``(namespace, kind, name, version)``. Later writer-produced facts replace
+earlier facts with the same envelope deterministically. Relationship metadata
+merges shallowly with writer-result keys winning. Result diagnostics and
+provenance are normalized to JSON-compatible metadata and copied only into the
+artifact-write audit event; durable/queryable provenance remains out of scope.
+
+This result model describes persisted artifact facts and catalog merge behavior.
+It does not define read handles, ``open_artifact()``, managed collection
+ergonomics, runtime pipe types such as ``str`` or ``xarray.Dataset``, or a
+pipeline value-adapter layer.
 
 ## Relationship To Classification Metadata
 

--- a/docs/design-note-artifact-claims-and-facets.md
+++ b/docs/design-note-artifact-claims-and-facets.md
@@ -298,14 +298,15 @@ This keeps storage shape separate from logical dataset shape:
 - collection facets say which members participate and how a reader should
   combine them.
 
-## Materializer-Produced Facts
+## Writer-Produced Facts
 
-Operation materializers are the natural source of produced artifact
-claims/facets because they know what they materialized. Issue #117 adds the
-merge path: descriptor-first materializer classes receive an
-``ArtifactWriteRequest`` and return an ``ArtifactWriteResult``. The operation
-runner builds a planned ``data`` descriptor first, calls the materializer, and
-merges returned descriptor facts before staging the catalog record.
+Writer capabilities are the natural source of produced artifact claims/facets
+because they know what they materialized. Issue #117 adds the merge path:
+writer capabilities return an ``ArtifactWriteResult`` and operation
+materializers wrap those capabilities or one-off functions inside the catalog
+operation lifecycle. The operation runner builds a planned ``data`` descriptor
+first, calls the materializer, and merges returned descriptor facts before
+staging the catalog record.
 
 The planned data descriptor has id ``data``, role ``data_artifact``, the planned
 locator, and state ``available``. A returned data descriptor may omit the
@@ -316,7 +317,7 @@ is kept. Duplicate artifact ids fail before commit, and only the ``data``
 descriptor may use role ``data_artifact``.
 
 Claims and facets merge by their envelope key:
-``(namespace, kind, name, version)``. Later materializer-produced facts replace
+``(namespace, kind, name, version)``. Later writer-produced facts replace
 earlier facts with the same envelope deterministically. Relationship metadata
 merges shallowly with result keys winning. Result diagnostics and provenance are
 normalized to JSON-compatible metadata and copied only into the artifact-write
@@ -326,6 +327,16 @@ This result model describes persisted artifact facts and catalog merge behavior.
 It does not define read handles, ``open_artifact()``, managed collection
 ergonomics, runtime pipe types such as ``str`` or ``xarray.Dataset``, or a
 pipeline value-adapter layer.
+
+Current ``source_kind`` and ``target_kind`` values are legacy operation helper
+shortcuts, not the future dispatch vocabulary. Source identity should migrate
+toward descriptors with claims/facets: for example, ``zip_file`` maps to
+``data_type=zip`` plus archive-member interface/facets, text input maps to
+``interface=text`` plus encoding facets, and local-file input maps to a path
+locator facet plus an appropriate representation claim. ``target_kind`` only
+describes storage shape: ``file`` maps to ``representation=file`` and
+``directory`` maps to ``representation=directory``. Collection-ness belongs in
+``interface=collection`` and collection facets, not in ``target_kind``.
 
 ## Relationship To Classification Metadata
 

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -99,13 +99,14 @@ version, evidence, confidence, and metadata are filled with defaults when the
 shape is otherwise clear. Older facet payloads with extra top-level fields have
 those fields folded into ``metadata``.
 
-## Materializer Result Merge
+## Writer Result Merge
 
-Operation materializers can produce descriptor facts through
-``ArtifactWriteResult``. The add-operation runner owns the single merge path: it
-prepares a planned ``data`` descriptor with the target locator, invokes
-``materializer.write(request)``, and stages the merged descriptor list with the
-record.
+Writer capabilities produce descriptor facts through ``ArtifactWriteResult``.
+Operation materializers are operation-scoped wrappers that prepare a planned
+``data`` descriptor with the target locator, invoke a writer capability or
+one-off function, register rollback, and return the result to the add-operation
+runner. The runner owns the single merge path and stages the merged descriptor
+list with the record.
 
 Returned data descriptors enrich the planned data descriptor. They may omit the
 locator; if present, it must match the planned locator. Returned claims and
@@ -124,10 +125,10 @@ leadership remains deferred to later `leader` or `write_leader` fields instead
 of overloading `primary`.
 
 `claims` and `facets` are schema and validation metadata only in this slice.
-This change does not implement reader/open behavior, the reader/writer/converter
-registry, replicas, cache/archive policy, mount resolution, permissions, locks,
-or Intake integration. ``ArtifactWriteResult`` diagnostics and provenance are
-audit-only operation details, not durable/queryable provenance.
+This change does not implement reader/open behavior, full pipeline execution,
+replicas, cache/archive policy, mount resolution, permissions, locks, or Intake
+integration. ``ArtifactWriteResult`` diagnostics and provenance are audit-only
+operation details, not durable/queryable provenance.
 
 `derived_metadata.classification` remains the current home for cheap inferred
 classification fields such as `artifact_kind`, `format`, `archive_format`,

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -99,12 +99,13 @@ version, evidence, confidence, and metadata are filled with defaults when the
 shape is otherwise clear. Older facet payloads with extra top-level fields have
 those fields folded into ``metadata``.
 
-## Writer Result Merge
+## Materializer Result Merge
 
-Artifact writers can produce descriptor facts through ``ArtifactWriteResult``.
-The add-operation runner owns the single merge path: it prepares a planned
-``data`` descriptor with the target locator, invokes ``writer.write(request)``,
-and stages the merged descriptor list with the record.
+Operation materializers can produce descriptor facts through
+``ArtifactWriteResult``. The add-operation runner owns the single merge path: it
+prepares a planned ``data`` descriptor with the target locator, invokes
+``materializer.write(request)``, and stages the merged descriptor list with the
+record.
 
 Returned data descriptors enrich the planned data descriptor. They may omit the
 locator; if present, it must match the planned locator. Returned claims and

--- a/docs/design-note-artifact-descriptors.md
+++ b/docs/design-note-artifact-descriptors.md
@@ -99,6 +99,21 @@ version, evidence, confidence, and metadata are filled with defaults when the
 shape is otherwise clear. Older facet payloads with extra top-level fields have
 those fields folded into ``metadata``.
 
+## Writer Result Merge
+
+Artifact writers can produce descriptor facts through ``ArtifactWriteResult``.
+The add-operation runner owns the single merge path: it prepares a planned
+``data`` descriptor with the target locator, invokes ``writer.write(request)``,
+and stages the merged descriptor list with the record.
+
+Returned data descriptors enrich the planned data descriptor. They may omit the
+locator; if present, it must match the planned locator. Returned claims and
+facets are keyed by ``(namespace, kind, name, version)`` and later returned
+facts replace earlier facts with the same key. Relationship metadata is merged
+shallowly with result keys winning. Auxiliary descriptors append, but duplicate
+artifact ids and non-``data`` descriptors with role ``data_artifact`` fail
+before commit.
+
 ## Current Limits
 
 `record_type` remains schema and search metadata. It is not an I/O dispatch key.
@@ -110,7 +125,8 @@ of overloading `primary`.
 `claims` and `facets` are schema and validation metadata only in this slice.
 This change does not implement reader/open behavior, the reader/writer/converter
 registry, replicas, cache/archive policy, mount resolution, permissions, locks,
-or Intake integration.
+or Intake integration. ``ArtifactWriteResult`` diagnostics and provenance are
+audit-only operation details, not durable/queryable provenance.
 
 `derived_metadata.classification` remains the current home for cheap inferred
 classification fields such as `artifact_kind`, `format`, `archive_format`,

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -178,8 +178,9 @@ source descriptor, selects or calls a table-to-JSON converter, and then passes
 the converter's runtime JSON document to a JSON writer capability. The writer
 returns an `ArtifactWriteResult`; an add/update operation materializer would
 wrap that result with rollback and pass it to the operation runner for catalog
-merge. In a later pipeline executor, the same composition should be selected
-as:
+merge. Issue [#108](https://github.com/openghg/ogcat/issues/108) tracks the
+larger pipeline/read-plan design. In a later pipeline executor, the same
+composition should be selected as:
 
 ```text
 Descriptor[interface=table, data_type=csv]

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -9,12 +9,13 @@ The scope is deliberately narrow:
 - define how capabilities are declared, registered, and selected;
 - dispatch by `ArtifactDescriptor` claims and facets, not by `record_type`;
 - explain how bundled and external plugins use the same route;
-- preserve room for future typed reader handles and operation-materializer
-  result merging.
+- preserve room for future typed reader handles, converter plans, and operation
+  merge of writer-capability results.
 
 This slice does not define the public `open_artifact()` API, read-handle
-lifecycle, shell-like pipeline syntax, or catalog merge of writer-returned
-artifact descriptors. Those remain separate work items.
+lifecycle, shell-like pipeline syntax, or a complete operation pipeline
+executor. Catalog merge of writer-returned artifact descriptors is #117's
+result boundary.
 
 ## Core Idea
 
@@ -36,10 +37,12 @@ slice does not make core invoke it implicitly.
 
 Terminology matters: a registry writer capability is not the same thing as the
 operation-scoped `ArtifactWriter`/materializer helpers in `ogcat.writers`.
-Writer capabilities declare typed I/O behavior. Operation materializers prepare
-the target descriptor, invoke a capability or one-off function, register
-rollback, collect produced descriptor facts, and hand those facts to the
-operation runner for merge.
+Writer capabilities are sinks: they accept a runtime value, source handle, or
+operation input plus a target `ArtifactDescriptor`, materialize the output, and
+return an `ArtifactWriteResult`. Operation materializers are wrappers around
+those sinks or one-off functions. They prepare the target descriptor, invoke the
+capability, register rollback, collect produced descriptor facts, and hand the
+result to the operation runner for merge.
 
 ## Declaration Shape
 
@@ -169,6 +172,23 @@ the artifact lacks required claims/facets, or the request needs a more exact
 interface. Malformed lookup filters should raise a lookup-domain validation
 error rather than leaking raw schema normalization exceptions.
 
+A conversion from CSV to JSON illustrates the executable shape without
+requiring a full pipeline runtime. The caller selects a table reader for the
+source descriptor, selects or calls a table-to-JSON converter, and then passes
+the converter's runtime JSON document to a JSON writer capability. The writer
+returns an `ArtifactWriteResult`; an add/update operation materializer would
+wrap that result with rollback and pass it to the operation runner for catalog
+merge. In a later pipeline executor, the same composition should be selected
+as:
+
+```text
+Descriptor[interface=table, data_type=csv]
+  -> Reader[table rows]
+  -> Converter[json document]
+  -> WriterCapability[interface=json, representation=text]
+  -> ArtifactWriteResult
+```
+
 ## Dispatch Inputs
 
 Dispatch uses `ArtifactDescriptor` facts:
@@ -229,16 +249,19 @@ Useful examples:
   Unicode emoji;
 - a Pig Latin text converter that shows CSV-like descriptors can be routed as
   text when text input and text output are requested, but the same converter
-  must not be selected when the requested output is CSV or a table.
+  must not be selected when the requested output is CSV or a table;
+- a delimited-table-to-JSON converter that demonstrates reader/filter/writer
+  composition with `ArtifactWriteResult` as the writer-capability result.
 
 These examples are meant to exercise the registry design. They must not bend
 core matching rules to make toy examples pass, and they must not introduce
 optional scientific dependencies. NetCDF, HDF5, Zarr, xarray, pandas, Intake,
 and OpenGHG-specific behavior remain optional plugin territory.
-The bundled converter implementations call the bundled text reader and writer
-directly only to keep this slice executable without the future handle API. That
-is useful as a plugin-style pressure test, but it is not the intended long-term
-pipeline executor.
+The bundled converter implementations operate only on runtime values. Tests and
+examples manually connect bundled readers, converters, and writers to keep this
+slice executable without the future handle API. That is useful as a
+plugin-style pressure test, but it is not the intended long-term pipeline
+executor.
 
 The long-term executor should make composition explicit. A reader selected with
 zero or more converters can be exposed as a reader/read plan for a requested
@@ -267,8 +290,8 @@ scope:
   that is not catalogued;
 - allow the registry to store and return runtime implementation objects, but do
   not make core invoke them implicitly;
-- keep reader handle APIs for #118 and catalog materializer-result merge for
-  #117.
+- keep reader handle APIs for #118 and catalog merge of writer-capability
+  results for #117.
 
 ## Deferred
 
@@ -278,7 +301,7 @@ This note intentionally leaves several choices to implementation:
 - trust and authentication policy for third-party plugin declarations;
 - how `PluginRegistry` exposes capability contribution methods;
 - the read-handle API that consumes selected reader implementations;
-- the operation-materializer result model that persists produced claims/facets;
+- richer writer-capability result provenance beyond #117's audit-only details;
 - optional integration with Intake pipelines or other external registries.
 - a converter orchestration layer that passes opened handles or runtime values
   between readers, filters, and writer capabilities so chained conversions do

--- a/docs/design-note-capability-registry.md
+++ b/docs/design-note-capability-registry.md
@@ -9,7 +9,8 @@ The scope is deliberately narrow:
 - define how capabilities are declared, registered, and selected;
 - dispatch by `ArtifactDescriptor` claims and facets, not by `record_type`;
 - explain how bundled and external plugins use the same route;
-- preserve room for future typed reader handles and writer-result merging.
+- preserve room for future typed reader handles and operation-materializer
+  result merging.
 
 This slice does not define the public `open_artifact()` API, read-handle
 lifecycle, shell-like pipeline syntax, or catalog merge of writer-returned
@@ -32,6 +33,13 @@ Capability declarations are data. Implementations are opaque to the registry.
 An implementation may be a function, object, class instance, protocol
 implementation, or plugin-owned adapter. The registry may return it, but this
 slice does not make core invoke it implicitly.
+
+Terminology matters: a registry writer capability is not the same thing as the
+operation-scoped `ArtifactWriter`/materializer helpers in `ogcat.writers`.
+Writer capabilities declare typed I/O behavior. Operation materializers prepare
+the target descriptor, invoke a capability or one-off function, register
+rollback, collect produced descriptor facts, and hand those facts to the
+operation runner for merge.
 
 ## Declaration Shape
 
@@ -142,8 +150,8 @@ metadata at runtime. Runtime helpers should consume the same namespaced
 facet/version that the capability declares, so unrelated plugins cannot change
 behavior by using the same facet kind/name in their own namespace.
 
-Writers and converters use the same rule. A caller requests exact input and
-output claims or interfaces:
+Writer capabilities and converters use the same rule. A caller requests exact
+input and output claims or interfaces:
 
 ```python
 emoji_converter = registry.select(
@@ -183,7 +191,7 @@ capabilities.
 participate in operation hooks such as `before_validate_metadata`,
 `extract_metadata`, and `after_commit`.
 
-The capability registry owns typed declarations for readers, writers, and
+The capability registry owns typed declarations for readers, writer capabilities, and
 converters. A plugin object may contribute both lifecycle hooks and capability
 declarations, but those are different extension points:
 
@@ -232,6 +240,13 @@ directly only to keep this slice executable without the future handle API. That
 is useful as a plugin-style pressure test, but it is not the intended long-term
 pipeline executor.
 
+The long-term executor should make composition explicit. A reader selected with
+zero or more converters can be exposed as a reader/read plan for a requested
+output interface, following Intake's idea that a pipeline of reader/converters
+is itself reader-like. Operation materializers then consume the final runtime
+value or handle and use writer capabilities to produce artifact descriptors
+inside the operation rollback/audit boundary.
+
 ## Preserved Testing Request
 
 When #119 moves from documentation into implementation, preserve this testing
@@ -252,7 +267,8 @@ scope:
   that is not catalogued;
 - allow the registry to store and return runtime implementation objects, but do
   not make core invoke them implicitly;
-- keep reader handle APIs for #118 and catalog writer-result merge for #117.
+- keep reader handle APIs for #118 and catalog materializer-result merge for
+  #117.
 
 ## Deferred
 
@@ -262,8 +278,8 @@ This note intentionally leaves several choices to implementation:
 - trust and authentication policy for third-party plugin declarations;
 - how `PluginRegistry` exposes capability contribution methods;
 - the read-handle API that consumes selected reader implementations;
-- the writer-result model that persists produced claims/facets;
+- the operation-materializer result model that persists produced claims/facets;
 - optional integration with Intake pipelines or other external registries.
 - a converter orchestration layer that passes opened handles or runtime values
-  between readers, filters, and writers so chained conversions do not repeat
-  reader/writer boilerplate.
+  between readers, filters, and writer capabilities so chained conversions do
+  not repeat reader/writer boilerplate.

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -109,10 +109,17 @@ database transactions.
 ## Writing Artifacts From Plugins
 
 Artifact writers materialise data before the catalog record is written. They receive the active
-`OperationContext`, an `OperationSource`, and the resolved target `ArtifactLocator`. Writers should
-create the artifact, register rollback for anything they created, and add writer-derived metadata to
-`context.derived_metadata`. `ogcat.writers` includes small helper writers for examples and lightweight
-workflows; they are intentionally minimal wrappers, not a full pipeline system.
+`ArtifactWriteRequest`, which contains the `OperationContext`, `OperationSource`, planned target
+`ArtifactDescriptor`, and storage plan. Writers should create the artifact, register rollback for
+anything they created, and return an `ArtifactWriteResult` with descriptor facts to merge into the
+catalog record. Diagnostics and provenance on the result are audit-only; persisted artifact facts
+belong in descriptor claims, facets, relationship metadata, locator, or state.
+
+The convenience wrappers in `ogcat.writers` keep one-off functions small. Wrapped functions can still
+return `None` or a metadata dictionary, and the adapter converts that return value into an
+`ArtifactWriteResult`. A descriptor-first writer class should implement `write(request)` directly.
+`ogcat.writers` remains intentionally minimal: it is not a read-handle API, managed collection API,
+or runtime pipeline system.
 
 `add_artifact()` remains record-only unless a writer is explicitly supplied:
 
@@ -149,7 +156,10 @@ remain committed.
 Internally, `Catalog` prepares an `AddOperationRequest` and delegates the ordered lifecycle to an
 `AddOperationRunner`. The runner is not public API, but the boundary matters for plugin behavior:
 hooks and artifact writers see the same `OperationContext`, hook ordering, rollback behavior, and
-audit events whether the operation started from `add_file()` or `add_artifact()`. The generic
+audit events whether the operation started from `add_file()` or `add_artifact()`. The runner also
+owns the single result merge path: it builds a planned `data` descriptor, passes it to the writer,
+merges returned data facts deterministically, appends auxiliary descriptors, and stages the merged
+artifact list with the record. The generic
 `OperationRunner` interface is intentionally broader than add operations so future operation
 families can use the same command boundary without changing the public hook API.
 

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -6,7 +6,8 @@
 
 Capability registration is a separate extension point. Lifecycle hooks observe
 or mutate catalog operations; capability declarations describe typed readers,
-writers, and converters that can be selected from artifact claims and facets.
+writer capabilities, and converters that can be selected from artifact claims
+and facets.
 A single plugin object may provide both, but the capability registry remains a
 registration and lookup layer rather than another hook lifecycle.
 
@@ -24,10 +25,10 @@ Terminology matters:
   hooks, and rollback.
 
 `Catalog.add_artifact(...)` is record-only by default: it records a locator for an artifact, but does
-not write artifact data unless an artifact writer is explicitly supplied. `Catalog.add_file(...)` is a
+not write artifact data unless an operation materializer is explicitly supplied. `Catalog.add_file(...)` is a
 bundled local-file operation: it resolves a path locator, copies or moves the source file, extracts
 generic metadata, and writes the record. Future data-from-memory writes should be modeled as explicit
-operations or artifact writers rather than as record-write hooks.
+operations or materializers rather than as record-write hooks.
 
 ## Direct Registration
 
@@ -106,22 +107,27 @@ class ExternalIndexPlugin:
 Rollback actions run in reverse registration order. They are best-effort compensating actions, not
 database transactions.
 
-## Writing Artifacts From Plugins
+## Materializing Artifacts From Plugins
 
-Artifact writers materialise data before the catalog record is written. They receive the active
-`ArtifactWriteRequest`, which contains the `OperationContext`, `OperationSource`, planned target
-`ArtifactDescriptor`, and storage plan. Writers should create the artifact, register rollback for
-anything they created, and return an `ArtifactWriteResult` with descriptor facts to merge into the
-catalog record. Diagnostics and provenance on the result are audit-only; persisted artifact facts
-belong in descriptor claims, facets, relationship metadata, locator, or state.
+Operation materializers materialise data before the catalog record is written. They receive the
+active `ArtifactWriteRequest`, which contains the `OperationContext`, `OperationSource`, planned
+target `ArtifactDescriptor`, and storage plan. Materializers should create the artifact, register
+rollback for anything they created, and return an `ArtifactWriteResult` with descriptor facts to
+merge into the catalog record. Diagnostics and provenance on the result are audit-only; persisted
+artifact facts belong in descriptor claims, facets, relationship metadata, locator, or state.
+
+This operation-scoped materializer layer is distinct from registry writer capabilities. A writer
+capability declares and implements typed output behavior such as `TextWriter.write(descriptor, str)`.
+A materializer may wrap that capability later, adding target preparation, rollback, audit, and result
+merge behavior needed by the catalog operation.
 
 The convenience wrappers in `ogcat.writers` keep one-off functions small. Wrapped functions can still
 return `None` or a metadata dictionary, and the adapter converts that return value into an
-`ArtifactWriteResult`. A descriptor-first writer class should implement `write(request)` directly.
+`ArtifactWriteResult`. A descriptor-first materializer class should implement `write(request)` directly.
 `ogcat.writers` remains intentionally minimal: it is not a read-handle API, managed collection API,
 or runtime pipeline system.
 
-`add_artifact()` remains record-only unless a writer is explicitly supplied:
+`add_artifact()` remains record-only unless a materializer is explicitly supplied:
 
 ```python
 from pathlib import Path
@@ -144,22 +150,23 @@ record = catalog.add_artifact(
 )
 ```
 
-Writers are the right place for artifact creation such as copying, extracting, parsing, or
-materialising data. Record hooks still surround catalog metadata and record persistence:
+Materializers are the right place for artifact creation such as copying, extracting, parsing, or
+materialising data inside today's add-operation lifecycle. Record hooks still surround catalog metadata and record persistence:
 `before_record_write` and `after_record_write` should not perform data writes unless the hook object
-is intentionally being used as an artifact writer.
+is intentionally being used as an operation materializer.
 
 `add_artifacts()` is equivalent to calling `add_artifact()` once per item. Each item runs the normal
-hook, writer, and commit lifecycle independently; if a later item fails, earlier successful items
+hook, materializer, and commit lifecycle independently; if a later item fails, earlier successful items
 remain committed.
 
 Internally, `Catalog` prepares an `AddOperationRequest` and delegates the ordered lifecycle to an
 `AddOperationRunner`. The runner is not public API, but the boundary matters for plugin behavior:
-hooks and artifact writers see the same `OperationContext`, hook ordering, rollback behavior, and
+hooks and operation materializers see the same `OperationContext`, hook ordering, rollback behavior, and
 audit events whether the operation started from `add_file()` or `add_artifact()`. The runner also
 owns the single result merge path: it builds a planned `data` descriptor, passes it to the writer,
-merges returned data facts deterministically, appends auxiliary descriptors, and stages the merged
-artifact list with the record. The generic
+owns the single result merge path: it builds a planned `data` descriptor, passes it to the
+materializer, merges returned data facts deterministically, appends auxiliary descriptors, and stages
+the merged artifact list with the record. The generic
 `OperationRunner` interface is intentionally broader than add operations so future operation
 families can use the same command boundary without changing the public hook API.
 
@@ -267,7 +274,7 @@ derived metadata, planned locators, source information, storage mode, and rollba
 The #119 capability registry builds on the plugin ergonomics described here
 without merging lifecycle hooks and typed artifact access. `PluginRegistry`
 continues to collect hook objects for operation lifecycle points. A
-`CapabilityRegistry` collects declarations for readers, writers, and
+`CapabilityRegistry` collects declarations for readers, writer capabilities, and
 converters: what input claims or interfaces they accept, what output claims or
 interfaces they produce, and any plugin-owned option metadata.
 

--- a/docs/design-note-hooks-plugins.md
+++ b/docs/design-note-hooks-plugins.md
@@ -111,10 +111,11 @@ database transactions.
 
 Operation materializers materialise data before the catalog record is written. They receive the
 active `ArtifactWriteRequest`, which contains the `OperationContext`, `OperationSource`, planned
-target `ArtifactDescriptor`, and storage plan. Materializers should create the artifact, register
-rollback for anything they created, and return an `ArtifactWriteResult` with descriptor facts to
-merge into the catalog record. Diagnostics and provenance on the result are audit-only; persisted
-artifact facts belong in descriptor claims, facets, relationship metadata, locator, or state.
+target `ArtifactDescriptor`, and storage plan. Materializers should prepare the target, register
+rollback for anything they created, invoke a writer capability or one-off function, and return the
+writer's `ArtifactWriteResult` with descriptor facts to merge into the catalog record. Diagnostics
+and provenance on the result are audit-only; persisted artifact facts belong in descriptor claims,
+facets, relationship metadata, locator, or state.
 
 This operation-scoped materializer layer is distinct from registry writer capabilities. A writer
 capability declares and implements typed output behavior such as `TextWriter.write(descriptor, str)`.

--- a/docs/design-note-virtual-artifact-filesystem-research.md
+++ b/docs/design-note-virtual-artifact-filesystem-research.md
@@ -865,7 +865,7 @@ the ADR makes each slice concrete enough to open as a separate sub-issue.
 3. Data type, representation, interface, and facet claim schemas.
 4. Reader, writer-capability, and converter capability registry.
 5. Managed collections as operation targets, including #109.
-6. Structured operation-materializer result model.
+6. Structured writer-capability result model and operation merge.
 7. Read-side artifact handles and accessors.
 8. Intake plugin design spike.
 9. Migration and compatibility plan for existing single-locator catalogs.

--- a/docs/design-note-virtual-artifact-filesystem-research.md
+++ b/docs/design-note-virtual-artifact-filesystem-research.md
@@ -9,7 +9,7 @@ actual architecture decision after these concepts have been reviewed.
 - GitHub issue #108, "Plan filesystem-like artifact interfaces and structured operator pipelines".
 - GitHub issue #109, "Make managed collections first-class operation targets".
 - Current `ogcat` code around `CatalogRecord`, `ArtifactLocator`, `StoragePlan`,
-  `OperationSource`, `ArtifactWriter`, `OperationContext`, collections, replicas,
+  `OperationSource`, `ArtifactWriter`/materializer helpers, `OperationContext`, collections, replicas,
   secondary artifacts, and plugins.
 - User-supplied notes:
   - `/Users/bm13805/Desktop/temp/chatgpt_unix_filesystem_review.md`
@@ -36,9 +36,10 @@ Storage and materialization are currently shaped around `StoragePlan` and
 `StoragePlan` describes where an artifact should be written or referenced and
 whether ogcat owns it.
 
-`OperationSource`, `ArtifactWriter`, and `OperationContext` are the existing
-write-side boundary. Writers materialize data into an `ArtifactLocator` and can
-mutate `context.derived_metadata` or register rollback actions.
+`OperationSource`, `ArtifactWriter`/materializer helpers, and
+`OperationContext` are the existing write-side boundary. Materializers write
+data into a planned artifact target and can return descriptor facts or register
+rollback actions.
 
 Collections are not a storage target today. They are explicit classification
 metadata layered over directory-like locators. This is a useful direction to
@@ -147,7 +148,7 @@ ogcat equivalents and gaps:
 | Replica | None yet for exact copies; symlink views are only links | Need checksum/freshness/resource/copy state. |
 | Resource | Storage root plus adapter hint | No resource hierarchy, health, policy, or cache/archive coordinator. |
 | Vault | `data/objects/` primary storage tree | Not necessarily archive storage and not a storage resource model. |
-| Rule engine | hooks, writers, secondary artifacts | Python-local, synchronous, and not a policy engine. |
+| Rule engine | hooks, materializers, secondary artifacts | Python-local, synchronous, and not a policy engine. |
 | Federation | explicit remote locators only | No zones, trust, ACL sync, or remote catalog protocol. |
 
 The ADR should avoid using "replica" for current symlink-based behavior without
@@ -339,8 +340,8 @@ versus prototype metadata first.
 
 `Operation`
 : Execution envelope that consumes and produces records/artifacts/handles
-  through declared readers, writers, and converters. Owns validation, rollback,
-  audit, and provenance.
+  through declared readers, writer capabilities, converters, and operation
+  materializers. Owns validation, rollback, audit, and provenance.
 
 ## Target Object Relationships
 
@@ -614,16 +615,17 @@ xarray unless a plugin provides the reader.
 | `Locator` | Serializable description of where an artifact is or can be resolved. | Resolved by mount/resource context and locator drivers. |
 | `StorageResource` | Named storage profile, root, adapter, and capabilities. | Used by locators, storage plans, replicas, caches, and mount resolver. |
 | `DataTypeClaim` | Intake-aligned source/external type assertion. | Informs readers, converters, validators, and documentation. |
-| `Representation` | Storage/encoding shape of an artifact. | Connects locators to readers and writers. |
+| `Representation` | Storage/encoding shape of an artifact. | Connects locators to readers and writer capabilities. |
 | `InterfaceClaim` | Capability contract an artifact can expose. | Dispatch key for reader/converter selection. |
-| `Facet` | Namespaced fact with evidence and confidence. | Produced by inspectors, readers, writers, validators, and plugins. |
+| `Facet` | Namespaced fact with evidence and confidence. | Produced by inspectors, readers, materializers, validators, and plugins. |
 | `PermissionPolicy` | Decides whether a principal can perform a catalog, record, artifact, resource, or operation action. | Uses principals, groups, record/artifact state, resource profiles, and plugin capability metadata. |
 | `LockManager` | Coordinates shared/exclusive locks, leases, and version checks. | Used by operations, handles, storage resources, and catalog backends. |
 | `Reader` | Opens an artifact through an interface and returns a runtime handle/object. | Uses locators, claims, facets, plugins, and operation context. |
-| `Writer` | Materializes runtime data or source handles into artifact storage. | Uses storage plans/resources and returns artifact result metadata. |
-| `Converter` | Transforms one runtime interface into another. | Composes readers and writers; may be lazy or materializing. |
+| `WriterCapability` | Declares and implements typed output behavior. | Uses descriptors, runtime values/handles, claims, facets, and plugin options. |
+| `OperationMaterializer` | Adapts a writer capability or one-off function into the catalog operation lifecycle. | Uses storage plans/resources, rollback registration, audit, and descriptor-result merge. |
+| `Converter` | Transforms one runtime interface into another. | Composes readers and writer capabilities; may be lazy or materializing. |
 | `Handle` | Runtime opened object scoped to an operation or user context. | Owned by operation lifecycle or user context; may hold read/write leases. |
-| `Operation` | Execution envelope for typed pipelines. | Coordinates readers, writers, converters, rollback, audit, and provenance. |
+| `Operation` | Execution envelope for typed pipelines. | Coordinates readers, writer capabilities, converters, materializers, rollback, audit, and provenance. |
 
 UML-style structural sketch:
 
@@ -757,7 +759,7 @@ Single-file ingest as the future model:
 
 ```text
 flowchart LR
-  A["Local source path"] --> B["copy/move writer"]
+  A["Local source path"] --> B["copy/move materializer"]
   B --> C["Primary artifact descriptor"]
   C --> D["record.locator compatibility field"]
   B --> E["facts: size, suffix, checksum, inferred claims"]
@@ -861,9 +863,9 @@ the ADR makes each slice concrete enough to open as a separate sub-issue.
 1. ADR: virtual artifact filesystem vocabulary and boundaries.
 2. First-class artifact descriptor target model.
 3. Data type, representation, interface, and facet claim schemas.
-4. Reader, writer, and converter capability registry.
+4. Reader, writer-capability, and converter capability registry.
 5. Managed collections as operation targets, including #109.
-6. Structured artifact writer result model.
+6. Structured operation-materializer result model.
 7. Read-side artifact handles and accessors.
 8. Intake plugin design spike.
 9. Migration and compatibility plan for existing single-locator catalogs.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -28,12 +28,12 @@ Managed file
 
 Reference record
 : A record added with `Catalog.add_artifact` whose artifact may be external,
-  already materialised, written by an artifact writer, or represented by an
-  opaque locator.
+  already materialised, written by an operation materializer, or represented by
+  an opaque locator.
 
 Metadata
 : JSON-compatible descriptive data attached to records. `user_metadata` comes
-  from callers, `derived_metadata` comes from hooks or writers, and
+  from callers, `derived_metadata` comes from hooks or materializers, and
   `naming_metadata` is used for storage template rendering.
 
 Schema
@@ -51,18 +51,24 @@ Plugin
 
 Operation context
 : The mutable `OperationContext` object passed to hooks and embedded in
-  `ArtifactWriteRequest` for writers. It carries source information, planned
-  locators, metadata, warnings, and the rollback registrar for the active
-  operation.
+  `ArtifactWriteRequest` for operation materializers. It carries source
+  information, planned locators, metadata, warnings, and the rollback registrar
+  for the active operation.
 
-Artifact writer
-: Any object satisfying the `ArtifactWriter` protocol. Writers materialise
-  artifact data from an `ArtifactWriteRequest` and return an
+Operation materializer
+: Any object satisfying the `ArtifactMaterializer` protocol. Materializers
+  materialise artifact data from an `ArtifactWriteRequest` and return an
   `ArtifactWriteResult` describing produced descriptor facts.
 
+Writer capability
+: A registered `ArtifactCapability` with kind `writer`. Writer capabilities
+  declare typed output behavior; operation materializers wrap them when catalog
+  rollback, audit, and descriptor merge are needed.
+
 Operation source
-: The `OperationSource` description passed to artifact writers. It can carry a
-  local path, non-path descriptor, source metadata, or in-memory payload.
+: The `OperationSource` description passed to operation materializers. It can
+  carry a local path, non-path descriptor, source metadata, or in-memory
+  payload.
 
 Unit of work
 : The current best-effort transaction helper. It stages catalog changes,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -50,13 +50,15 @@ Plugin
   usually through `PluginRegistry`.
 
 Operation context
-: The mutable `OperationContext` object passed to hooks and artifact writers.
-  It carries source information, planned locators, metadata, warnings, and the
-  rollback registrar for the active operation.
+: The mutable `OperationContext` object passed to hooks and embedded in
+  `ArtifactWriteRequest` for writers. It carries source information, planned
+  locators, metadata, warnings, and the rollback registrar for the active
+  operation.
 
 Artifact writer
 : Any object satisfying the `ArtifactWriter` protocol. Writers materialise
-  artifact data from an `OperationSource` into a target `ArtifactLocator`.
+  artifact data from an `ArtifactWriteRequest` and return an
+  `ArtifactWriteResult` describing produced descriptor facts.
 
 Operation source
 : The `OperationSource` description passed to artifact writers. It can carry a

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,18 +57,20 @@ Operation context
 
 Operation materializer
 : Any object satisfying the `ArtifactMaterializer` protocol. Materializers
-  materialise artifact data from an `ArtifactWriteRequest` and return an
-  `ArtifactWriteResult` describing produced descriptor facts.
+  prepare operation targets, register rollback, and wrap writer capabilities or
+  one-off functions from an `ArtifactWriteRequest`.
 
 Writer capability
 : A registered `ArtifactCapability` with kind `writer`. Writer capabilities
-  declare typed output behavior; operation materializers wrap them when catalog
+  declare typed output behavior and return `ArtifactWriteResult` values with
+  produced descriptor facts; operation materializers wrap them when catalog
   rollback, audit, and descriptor merge are needed.
 
 Operation source
 : The `OperationSource` description passed to operation materializers. It can
   carry a local path, non-path descriptor, source metadata, or in-memory
-  payload.
+  payload. New capability dispatch should prefer source artifact descriptor
+  claims/facets when available.
 
 Unit of work
 : The current best-effort transaction helper. It stages catalog changes,

--- a/docs/ogcat_long_term_plan.md
+++ b/docs/ogcat_long_term_plan.md
@@ -585,7 +585,8 @@ Use fsspec as the generic filesystem abstraction while preserving simple local p
 
 - `StorageManager`
 - `PathPlanner`
-- `ArtifactWriter`
+- `ArtifactMaterializer`
+- `WriterCapability`
 - `ArtifactReader`
 - `FSSpecLocator`
 - `StorageProfile`

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -421,7 +421,7 @@ from pathlib import Path
 import fsspec
 import xarray as xr
 
-from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+from ogcat import ArtifactLocator, ArtifactWriteRequest, ArtifactWriteResult, OperationContext, memory_source
 
 
 def cams_zip_member_urlpath(locator: ArtifactLocator, *, member_glob: str) -> str:
@@ -457,13 +457,10 @@ class CamsZipMemberUrlpathHook:
 class CamsZipChainToZarrWriter:
     """Create a Zarr store from a prepared fsspec zip-member URL path."""
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        target_path = target.as_path()
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+        context = request.context
+        source = request.source
+        target_path = request.locator.as_path()
         if target_path is None:
             raise ValueError("CAMS writer requires a local Zarr target.")
         if target_path.exists():
@@ -506,6 +503,12 @@ class CamsZipChainToZarrWriter:
                 "bc_input_version": "cams73_latest",
                 "domain": processing_domain.lower(),
                 "reader_hint": "xarray.open_zarr",
+            }
+        )
+        return ArtifactWriteResult.for_data_artifact(
+            relationship={
+                "kind": "processed_from",
+                "source_record_id": source.metadata["raw_zip_record_id"],
             }
         )
 ```
@@ -614,14 +617,16 @@ Write a managed copy with a small requests-based writer:
 ```python
 import requests
 
-from ogcat import ArtifactLocator, OperationContext, OperationSource, memory_source
+from ogcat import ArtifactLocator, ArtifactWriteRequest, ArtifactWriteResult, memory_source
 
 
 class RequestsDownloadWriter:
     """Download a URI to the planned local target."""
 
-    def write(self, context: OperationContext, source: OperationSource, target: ArtifactLocator) -> None:
-        target_path = target.as_path()
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+        context = request.context
+        source = request.source
+        target_path = request.locator.as_path()
         if target_path is None:
             raise ValueError("Download writer requires a local path target.")
         if target_path.exists():
@@ -645,6 +650,10 @@ class RequestsDownloadWriter:
                 "downloaded_on": source.metadata["downloaded_on"],
                 "byte_count": target_path.stat().st_size,
             }
+        )
+        return ArtifactWriteResult.for_data_artifact(
+            relationship={"kind": "downloaded_from", "url": url},
+            diagnostics={"byte_count": target_path.stat().st_size},
         )
 
 

--- a/docs/tutorials/artifact-workflows.md
+++ b/docs/tutorials/artifact-workflows.md
@@ -261,7 +261,7 @@ The resulting record points at a managed directory under ``data/objects``. It is
 still one logical dataset, not 36 separate file records. The explicit
 ``collection_pattern`` and ``reader_hint`` in the classification metadata
 document how downstream code should read the members. This uses the lower-level
-artifact writer path because managed collections are not yet a first-class
+operation materializer path because managed collections are not yet a first-class
 ``add_collection(...)`` write target. When that API grows, archive-to-collection
 workflows should be expressible without manually attaching collection
 classification metadata.

--- a/docs/tutorials/intermediate.md
+++ b/docs/tutorials/intermediate.md
@@ -20,7 +20,7 @@ Future content should show:
 - `context.add_warning(...)` for non-fatal findings
 - focused tests for hook outcomes
 
-## Artifact writers
+## Operation materializers
 
 Use this level for examples that materialise data during `add_artifact()`, for
 example writing an in-memory object or unpacking a zip archive with helpers from
@@ -31,7 +31,7 @@ Future content should show:
 - `memory_source()` with `memory_writer()`
 - `path_source()` with `path_writer()`
 - `UnzipArtifactWriter`
-- rollback behavior when a writer fails
+- rollback behavior when a materializer fails
 
 ## Validation patterns
 

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -22,12 +22,20 @@ from ogcat.capabilities import (
 )
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
-from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
+from ogcat.hooks import (
+    ArtifactWriter,
+    ArtifactWriteRequest,
+    HookManager,
+    HookWarning,
+    OperationContext,
+    OperationSource,
+)
 from ogcat.models import (
     ArtifactClaim,
     ArtifactDescriptor,
     ArtifactFacet,
     ArtifactLocator,
+    ArtifactWriteResult,
     CatalogRecord,
     DataTypeClaim,
     Facet,
@@ -90,6 +98,8 @@ __all__ = [
     "ArtifactClaim",
     "ArtifactDescriptor",
     "ArtifactFacet",
+    "ArtifactWriteRequest",
+    "ArtifactWriteResult",
     "ArtifactWriter",
     "AuditEvent",
     "AuditSink",

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -23,6 +23,7 @@ from ogcat.capabilities import (
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
 from ogcat.hooks import (
+    ArtifactMaterializer,
     ArtifactWriter,
     ArtifactWriteRequest,
     HookManager,
@@ -98,6 +99,7 @@ __all__ = [
     "ArtifactClaim",
     "ArtifactDescriptor",
     "ArtifactFacet",
+    "ArtifactMaterializer",
     "ArtifactWriteRequest",
     "ArtifactWriteResult",
     "ArtifactWriter",

--- a/src/ogcat/bundled_plugins/stdlib_io.py
+++ b/src/ogcat/bundled_plugins/stdlib_io.py
@@ -32,6 +32,7 @@ from ogcat.models import (
     ArtifactFacet,
     ArtifactFacetInput,
     ArtifactLocator,
+    ArtifactWriteResult,
     DataTypeClaim,
     InterfaceClaim,
     JsonValue,
@@ -72,7 +73,7 @@ class BytesReader:
 class BytesWriter:
     """Write path-backed artifacts as raw bytes."""
 
-    def write(self, descriptor: ArtifactDescriptor, data: bytes) -> ArtifactDescriptor:
+    def write(self, descriptor: ArtifactDescriptor, data: bytes) -> ArtifactWriteResult:
         """Write bytes to the descriptor's path locator.
 
         Args:
@@ -80,17 +81,20 @@ class BytesWriter:
             data: Bytes to write.
 
         Returns:
-            Descriptor metadata with bytes/file claims and path locator facet.
+            Result containing descriptor metadata with bytes/file claims and
+            path locator facet.
 
         Raises:
             ValueError: If the descriptor has no local path locator.
             OSError: If the path cannot be written.
         """
         _descriptor_path(descriptor).write_bytes(data)
-        return descriptor_with_claims(
-            descriptor,
-            claims=(InterfaceClaim("bytes"), RepresentationClaim("file")),
-            facets=(path_locator_facet(),),
+        return ArtifactWriteResult.from_artifact(
+            descriptor_with_claims(
+                descriptor,
+                claims=(InterfaceClaim("bytes"), RepresentationClaim("file")),
+                facets=(path_locator_facet(),),
+            )
         )
 
 
@@ -126,7 +130,7 @@ class TextWriter:
         text: str,
         *,
         encoding: str | None = None,
-    ) -> ArtifactDescriptor:
+    ) -> ArtifactWriteResult:
         """Write text and return descriptor metadata with an encoding facet.
 
         Args:
@@ -136,8 +140,8 @@ class TextWriter:
                 stdlib encoding facet is used, falling back to UTF-8.
 
         Returns:
-            Descriptor metadata with text claims, path locator facet, and the
-            resolved encoding facet.
+            Result containing descriptor metadata with text claims, path
+            locator facet, and the resolved encoding facet.
 
         Raises:
             ValueError: If the descriptor has no local path locator.
@@ -147,10 +151,12 @@ class TextWriter:
         """
         resolved_encoding = encoding or encoding_from_descriptor(descriptor)
         _descriptor_path(descriptor).write_text(text, encoding=resolved_encoding)
-        return descriptor_with_claims(
-            descriptor,
-            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
+        return ArtifactWriteResult.from_artifact(
+            descriptor_with_claims(
+                descriptor,
+                claims=(RepresentationClaim("text"), InterfaceClaim("text")),
+                facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
+            )
         )
 
 
@@ -206,7 +212,7 @@ class DelimitedTableWriter:
         fieldnames: Sequence[str] | None = None,
         delimiter: str | None = None,
         encoding: str | None = None,
-    ) -> ArtifactDescriptor:
+    ) -> ArtifactWriteResult:
         """Write a delimited table using ``csv.DictWriter``.
 
         Args:
@@ -220,8 +226,8 @@ class DelimitedTableWriter:
                 stdlib encoding facet is used, falling back to UTF-8.
 
         Returns:
-            Descriptor metadata with text/table claims plus path, encoding, and
-            delimiter facets.
+            Result containing descriptor metadata with text/table claims plus
+            path, encoding, and delimiter facets.
 
         Raises:
             ValueError: If the descriptor has no local path locator.
@@ -241,17 +247,19 @@ class DelimitedTableWriter:
             )
             writer.writeheader()
             writer.writerows(row_list)
-        return descriptor_with_claims(
-            descriptor,
-            claims=(
-                RepresentationClaim("text"),
-                InterfaceClaim("text"),
-                InterfaceClaim("table"),
-            ),
-            facets=(
-                path_locator_facet(),
-                encoding_facet(resolved_encoding),
-                delimiter_facet(resolved_delimiter),
+        return ArtifactWriteResult.from_artifact(
+            descriptor_with_claims(
+                descriptor,
+                claims=(
+                    RepresentationClaim("text"),
+                    InterfaceClaim("text"),
+                    InterfaceClaim("table"),
+                ),
+                facets=(
+                    path_locator_facet(),
+                    encoding_facet(resolved_encoding),
+                    delimiter_facet(resolved_delimiter),
+                ),
             ),
         )
 
@@ -290,7 +298,7 @@ class JsonWriter:
         *,
         indent: int | None = 2,
         encoding: str | None = None,
-    ) -> ArtifactDescriptor:
+    ) -> ArtifactWriteResult:
         """Write JSON and return descriptor metadata with JSON claims.
 
         Args:
@@ -301,8 +309,8 @@ class JsonWriter:
                 stdlib encoding facet is used, falling back to UTF-8.
 
         Returns:
-            Descriptor metadata with JSON/text claims plus path and encoding
-            facets.
+            Result containing descriptor metadata with JSON/text claims plus
+            path and encoding facets.
 
         Raises:
             TypeError: If ``document`` contains values that ``json.dump`` cannot
@@ -314,15 +322,17 @@ class JsonWriter:
         with _descriptor_path(descriptor).open("w", encoding=resolved_encoding) as stream:
             json.dump(document, stream, ensure_ascii=False, indent=indent)
             stream.write("\n")
-        return descriptor_with_claims(
-            descriptor,
-            claims=(
-                RepresentationClaim("text"),
-                DataTypeClaim("json", namespace="iana.media-types"),
-                InterfaceClaim("text"),
-                InterfaceClaim("json"),
-            ),
-            facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
+        return ArtifactWriteResult.from_artifact(
+            descriptor_with_claims(
+                descriptor,
+                claims=(
+                    RepresentationClaim("text"),
+                    DataTypeClaim("json", namespace="iana.media-types"),
+                    InterfaceClaim("text"),
+                    InterfaceClaim("json"),
+                ),
+                facets=(path_locator_facet(), encoding_facet(resolved_encoding)),
+            )
         )
 
 
@@ -338,67 +348,49 @@ class EmoticonEmojiTextConverter:
         ";-)": "😉",
     }
 
-    def convert(
-        self,
-        source_descriptor: ArtifactDescriptor,
-        output_descriptor: ArtifactDescriptor,
-    ) -> ArtifactDescriptor:
-        """Read ASCII-compatible text and write UTF-8 emoji text output.
+    def convert(self, text: str) -> str:
+        """Convert ASCII-compatible text to Unicode emoji text.
 
         Args:
-            source_descriptor: Path-backed text descriptor to read.
-            output_descriptor: Path-backed descriptor to write.
+            text: Runtime text value to convert.
 
         Returns:
-            Output descriptor with text claims, UTF-8 encoding, path facet, and
-            relationship metadata linking the source.
+            Converted runtime text value.
         """
-        source_text = TextReader().read(source_descriptor)
-        converted = source_text
+        converted = text
         for emoticon, emoji in self.emoticons.items():
             converted = converted.replace(emoticon, emoji)
-
-        output = descriptor_with_claims(
-            output_descriptor,
-            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
-            relationship={
-                "generated_by": "ogcat.stdlib.emoticon_to_emoji",
-                "source_artifact_id": source_descriptor.id,
-            },
-        )
-        return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
+        return converted
 
 
 class PigLatinTextConverter:
     """Convert text artifacts to Pig Latin text."""
 
-    def convert(
-        self,
-        source_descriptor: ArtifactDescriptor,
-        output_descriptor: ArtifactDescriptor,
-    ) -> ArtifactDescriptor:
-        """Read text and write UTF-8 Pig Latin text output.
+    def convert(self, text: str) -> str:
+        """Convert runtime text to Pig Latin text.
 
         Args:
-            source_descriptor: Path-backed text descriptor to read.
-            output_descriptor: Path-backed descriptor to write.
+            text: Runtime text value to convert.
 
         Returns:
-            Output descriptor with text claims, UTF-8 encoding, path facet, and
-            relationship metadata linking the source.
+            Converted runtime text value.
         """
-        converted = _pig_latin_text(TextReader().read(source_descriptor))
-        output = descriptor_with_claims(
-            output_descriptor,
-            claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            facets=(encoding_facet(DEFAULT_TEXT_ENCODING),),
-            relationship={
-                "generated_by": "ogcat.stdlib.pig_latin",
-                "source_artifact_id": source_descriptor.id,
-            },
-        )
-        return TextWriter().write(output, converted, encoding=DEFAULT_TEXT_ENCODING)
+        return _pig_latin_text(text)
+
+
+class DelimitedTableToJsonConverter:
+    """Convert table rows to a JSON-compatible document."""
+
+    def convert(self, rows: TableRows) -> JsonDocument:
+        """Convert runtime table rows to a JSON-compatible document.
+
+        Args:
+            rows: Runtime table rows from a table reader.
+
+        Returns:
+            JSON-compatible list of row dictionaries.
+        """
+        return cast(JsonDocument, [dict(row) for row in rows])
 
 
 def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
@@ -498,7 +490,6 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=EmoticonEmojiTextConverter(),
             input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Convert ASCII emoticons in text artifacts to Unicode emoji text.",
         ),
         _capability(
@@ -507,8 +498,20 @@ def stdlib_capabilities() -> tuple[ArtifactCapability, ...]:
             implementation=PigLatinTextConverter(),
             input_claims=(InterfaceClaim("text"),),
             output_claims=(RepresentationClaim("text"), InterfaceClaim("text")),
-            required_facets=(path_locator_facet_requirement(), encoding_facet_requirement()),
             description="Convert text artifacts to Pig Latin text.",
+        ),
+        _capability(
+            name="delimited-table-to-json-converter",
+            kind=CapabilityKind.CONVERTER,
+            implementation=DelimitedTableToJsonConverter(),
+            input_claims=(InterfaceClaim("table"),),
+            output_claims=(
+                RepresentationClaim("text"),
+                DataTypeClaim("json", namespace="iana.media-types"),
+                InterfaceClaim("text"),
+                InterfaceClaim("json"),
+            ),
+            description="Read delimited text rows and write a JSON document.",
         ),
     )
 

--- a/src/ogcat/capabilities.py
+++ b/src/ogcat/capabilities.py
@@ -1,8 +1,8 @@
 """Artifact capability registration and lookup.
 
-The capability registry is the #119 dispatch surface for readers, writers, and
-converters. It stores typed declarations and optional opaque implementation
-objects, then answers discovery and selection requests from
+The capability registry is the #119 dispatch surface for readers, writer
+capabilities, and converters. It stores typed declarations and optional opaque
+implementation objects, then answers discovery and selection requests from
 ``ArtifactDescriptor`` claims and facets. Core does not invoke implementations
 or dispatch by ``CatalogRecord.record_type``.
 

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -29,7 +29,14 @@ from ogcat.hooks import (
     coerce_hook_iterable,
     validate_hook_objects,
 )
-from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
+from ogcat.models import (
+    ArtifactDescriptor,
+    ArtifactLocator,
+    CatalogRecord,
+    JsonValue,
+    MetadataDict,
+    normalize_metadata,
+)
 from ogcat.operation_helpers import (
     artifact_locator_from_context,
     naming_metadata_from_storage_plan,
@@ -1168,6 +1175,7 @@ class Catalog:
         original_path: str | Path | None = None,
         original_filename: str | None = None,
         suffixes: list[str] | None = None,
+        artifacts: list[ArtifactDescriptor] | None = None,
         derived_metadata: Mapping[Any, Any] | None = None,
         naming_metadata: Mapping[Any, Any] | None = None,
         time_added: str | None = None,
@@ -1199,6 +1207,7 @@ class Catalog:
             time_added=resolved_time_added,
             record_type=record_type,
             locator=locator,
+            artifacts=[] if artifacts is None else list(artifacts),
             stored_abspath=str(locator_path) if locator_path is not None else None,
             stored_relpath=locator.relative_path if locator.kind == "path" else None,
             storage_mode=storage_mode,

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -21,7 +21,7 @@ from ogcat.audit import (
 from ogcat.catalog_application import CatalogApplication
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, collection_classification_metadata
 from ogcat.hooks import (
-    ArtifactWriter,
+    ArtifactMaterializer,
     HookLifecycleEvent,
     HookManager,
     OperationContext,
@@ -382,7 +382,7 @@ class Catalog:
         naming_metadata: Mapping[Any, Any] | None = None,
         time_added: str | None = None,
         source: OperationSource | None = None,
-        artifact_writer: ArtifactWriter | None = None,
+        artifact_writer: ArtifactMaterializer | None = None,
         transaction: UnitOfWork | None = None,
     ) -> CatalogRecord:
         """Add an artifact record and optionally materialise planned storage.
@@ -405,16 +405,16 @@ class Catalog:
             derived_metadata: Optional derived metadata to persist.
             naming_metadata: Optional naming metadata to persist.
             time_added: Optional timestamp override.
-            source: Optional operation source for hooks and writers.
-            artifact_writer: Optional writer that materialises data before the
-                record is written.
+            source: Optional operation source for hooks and materializers.
+            artifact_writer: Optional operation materializer that materialises
+                data before the record is written.
             transaction: Optional caller-owned unit of work.
 
         Returns:
             Persisted or staged catalog record.
 
         Raises:
-            TypeError: If metadata or writer inputs are invalid.
+            TypeError: If metadata or materializer inputs are invalid.
             ValueError: If validation fails or the transaction belongs to a
                 different repository.
         """
@@ -728,8 +728,8 @@ class Catalog:
         """Add multiple artifact records.
 
         Each item should provide the same keyword-style fields accepted by
-        `add_artifact()`. Items are added one at a time so hooks and artifact
-        writers run consistently for each record. Earlier items remain
+        `add_artifact()`. Items are added one at a time so hooks and operation
+        materializers run consistently for each record. Earlier items remain
         committed if a later item fails.
 
         Args:
@@ -1235,7 +1235,7 @@ class Catalog:
         naming_metadata: MetadataDict | None,
         time_added: str | None,
         source: OperationSource | None,
-        artifact_writer: ArtifactWriter | None,
+        artifact_writer: ArtifactMaterializer | None,
         storage_plan: StoragePlan | None,
         schema: RecordSchema,
     ) -> CatalogRecord:
@@ -1656,8 +1656,8 @@ def _optional_operation_source(value: object) -> OperationSource | None:
     raise TypeError(f"source must be an OperationSource, got {type(value).__name__}")
 
 
-def _optional_artifact_writer(value: object) -> ArtifactWriter | None:
-    """Return an optional artifact writer for artifact batch forwarding."""
+def _optional_artifact_writer(value: object) -> ArtifactMaterializer | None:
+    """Return an optional artifact materializer for artifact batch forwarding."""
     return _validate_artifact_writer(value)
 
 
@@ -1670,12 +1670,12 @@ def _optional_storage_plan(value: object) -> StoragePlan | None:
     raise TypeError(f"storage_plan must be a StoragePlan, got {type(value).__name__}")
 
 
-def _validate_artifact_writer(value: object) -> ArtifactWriter | None:
-    """Return an artifact writer when the optional value implements the writer protocol."""
+def _validate_artifact_writer(value: object) -> ArtifactMaterializer | None:
+    """Return a materializer when the optional value implements the protocol."""
     if value is None:
         return None
     if callable(getattr(value, "write", None)):
-        return cast(ArtifactWriter, value)
+        return cast(ArtifactMaterializer, value)
     raise TypeError(f"artifact_writer must provide a callable write() method, got {type(value).__name__}")
 
 

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -7,13 +7,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ogcat.extractors import extract_derived_metadata
-from ogcat.hooks import ArtifactWriter, OperationContext, OperationSource
+from ogcat.hooks import ArtifactMaterializer, OperationContext, OperationSource
 from ogcat.materialization import (
     MaterializationIntent,
     MaterializationPlan,
+    materializer_intent,
     reference_intent,
     storage_plan_intent,
-    writer_intent,
 )
 from ogcat.models import ArtifactLocator, CatalogRecord, MetadataDict
 from ogcat.operation_helpers import storage_plan_with_locator
@@ -127,7 +127,7 @@ class CatalogApplication:
 
         source_description = OperationSource(kind="local_file", path=source, descriptor=str(source))
         artifact_writer = _managed_path_writer(source=source, operation=operation)
-        materialization_intent = writer_intent(artifact_writer)
+        materialization_intent = materializer_intent(artifact_writer)
         secondary_artifact_operations = self._template_link_secondary_artifacts(
             primary_location=primary_location,
             create_template_replica=create_template_replica,
@@ -175,7 +175,7 @@ class CatalogApplication:
         naming_metadata: MetadataDict | None,
         time_added: str | None,
         source: OperationSource | None,
-        artifact_writer: ArtifactWriter | None,
+        artifact_writer: ArtifactMaterializer | None,
         storage_plan: StoragePlan | None,
         schema: RecordSchema,
     ) -> CatalogRecord:
@@ -186,10 +186,10 @@ class CatalogApplication:
             descriptor=locator.value,
         )
         if storage_plan is not None:
-            materialization_intent = storage_plan_intent(storage_plan, writer=artifact_writer)
+            materialization_intent = storage_plan_intent(storage_plan, materializer=artifact_writer)
         else:
             materialization_intent = (
-                reference_intent() if artifact_writer is None else writer_intent(artifact_writer)
+                reference_intent() if artifact_writer is None else materializer_intent(artifact_writer)
             )
         return self.run_add_operation(
             transaction=transaction,
@@ -289,8 +289,8 @@ class CatalogApplication:
         )
 
 
-def _managed_path_writer(*, source: Path, operation: str) -> ArtifactWriter:
-    """Return the managed-ingest writer for the source path shape."""
+def _managed_path_writer(*, source: Path, operation: str) -> ArtifactMaterializer:
+    """Return the managed-ingest materializer for the source path shape."""
     if source.is_dir():
         return CopyDirectoryArtifactWriter() if operation == "copy" else MoveDirectoryArtifactWriter()
     return CopyArtifactWriter() if operation == "copy" else MoveArtifactWriter()

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -1,4 +1,4 @@
-"""Lifecycle hooks, writer protocols, and operation context objects.
+"""Lifecycle hooks, materializer protocols, and operation context objects.
 
 Hooks are structural protocols: a plugin object participates in a lifecycle
 phase by implementing the corresponding method, such as
@@ -21,9 +21,11 @@ public mapping used during dispatch and validation. ``HOOK_METHOD_NAMES`` is
 derived from that source of truth for compatibility with existing validation
 callers.
 
-Artifact writers use the same context model. Any object satisfying
-:class:`ArtifactWriter` can materialise an :class:`ogcat.models.ArtifactLocator`
-from an :class:`OperationSource` before the catalog record is committed.
+Artifact materializers use the same context model. Any object satisfying
+:class:`ArtifactMaterializer` can materialise a planned
+:class:`ogcat.models.ArtifactDescriptor` from an :class:`OperationSource`
+before the catalog record is committed. This operation-scoped materializer
+boundary is distinct from registry writer capabilities.
 """
 
 from __future__ import annotations
@@ -215,12 +217,21 @@ class OperationSource:
     payload: object | None = None
 
 
-class ArtifactWriter(Protocol):
-    """Plugin-facing writer that materialises artifact data before record write."""
+class ArtifactMaterializer(Protocol):
+    """Operation-scoped adapter that materialises artifact data before record write."""
 
     def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Write artifact data from the request and return produced artifact facts."""
         ...
+
+
+class ArtifactWriter(ArtifactMaterializer, Protocol):
+    """Deprecated alias for :class:`ArtifactMaterializer`.
+
+    Registry writer capabilities are represented by
+    :class:`ogcat.capabilities.ArtifactCapability` with ``kind="writer"``. This
+    protocol names the older operation-scoped materializer surface.
+    """
 
 
 @dataclass(slots=True)
@@ -310,13 +321,13 @@ class OperationContext:
 
 @dataclass(frozen=True, slots=True)
 class ArtifactWriteRequest:
-    """Operation input passed to an artifact writer.
+    """Operation input passed to an operation materializer.
 
     Args:
         context: Mutable operation context shared with hooks.
         source: Source description supplied for this operation.
-        target: Planned data artifact descriptor for the writer to materialise
-            or enrich.
+        target: Planned data artifact descriptor for the materializer to
+            materialise or enrich.
         storage_plan: Planned storage decision for the target.
     """
 
@@ -662,6 +673,7 @@ __all__ = [
     "AfterCommitHook",
     "AfterValidateMetadataHook",
     "AfterRecordWriteHook",
+    "ArtifactMaterializer",
     "ArtifactWriter",
     "ArtifactWriteRequest",
     "BeforeCommitHook",

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -200,14 +200,22 @@ class RollbackRegistrar(Protocol):
 
 @dataclass(slots=True)
 class OperationSource:
-    """Description of the artifact source for a catalog operation.
+    """Description of the source envelope for a catalog operation.
+
+    ``OperationSource`` is a compatibility and provenance DTO for current
+    operation helpers. Future reader/source dispatch should prefer
+    descriptor claims and facets on ``artifact`` over the legacy ``kind``
+    string whenever a descriptor is available.
 
     Args:
-        kind: Short source kind, such as ``"local_file"`` or ``"external"``.
+        kind: Legacy short source kind, such as ``"local_file"`` or
+            ``"external"``.
         path: Optional local source path.
         descriptor: Optional non-path source description or URI.
         metadata: Source-specific JSON-compatible metadata.
         payload: Optional in-memory Python object for writer helpers.
+        artifact: Optional source artifact descriptor for claim/facet-based
+            reader, converter, or writer capability selection.
     """
 
     kind: str
@@ -215,6 +223,7 @@ class OperationSource:
     descriptor: str | None = None
     metadata: MetadataDict = field(default_factory=dict)
     payload: object | None = None
+    artifact: ArtifactDescriptor | None = None
 
 
 class ArtifactMaterializer(Protocol):

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Literal, Protocol, cast, runtime_checkable
 
-from ogcat.models import ArtifactLocator, MetadataDict
+from ogcat.models import ArtifactDescriptor, ArtifactLocator, ArtifactWriteResult, MetadataDict
 from ogcat.storage import StoragePlan
 from ogcat.transactions import RollbackAction
 from ogcat.validation import ValidationReport
@@ -218,13 +218,8 @@ class OperationSource:
 class ArtifactWriter(Protocol):
     """Plugin-facing writer that materialises artifact data before record write."""
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
-        """Write artifact data from source to target."""
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+        """Write artifact data from the request and return produced artifact facts."""
         ...
 
 
@@ -311,6 +306,31 @@ class OperationContext:
         if self.register_rollback is None:
             raise RuntimeError("No active rollback registration is available.")
         return self.register_rollback(action, description=description)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactWriteRequest:
+    """Operation input passed to an artifact writer.
+
+    Args:
+        context: Mutable operation context shared with hooks.
+        source: Source description supplied for this operation.
+        target: Planned data artifact descriptor for the writer to materialise
+            or enrich.
+        storage_plan: Planned storage decision for the target.
+    """
+
+    context: OperationContext
+    source: OperationSource
+    target: ArtifactDescriptor
+    storage_plan: StoragePlan
+
+    @property
+    def locator(self) -> ArtifactLocator:
+        """Return the planned target locator for path-oriented writers."""
+        if self.target.locator is None:
+            raise ValueError(f"artifact write target {self.target.id!r} has no locator")
+        return self.target.locator
 
 
 @runtime_checkable
@@ -643,6 +663,7 @@ __all__ = [
     "AfterValidateMetadataHook",
     "AfterRecordWriteHook",
     "ArtifactWriter",
+    "ArtifactWriteRequest",
     "BeforeCommitHook",
     "BeforeValidateMetadataHook",
     "BeforeRecordWriteHook",

--- a/src/ogcat/hooks.py
+++ b/src/ogcat/hooks.py
@@ -202,13 +202,14 @@ class RollbackRegistrar(Protocol):
 class OperationSource:
     """Description of the source envelope for a catalog operation.
 
-    ``OperationSource`` is a compatibility and provenance DTO for current
-    operation helpers. Future reader/source dispatch should prefer
-    descriptor claims and facets on ``artifact`` over the legacy ``kind``
-    string whenever a descriptor is available.
+    ``OperationSource`` is a compatibility and provenance container for current
+    operation helpers. Its modern replacement is a source
+    ``ArtifactDescriptor`` plus a selected reader and converter plan. New
+    dispatch should prefer descriptor claims and facets on ``artifact`` over
+    the ``kind`` string whenever a descriptor is available.
 
     Args:
-        kind: Legacy short source kind, such as ``"local_file"`` or
+        kind: Compatibility source label, such as ``"local_file"`` or
             ``"external"``.
         path: Optional local source path.
         descriptor: Optional non-path source description or URI.

--- a/src/ogcat/materialization.py
+++ b/src/ogcat/materialization.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from ogcat.hooks import ArtifactWriter
+from ogcat.hooks import ArtifactMaterializer
 from ogcat.models import ArtifactLocator
 from ogcat.operation_helpers import adapter_name, directory_from_locator, filename_from_locator
 from ogcat.storage import (
@@ -23,7 +23,8 @@ class MaterializationIntent:
     """Operation intent for artifact materialization.
 
     Args:
-        writer: Optional writer used to materialize artifact data.
+        materializer: Optional operation materializer used to materialize
+            artifact data.
         target_kind: Whether the materialized target is file-like or
             directory-like.
         write_mode: How the target is materialized, or ``"reference"`` when no
@@ -32,7 +33,7 @@ class MaterializationIntent:
             owned for storage-plan metadata.
     """
 
-    writer: ArtifactWriter | None
+    materializer: ArtifactMaterializer | None
     target_kind: TargetKind
     write_mode: WriteMode
     ogcat_owned: bool
@@ -100,19 +101,19 @@ class MaterializationPlan:
 def reference_intent() -> MaterializationIntent:
     """Return the materialization intent for record-only references."""
     return MaterializationIntent(
-        writer=None,
+        materializer=None,
         target_kind="file",
         write_mode="reference",
         ogcat_owned=False,
     )
 
 
-def writer_intent(writer: ArtifactWriter) -> MaterializationIntent:
-    """Return the materialization intent declared by a writer."""
+def materializer_intent(materializer: ArtifactMaterializer) -> MaterializationIntent:
+    """Return the materialization intent declared by an operation materializer."""
     return MaterializationIntent(
-        writer=writer,
-        target_kind=target_kind_from_writer(writer),
-        write_mode=write_mode_from_writer(writer),
+        materializer=materializer,
+        target_kind=target_kind_from_materializer(materializer),
+        write_mode=write_mode_from_materializer(materializer),
         ogcat_owned=True,
     )
 
@@ -120,11 +121,11 @@ def writer_intent(writer: ArtifactWriter) -> MaterializationIntent:
 def storage_plan_intent(
     plan: StoragePlan,
     *,
-    writer: ArtifactWriter | None = None,
+    materializer: ArtifactMaterializer | None = None,
 ) -> MaterializationIntent:
     """Return materialization intent with an explicit storage plan as authority."""
     return MaterializationIntent(
-        writer=None if plan.write_mode == "reference" else writer,
+        materializer=None if plan.write_mode == "reference" else materializer,
         target_kind=plan.target_kind,
         write_mode=plan.write_mode,
         ogcat_owned=plan.ogcat_owned,
@@ -155,36 +156,39 @@ def materialization_plan_from_locator(
     )
 
 
-def validate_writer_matches_storage_plan(writer: ArtifactWriter, plan: StoragePlan) -> None:
-    """Raise when a writer declares target semantics that conflict with a plan."""
-    declared_target_kind = getattr(writer, "target_kind", plan.target_kind)
+def validate_materializer_matches_storage_plan(
+    materializer: ArtifactMaterializer,
+    plan: StoragePlan,
+) -> None:
+    """Raise when a materializer declares target semantics that conflict with a plan."""
+    declared_target_kind = getattr(materializer, "target_kind", plan.target_kind)
     if declared_target_kind in {"file", "directory"} and declared_target_kind != plan.target_kind:
         raise ValueError(
-            f"Artifact writer target_kind {declared_target_kind!r} does not match "
+            f"Artifact materializer target_kind {declared_target_kind!r} does not match "
             f"storage plan target_kind {plan.target_kind!r}."
         )
-    declared_write_mode = getattr(writer, "write_mode", plan.write_mode)
+    declared_write_mode = getattr(materializer, "write_mode", plan.write_mode)
     if (
         declared_write_mode in {"copy", "move", "write", "reference"}
         and declared_write_mode != plan.write_mode
     ):
         raise ValueError(
-            f"Artifact writer write_mode {declared_write_mode!r} does not match "
+            f"Artifact materializer write_mode {declared_write_mode!r} does not match "
             f"storage plan write_mode {plan.write_mode!r}."
         )
 
 
-def target_kind_from_writer(writer: ArtifactWriter) -> TargetKind:
-    """Infer a storage target kind from a writer when it declares one."""
-    target_kind = getattr(writer, "target_kind", "file")
+def target_kind_from_materializer(materializer: ArtifactMaterializer) -> TargetKind:
+    """Infer a storage target kind from a materializer when it declares one."""
+    target_kind = getattr(materializer, "target_kind", "file")
     if target_kind in {"file", "directory"}:
         return cast(TargetKind, target_kind)
     return "file"
 
 
-def write_mode_from_writer(writer: ArtifactWriter) -> WriteMode:
-    """Infer a storage write mode from a writer when it declares one."""
-    write_mode = getattr(writer, "write_mode", "write")
+def write_mode_from_materializer(materializer: ArtifactMaterializer) -> WriteMode:
+    """Infer a storage write mode from a materializer when it declares one."""
+    write_mode = getattr(materializer, "write_mode", "write")
     if write_mode in {"copy", "move", "write", "reference"}:
         return cast(WriteMode, write_mode)
     return "write"
@@ -194,12 +198,12 @@ __all__ = [
     "MaterializationIntent",
     "MaterializationPlan",
     "MaterializationTarget",
+    "materializer_intent",
     "materialization_plan_from_locator",
     "reference_intent",
     "storage_plan_intent",
     "target_from_locator",
-    "target_kind_from_writer",
-    "validate_writer_matches_storage_plan",
-    "write_mode_from_writer",
-    "writer_intent",
+    "target_kind_from_materializer",
+    "validate_materializer_matches_storage_plan",
+    "write_mode_from_materializer",
 ]

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -820,13 +820,16 @@ class CatalogRecord:
 
 @dataclass(slots=True, init=False)
 class ArtifactWriteResult:
-    """Transient writer output describing artifacts produced by an operation.
+    """Transient writer-capability output describing produced artifacts.
 
-    ``ArtifactWriteResult`` is not stored directly. Operation runners merge its
-    artifact descriptors into the catalog record and copy diagnostics and
-    provenance into operation audit details. Writers should use artifact claims
-    and facets for persisted descriptor facts, and use diagnostics/provenance
-    only for JSON-compatible operation audit context.
+    ``ArtifactWriteResult`` is not stored directly. Writer capabilities return
+    it to describe artifact facts produced while materializing an output
+    descriptor. Operation-scoped materializers may wrap those capabilities or
+    one-off functions, then pass the same result shape to operation runners.
+    Runners merge artifact descriptors into the catalog record and copy
+    diagnostics/provenance into operation audit details. Writers should use
+    artifact claims and facets for persisted descriptor facts, and use
+    diagnostics/provenance only for JSON-compatible operation audit context.
 
     Args:
         artifacts: Artifact descriptors produced or enriched by the writer.
@@ -855,6 +858,23 @@ class ArtifactWriteResult:
             {} if provenance is None else provenance,
             field_name="artifact_write_result.provenance",
         )
+
+    @property
+    def artifact(self) -> ArtifactDescriptor:
+        """Return the sole artifact descriptor in a single-output result.
+
+        Returns:
+            The only artifact descriptor in this result.
+
+        Raises:
+            ValueError: If the result has zero or multiple artifact
+                descriptors.
+        """
+        if len(self.artifacts) != 1:
+            raise ValueError(
+                f"ArtifactWriteResult.artifact requires exactly one artifact; got {len(self.artifacts)}"
+            )
+        return self.artifacts[0]
 
     @classmethod
     def for_data_artifact(

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path, PurePath
@@ -687,6 +687,9 @@ class ArtifactDescriptor:
         )
 
 
+ArtifactDescriptorInput: TypeAlias = ArtifactDescriptor | Mapping[str, object]
+
+
 @dataclass(slots=True)
 class CatalogRecord:
     """A single catalogued artifact record.
@@ -813,6 +816,121 @@ class CatalogRecord:
             derived_metadata=_coerce_metadata_dict(data.get("derived_metadata", {})),
             naming_metadata=_coerce_metadata_dict(data.get("naming_metadata", {})),
         )
+
+
+@dataclass(slots=True, init=False)
+class ArtifactWriteResult:
+    """Transient writer output describing artifacts produced by an operation.
+
+    ``ArtifactWriteResult`` is not stored directly. Operation runners merge its
+    artifact descriptors into the catalog record and copy diagnostics and
+    provenance into operation audit details. Writers should use artifact claims
+    and facets for persisted descriptor facts, and use diagnostics/provenance
+    only for JSON-compatible operation audit context.
+
+    Args:
+        artifacts: Artifact descriptors produced or enriched by the writer.
+        diagnostics: JSON-compatible diagnostic details for operation audit.
+        provenance: JSON-compatible provenance details for operation audit.
+    """
+
+    artifacts: tuple[ArtifactDescriptor, ...]
+    diagnostics: MetadataDict
+    provenance: MetadataDict
+
+    def __init__(
+        self,
+        artifacts: Iterable[ArtifactDescriptorInput] = (),
+        *,
+        diagnostics: Mapping[str, object] | None = None,
+        provenance: Mapping[str, object] | None = None,
+    ) -> None:
+        """Create a normalized artifact write result."""
+        self.artifacts = tuple(_coerce_artifact_descriptors(list(artifacts)))
+        self.diagnostics = normalize_metadata(
+            {} if diagnostics is None else diagnostics,
+            field_name="artifact_write_result.diagnostics",
+        )
+        self.provenance = normalize_metadata(
+            {} if provenance is None else provenance,
+            field_name="artifact_write_result.provenance",
+        )
+
+    @classmethod
+    def for_data_artifact(
+        cls,
+        *,
+        locator: ArtifactLocator | None = None,
+        state: str = "available",
+        relationship: Mapping[str, object] | None = None,
+        claims: Iterable[ArtifactClaimInput] = (),
+        facets: Iterable[ArtifactFacetInput] = (),
+        diagnostics: Mapping[str, object] | None = None,
+        provenance: Mapping[str, object] | None = None,
+    ) -> ArtifactWriteResult:
+        """Build a result that updates the operation's primary data artifact.
+
+        Args:
+            locator: Optional locator. When omitted, the operation runner uses
+                the planned target locator.
+            state: Availability state to store on the data descriptor.
+            relationship: Relationship metadata to merge into the data
+                descriptor.
+            claims: Claims produced by the writer.
+            facets: Facets produced by the writer.
+            diagnostics: Audit-only writer diagnostics.
+            provenance: Audit-only writer provenance.
+
+        Returns:
+            Result containing one ``data`` artifact descriptor.
+        """
+        return cls(
+            artifacts=(
+                ArtifactDescriptor(
+                    id=DATA_ARTIFACT_ID,
+                    role="data_artifact",
+                    locator=locator,
+                    state=state,
+                    relationship=normalize_metadata(
+                        {} if relationship is None else relationship,
+                        field_name="artifact_write_result.artifacts[data].relationship",
+                    ),
+                    claims=list(claims),
+                    facets=list(facets),
+                ),
+            ),
+            diagnostics=diagnostics,
+            provenance=provenance,
+        )
+
+    @classmethod
+    def from_artifact(
+        cls,
+        artifact: ArtifactDescriptorInput,
+        *,
+        diagnostics: Mapping[str, object] | None = None,
+        provenance: Mapping[str, object] | None = None,
+    ) -> ArtifactWriteResult:
+        """Build a result from one artifact descriptor."""
+        return cls(
+            artifacts=(artifact,),
+            diagnostics=diagnostics,
+            provenance=provenance,
+        )
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Convert the result to a JSON-compatible dictionary."""
+        return {
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "diagnostics": normalize_metadata(
+                self.diagnostics,
+                field_name="artifact_write_result.diagnostics",
+            ),
+            "provenance": normalize_metadata(
+                self.provenance,
+                field_name="artifact_write_result.provenance",
+            ),
+        }
 
 
 def _coerce_locator(

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -36,7 +36,7 @@ from ogcat.hooks import (
 from ogcat.materialization import (
     MaterializationIntent,
     materialization_plan_from_locator,
-    validate_writer_matches_storage_plan,
+    validate_materializer_matches_storage_plan,
 )
 from ogcat.models import (
     DATA_ARTIFACT_ID,
@@ -251,7 +251,7 @@ class AddOperationRunner(OperationRunner):
             raise
 
     def _build_context(self) -> OperationContext:
-        """Build the mutable context shared by add-operation hooks and writers."""
+        """Build the mutable context shared by add-operation hooks and materializers."""
         return OperationContext(
             catalog_root=self.dependencies.catalog_root,
             operation_id=self.request.transaction.operation_id,
@@ -362,7 +362,7 @@ class AddOperationRunner(OperationRunner):
         set_phase: _PhaseSetter,
     ) -> None:
         """Materialise or skip the artifact write for an add operation."""
-        writer = self.request.materialization_intent.writer
+        materializer = self.request.materialization_intent.materializer
         base_artifact = _planned_data_artifact(add_plan.locator)
         if add_plan.storage_plan.write_mode == "reference":
             add_plan.artifacts = (base_artifact,)
@@ -377,15 +377,15 @@ class AddOperationRunner(OperationRunner):
                 locator=add_plan.locator,
             )
             return
-        if writer is None:
+        if materializer is None:
             raise ValueError(
                 f"Storage plan with write mode {add_plan.storage_plan.write_mode!r} "
                 "requires an artifact_writer."
             )
-        validate_writer_matches_storage_plan(writer, add_plan.storage_plan)
+        validate_materializer_matches_storage_plan(materializer, add_plan.storage_plan)
 
         set_phase("artifact-write")
-        write_result = writer.write(
+        write_result = materializer.write(
             ArtifactWriteRequest(
                 context=add_plan.context,
                 source=add_plan.context.source,
@@ -395,20 +395,20 @@ class AddOperationRunner(OperationRunner):
         )
         if not isinstance(write_result, ArtifactWriteResult):
             raise TypeError(
-                "ArtifactWriter.write() must return an ArtifactWriteResult. "
+                "ArtifactMaterializer.write() must return an ArtifactWriteResult. "
                 "Use source_writer(), memory_writer(), or path_writer() to adapt "
                 "one-off functions that return None, metadata, or descriptors."
             )
-        add_plan.artifacts = _merge_writer_artifacts(base_artifact, write_result)
+        add_plan.artifacts = _merge_materializer_artifacts(base_artifact, write_result)
         write_details: dict[str, object] = {
             "write_phase": "artifact-write",
-            "writer_type": type(writer).__name__,
+            "materializer_type": type(materializer).__name__,
             "write_mode": add_plan.storage_plan.write_mode,
         }
         if write_result.diagnostics:
-            write_details["writer_diagnostics"] = write_result.diagnostics
+            write_details["materializer_diagnostics"] = write_result.diagnostics
         if write_result.provenance:
-            write_details["writer_provenance"] = write_result.provenance
+            write_details["materializer_provenance"] = write_result.provenance
         self.dependencies.emit_operation_audit(
             add_plan.context,
             event_type="write",
@@ -666,11 +666,11 @@ def _planned_data_artifact(locator: ArtifactLocator) -> ArtifactDescriptor:
     return ArtifactDescriptor(id=DATA_ARTIFACT_ID, role="data_artifact", locator=locator)
 
 
-def _merge_writer_artifacts(
+def _merge_materializer_artifacts(
     base_artifact: ArtifactDescriptor,
     result: ArtifactWriteResult,
 ) -> tuple[ArtifactDescriptor, ...]:
-    """Merge writer-produced descriptors over the planned data descriptor."""
+    """Merge materializer-produced descriptors over the planned data descriptor."""
     data_result: ArtifactDescriptor | None = None
     auxiliary: list[ArtifactDescriptor] = []
     seen_auxiliary_ids: set[str] = set()
@@ -679,36 +679,38 @@ def _merge_writer_artifacts(
         if artifact.id == DATA_ARTIFACT_ID:
             if artifact.role != "data_artifact":
                 raise ValueError(
-                    f"writer result artifact {DATA_ARTIFACT_ID!r} must use role 'data_artifact', "
+                    f"materializer result artifact {DATA_ARTIFACT_ID!r} must use role 'data_artifact', "
                     f"got {artifact.role!r}"
                 )
             data_result = artifact
             continue
         if artifact.role == "data_artifact":
             raise ValueError(
-                "writer result may only describe the operation data artifact with "
+                "materializer result may only describe the operation data artifact with "
                 f"id {DATA_ARTIFACT_ID!r}; got id {artifact.id!r}"
             )
         if artifact.id in seen_auxiliary_ids:
-            raise ValueError(f"writer result contains duplicate artifact id: {artifact.id!r}")
+            raise ValueError(f"materializer result contains duplicate artifact id: {artifact.id!r}")
         seen_auxiliary_ids.add(artifact.id)
         auxiliary.append(_normalize_descriptor_schema(artifact))
 
     data_artifact = (
         _normalize_descriptor_schema(base_artifact)
         if data_result is None
-        else _merge_data_artifact(base_artifact, data_result)
+        else _merge_materialized_data_artifact(base_artifact, data_result)
     )
     return (data_artifact, *auxiliary)
 
 
-def _merge_data_artifact(
+def _merge_materialized_data_artifact(
     base_artifact: ArtifactDescriptor,
     result_artifact: ArtifactDescriptor,
 ) -> ArtifactDescriptor:
-    """Merge a writer-produced data descriptor over the planned base descriptor."""
+    """Merge a materializer-produced data descriptor over the planned base descriptor."""
     if result_artifact.locator is not None and result_artifact.locator != base_artifact.locator:
-        raise ValueError("writer result data artifact locator must match the planned locator or be omitted")
+        raise ValueError(
+            "materializer result data artifact locator must match the planned locator or be omitted"
+        )
     return ArtifactDescriptor(
         id=DATA_ARTIFACT_ID,
         role="data_artifact",

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -16,15 +16,17 @@ separately testable and replaceable by future sibling runners.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Protocol
 
+from ogcat.artifact_claims import claim_key, facet_key
 from ogcat.audit import add_operation_note
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
 from ogcat.hooks import (
     HOOK_PHASES,
+    ArtifactWriteRequest,
     HookDispatcher,
     HookLifecycleCallback,
     HookManager,
@@ -36,7 +38,18 @@ from ogcat.materialization import (
     materialization_plan_from_locator,
     validate_writer_matches_storage_plan,
 )
-from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
+from ogcat.models import (
+    DATA_ARTIFACT_ID,
+    ArtifactClaimInput,
+    ArtifactDescriptor,
+    ArtifactFacetInput,
+    ArtifactLocator,
+    ArtifactWriteResult,
+    CatalogRecord,
+    JsonValue,
+    MetadataDict,
+    normalize_metadata,
+)
 from ogcat.operation_helpers import (
     artifact_locator_from_context,
     naming_metadata_from_storage_plan,
@@ -100,6 +113,7 @@ class ArtifactRecordBuilder(Protocol):
         original_path: str | Path | None = None,
         original_filename: str | None = None,
         suffixes: list[str] | None = None,
+        artifacts: list[ArtifactDescriptor] | None = None,
         derived_metadata: Mapping[Any, Any] | None = None,
         naming_metadata: Mapping[Any, Any] | None = None,
         time_added: str | None = None,
@@ -155,6 +169,7 @@ class _AddOperationPlan:
     locator: ArtifactLocator
     storage_plan: StoragePlan
     validation_report: ValidationReport
+    artifacts: tuple[ArtifactDescriptor, ...] = ()
 
 
 class OperationRunner(ABC):
@@ -348,7 +363,9 @@ class AddOperationRunner(OperationRunner):
     ) -> None:
         """Materialise or skip the artifact write for an add operation."""
         writer = self.request.materialization_intent.writer
+        base_artifact = _planned_data_artifact(add_plan.locator)
         if add_plan.storage_plan.write_mode == "reference":
+            add_plan.artifacts = (base_artifact,)
             self.dependencies.emit_operation_audit(
                 add_plan.context,
                 event_type="write",
@@ -368,16 +385,35 @@ class AddOperationRunner(OperationRunner):
         validate_writer_matches_storage_plan(writer, add_plan.storage_plan)
 
         set_phase("artifact-write")
-        writer.write(add_plan.context, add_plan.context.source, add_plan.locator)
+        write_result = writer.write(
+            ArtifactWriteRequest(
+                context=add_plan.context,
+                source=add_plan.context.source,
+                target=base_artifact,
+                storage_plan=add_plan.storage_plan,
+            )
+        )
+        if not isinstance(write_result, ArtifactWriteResult):
+            raise TypeError(
+                "ArtifactWriter.write() must return an ArtifactWriteResult. "
+                "Use source_writer(), memory_writer(), or path_writer() to adapt "
+                "one-off functions that return None, metadata, or descriptors."
+            )
+        add_plan.artifacts = _merge_writer_artifacts(base_artifact, write_result)
+        write_details: dict[str, object] = {
+            "write_phase": "artifact-write",
+            "writer_type": type(writer).__name__,
+            "write_mode": add_plan.storage_plan.write_mode,
+        }
+        if write_result.diagnostics:
+            write_details["writer_diagnostics"] = write_result.diagnostics
+        if write_result.provenance:
+            write_details["writer_provenance"] = write_result.provenance
         self.dependencies.emit_operation_audit(
             add_plan.context,
             event_type="write",
             message="Artifact write completed.",
-            details={
-                "write_phase": "artifact-write",
-                "writer_type": type(writer).__name__,
-                "write_mode": add_plan.storage_plan.write_mode,
-            },
+            details=write_details,
             locator=add_plan.locator,
         )
 
@@ -426,6 +462,7 @@ class AddOperationRunner(OperationRunner):
             original_path=self.request.original_path,
             original_filename=self.request.original_filename,
             suffixes=self.request.suffixes,
+            artifacts=list(add_plan.artifacts),
             derived_metadata=_metadata_with_hook_warnings(add_plan.context),
             naming_metadata=self.request.naming_metadata,
             time_added=self.request.time_added,
@@ -622,6 +659,100 @@ def _add_classification_metadata(context: OperationContext, locator: ArtifactLoc
         }
     elif existing is None:
         context.derived_metadata[CLASSIFICATION_METADATA_KEY] = classification
+
+
+def _planned_data_artifact(locator: ArtifactLocator) -> ArtifactDescriptor:
+    """Return the base descriptor for the operation's planned data artifact."""
+    return ArtifactDescriptor(id=DATA_ARTIFACT_ID, role="data_artifact", locator=locator)
+
+
+def _merge_writer_artifacts(
+    base_artifact: ArtifactDescriptor,
+    result: ArtifactWriteResult,
+) -> tuple[ArtifactDescriptor, ...]:
+    """Merge writer-produced descriptors over the planned data descriptor."""
+    data_result: ArtifactDescriptor | None = None
+    auxiliary: list[ArtifactDescriptor] = []
+    seen_auxiliary_ids: set[str] = set()
+
+    for artifact in result.artifacts:
+        if artifact.id == DATA_ARTIFACT_ID:
+            if artifact.role != "data_artifact":
+                raise ValueError(
+                    f"writer result artifact {DATA_ARTIFACT_ID!r} must use role 'data_artifact', "
+                    f"got {artifact.role!r}"
+                )
+            data_result = artifact
+            continue
+        if artifact.role == "data_artifact":
+            raise ValueError(
+                "writer result may only describe the operation data artifact with "
+                f"id {DATA_ARTIFACT_ID!r}; got id {artifact.id!r}"
+            )
+        if artifact.id in seen_auxiliary_ids:
+            raise ValueError(f"writer result contains duplicate artifact id: {artifact.id!r}")
+        seen_auxiliary_ids.add(artifact.id)
+        auxiliary.append(_normalize_descriptor_schema(artifact))
+
+    data_artifact = (
+        _normalize_descriptor_schema(base_artifact)
+        if data_result is None
+        else _merge_data_artifact(base_artifact, data_result)
+    )
+    return (data_artifact, *auxiliary)
+
+
+def _merge_data_artifact(
+    base_artifact: ArtifactDescriptor,
+    result_artifact: ArtifactDescriptor,
+) -> ArtifactDescriptor:
+    """Merge a writer-produced data descriptor over the planned base descriptor."""
+    if result_artifact.locator is not None and result_artifact.locator != base_artifact.locator:
+        raise ValueError("writer result data artifact locator must match the planned locator or be omitted")
+    return ArtifactDescriptor(
+        id=DATA_ARTIFACT_ID,
+        role="data_artifact",
+        locator=base_artifact.locator,
+        state=result_artifact.state,
+        relationship={**base_artifact.relationship, **result_artifact.relationship},
+        claims=_merge_claim_items(base_artifact.claims, result_artifact.claims),
+        facets=_merge_facet_items(base_artifact.facets, result_artifact.facets),
+    )
+
+
+def _normalize_descriptor_schema(artifact: ArtifactDescriptor) -> ArtifactDescriptor:
+    """Return a descriptor with deterministic claim and facet replacement."""
+    return ArtifactDescriptor(
+        id=artifact.id,
+        role=artifact.role,
+        locator=artifact.locator,
+        state=artifact.state,
+        relationship=artifact.relationship,
+        claims=_merge_claim_items((), artifact.claims),
+        facets=_merge_facet_items((), artifact.facets),
+    )
+
+
+def _merge_claim_items(
+    existing: Iterable[ArtifactClaimInput],
+    added: Iterable[ArtifactClaimInput],
+) -> list[ArtifactClaimInput]:
+    """Merge claim schema items by envelope, with later items replacing earlier ones."""
+    items_by_key: dict[tuple[str, str, str, str], ArtifactClaimInput] = {}
+    for item in [*existing, *added]:
+        items_by_key[claim_key(item)] = item
+    return list(items_by_key.values())
+
+
+def _merge_facet_items(
+    existing: Iterable[ArtifactFacetInput],
+    added: Iterable[ArtifactFacetInput],
+) -> list[ArtifactFacetInput]:
+    """Merge facet schema items by envelope, with later items replacing earlier ones."""
+    items_by_key: dict[tuple[str, str, str, str], ArtifactFacetInput] = {}
+    for item in [*existing, *added]:
+        items_by_key[facet_key(item)] = item
+    return list(items_by_key.values())
 
 
 def _validation_audit_level(report: ValidationReport) -> str:

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -2,8 +2,8 @@
 
 This module keeps storage decisions explicit without turning ``ogcat`` into a
 domain storage framework.  Plans describe where an artifact should live and how
-it should be materialised; :class:`ogcat.hooks.ArtifactWriter` implementations
-perform any side effects.
+it should be materialised; :class:`ogcat.hooks.ArtifactMaterializer`
+implementations perform any side effects.
 """
 
 from __future__ import annotations

--- a/src/ogcat/storage_planning.py
+++ b/src/ogcat/storage_planning.py
@@ -128,7 +128,7 @@ class PrimaryStoragePlanResult:
             Storage plan carrying the primary storage planning metadata.
         """
         intent = MaterializationIntent(
-            writer=None,
+            materializer=None,
             target_kind=target_kind,
             write_mode=write_mode,
             ogcat_owned=ogcat_owned,

--- a/src/ogcat/transactions.py
+++ b/src/ogcat/transactions.py
@@ -4,7 +4,7 @@ The TinyDB-backed implementation uses compensating rollback actions. This is a
 unit-of-work helper, not a true database transaction or ACID boundary.
 
 ``UnitOfWork`` coordinates record writes with cleanup callbacks registered by
-artifact writers and hooks. Staged work starts in ``PLANNED`` state, moves to
+artifact materializers and hooks. Staged work starts in ``PLANNED`` state, moves to
 ``STAGED`` when a record or rollback action is registered, and becomes
 ``COMMITTED`` only after all catalog and artifact work has succeeded. If the
 operation exits early, rollback actions run in reverse order and failures are

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -1,19 +1,22 @@
-"""Artifact writer helpers for lightweight catalog workflows.
+"""Artifact materializer helpers for lightweight catalog workflows.
 
-Writers bridge ``Catalog.add_artifact`` and concrete storage code. A writer is
-any object that satisfies :class:`ogcat.hooks.ArtifactWriter`: it exposes a
-``write(request)`` method, receives an :class:`ogcat.hooks.ArtifactWriteRequest`,
-and returns :class:`ogcat.models.ArtifactWriteResult` metadata for the produced
-artifact descriptors.
+Materializers bridge ``Catalog.add_artifact`` and concrete storage code. A
+materializer is any object that satisfies
+:class:`ogcat.hooks.ArtifactMaterializer`: it exposes a ``write(request)``
+method, receives an :class:`ogcat.hooks.ArtifactWriteRequest`, registers
+operation rollback, and returns :class:`ogcat.models.ArtifactWriteResult`
+metadata for the produced artifact descriptors.
 
 This module provides small adapters for common examples. ``source_writer`` wraps
 a function that accepts an ``OperationSource`` and target ``Path``.
 ``memory_writer`` and ``path_writer`` adapt narrower functions for in-memory
-payloads and local files. ``UnzipArtifactWriter`` is a concrete directory writer
-used by tutorials and tests. ``UnzipSingleFileArtifactWriter`` extracts one zip
-member to a file target. These helpers register rollback actions through the
-operation context before writing so partially-created targets can be cleaned up
-if the catalog operation fails.
+payloads and local files. ``UnzipArtifactWriter`` is a concrete directory
+materializer used by tutorials and tests. These historical class and function
+names still use "writer", but they are operation materializer adapters, not
+registry writer capabilities. ``UnzipSingleFileArtifactWriter`` extracts one
+zip member to a file target. These helpers register rollback actions through
+the operation context before writing so partially-created targets can be
+cleaned up if the catalog operation fails.
 """
 
 from __future__ import annotations
@@ -106,7 +109,7 @@ def path_source(
 
 @dataclass(frozen=True, slots=True)
 class FunctionArtifactWriter:
-    """Artifact writer adapter around a small Python function.
+    """Operation materializer adapter around a small Python function.
 
     The wrapped function receives an ``OperationSource`` and a local target
     path. It should write either a single file or a directory, matching
@@ -131,7 +134,7 @@ class FunctionArtifactWriter:
         """Write artifact data and register rollback for the created target."""
         source = request.source
         if self.source_kind is not None and source.kind != self.source_kind:
-            raise ValueError(f"writer requires source kind {self.source_kind!r}, got {source.kind!r}")
+            raise ValueError(f"materializer requires source kind {self.source_kind!r}, got {source.kind!r}")
 
         target_path = _target_path(request.locator)
         _prepare_empty_target(target_path, self.target_kind)
@@ -145,7 +148,7 @@ class FunctionArtifactWriter:
 
 @dataclass(frozen=True, slots=True)
 class CopyArtifactWriter:
-    """Artifact writer that copies a local source path to a storage target."""
+    """Operation materializer that copies a local source path to a target."""
 
     source_kind: str = "local_file"
     target_kind: ClassVar[TargetKind] = "file"
@@ -155,9 +158,11 @@ class CopyArtifactWriter:
         """Copy a local source path to the target and register rollback."""
         source = request.source
         if source.kind != self.source_kind or source.path is None:
-            raise ValueError(f"copy writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+            raise ValueError(
+                f"copy materializer requires OperationSource(kind={self.source_kind!r}, path=...)"
+            )
         if self.target_kind != "file":
-            raise ValueError("copy writer currently supports file targets only")
+            raise ValueError("copy materializer currently supports file targets only")
         target = request.locator
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
@@ -176,7 +181,7 @@ class CopyArtifactWriter:
 
 @dataclass(frozen=True, slots=True)
 class CopyDirectoryArtifactWriter:
-    """Artifact writer that copies a local source directory to a directory target."""
+    """Operation materializer that copies a local directory to a target."""
 
     source_kind: str = "local_file"
     target_kind: ClassVar[TargetKind] = "directory"
@@ -187,13 +192,13 @@ class CopyDirectoryArtifactWriter:
         source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
-                f"copy directory writer requires OperationSource(kind={self.source_kind!r}, path=...)"
+                f"copy directory materializer requires OperationSource(kind={self.source_kind!r}, path=...)"
             )
         if not source.path.is_dir():
-            raise ValueError(f"copy directory writer requires an existing directory: {source.path}")
+            raise ValueError(f"copy directory materializer requires an existing directory: {source.path}")
         target = request.locator
         if target.kind != "path":
-            raise ValueError("copy directory writer currently requires a path-backed target")
+            raise ValueError("copy directory materializer currently requires a path-backed target")
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
@@ -212,7 +217,7 @@ class CopyDirectoryArtifactWriter:
 
 @dataclass(frozen=True, slots=True)
 class MoveArtifactWriter:
-    """Artifact writer that moves a local source path to a storage target."""
+    """Operation materializer that moves a local source path to a target."""
 
     source_kind: str = "local_file"
     target_kind: ClassVar[TargetKind] = "file"
@@ -222,12 +227,16 @@ class MoveArtifactWriter:
         """Move a local source path to the target and register rollback."""
         source = request.source
         if source.kind != self.source_kind or source.path is None:
-            raise ValueError(f"move writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+            raise ValueError(
+                f"move materializer requires OperationSource(kind={self.source_kind!r}, path=...)"
+            )
         target = request.locator
         if target.kind != "path":
-            raise ValueError("move writer currently requires a path-backed target for rollback-safe moves")
+            raise ValueError(
+                "move materializer currently requires a path-backed target for rollback-safe moves"
+            )
         if self.target_kind != "file":
-            raise ValueError("move writer currently supports file targets only")
+            raise ValueError("move materializer currently supports file targets only")
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
@@ -245,7 +254,7 @@ class MoveArtifactWriter:
 
 @dataclass(frozen=True, slots=True)
 class MoveDirectoryArtifactWriter:
-    """Artifact writer that moves a local source directory to a directory target."""
+    """Operation materializer that moves a local source directory to a target."""
 
     source_kind: str = "local_file"
     target_kind: ClassVar[TargetKind] = "directory"
@@ -256,13 +265,13 @@ class MoveDirectoryArtifactWriter:
         source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
-                f"move directory writer requires OperationSource(kind={self.source_kind!r}, path=...)"
+                f"move directory materializer requires OperationSource(kind={self.source_kind!r}, path=...)"
             )
         if not source.path.is_dir():
-            raise ValueError(f"move directory writer requires an existing directory: {source.path}")
+            raise ValueError(f"move directory materializer requires an existing directory: {source.path}")
         target = request.locator
         if target.kind != "path":
-            raise ValueError("move directory writer currently requires a path-backed target")
+            raise ValueError("move directory materializer currently requires a path-backed target")
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
@@ -319,7 +328,7 @@ def path_writer(
     def write_from_path(source: OperationSource, target: Path) -> FunctionWriteResult:
         """Write the source path to the target path."""
         if source.path is None:
-            raise ValueError("path writer requires source.path")
+            raise ValueError("path materializer requires source.path")
         return write_function(source.path, target)
 
     return source_writer(write_from_path, target_kind=target_kind, source_kind=source_kind)
@@ -330,7 +339,7 @@ def _adapt_function_write_result(
     *,
     request: ArtifactWriteRequest,
 ) -> ArtifactWriteResult:
-    """Adapt a convenience function return value to a structured writer result."""
+    """Adapt a convenience function return value to a materializer result."""
     if isinstance(result, ArtifactWriteResult):
         return result
     if isinstance(result, ArtifactDescriptor):
@@ -360,7 +369,9 @@ class UnzipArtifactWriter:
         """Extract a zip source into the target directory."""
         source = request.source
         if source.kind != self.source_kind or source.path is None:
-            raise ValueError(f"unzip writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+            raise ValueError(
+                f"unzip materializer requires OperationSource(kind={self.source_kind!r}, path=...)"
+            )
 
         target_dir = _target_path(request.locator)
         _prepare_empty_target(target_dir, "directory")
@@ -415,7 +426,8 @@ class UnzipSingleFileArtifactWriter:
         source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
-                f"single-file unzip writer requires OperationSource(kind={self.source_kind!r}, path=...)"
+                "single-file unzip materializer requires "
+                f"OperationSource(kind={self.source_kind!r}, path=...)"
             )
 
         target_path = _target_path(request.locator)
@@ -467,12 +479,12 @@ def _target_path(locator: ArtifactLocator) -> Path:
     """Return a path-backed locator target."""
     target_path = locator.as_path()
     if target_path is None:
-        raise ValueError("artifact writer requires a path-backed target locator")
+        raise ValueError("artifact materializer requires a path-backed target locator")
     return target_path
 
 
 def _prepare_empty_target(target_path: Path, target_kind: TargetKind) -> None:
-    """Prepare a target that this writer can safely remove on rollback."""
+    """Prepare a target that this materializer can safely remove on rollback."""
     if target_path.exists():
         raise FileExistsError(f"target {target_path} already exists")
     if target_kind == "file":

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -2,9 +2,9 @@
 
 Writers bridge ``Catalog.add_artifact`` and concrete storage code. A writer is
 any object that satisfies :class:`ogcat.hooks.ArtifactWriter`: it exposes a
-``write(context, source, target)`` method, receives an
-:class:`ogcat.hooks.OperationContext`, and materialises an
-:class:`ogcat.models.ArtifactLocator` from an :class:`ogcat.hooks.OperationSource`.
+``write(request)`` method, receives an :class:`ogcat.hooks.ArtifactWriteRequest`,
+and returns :class:`ogcat.models.ArtifactWriteResult` metadata for the produced
+artifact descriptors.
 
 This module provides small adapters for common examples. ``source_writer`` wraps
 a function that accepts an ``OperationSource`` and target ``Path``.
@@ -20,13 +20,20 @@ from __future__ import annotations
 
 import shutil
 import zipfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, TypeAlias
 
-from ogcat.hooks import OperationContext, OperationSource
-from ogcat.models import ArtifactLocator, JsonValue, MetadataDict
+from ogcat.hooks import ArtifactWriteRequest, OperationSource
+from ogcat.models import (
+    ArtifactDescriptor,
+    ArtifactLocator,
+    ArtifactWriteResult,
+    JsonValue,
+    MetadataDict,
+    normalize_metadata,
+)
 from ogcat.storage import (
     TargetKind,
     WriteMode,
@@ -37,9 +44,10 @@ from ogcat.storage import (
     require_local_path,
 )
 
-SourceWriteFunction: TypeAlias = Callable[[OperationSource, Path], MetadataDict | None]
-MemoryWriteFunction: TypeAlias = Callable[[object, Path], MetadataDict | None]
-PathWriteFunction: TypeAlias = Callable[[Path, Path], MetadataDict | None]
+FunctionWriteResult: TypeAlias = ArtifactWriteResult | ArtifactDescriptor | Mapping[str, object] | None
+SourceWriteFunction: TypeAlias = Callable[[OperationSource, Path], FunctionWriteResult]
+MemoryWriteFunction: TypeAlias = Callable[[object, Path], FunctionWriteResult]
+PathWriteFunction: TypeAlias = Callable[[Path, Path], FunctionWriteResult]
 
 
 def memory_source(
@@ -103,7 +111,9 @@ class FunctionArtifactWriter:
     The wrapped function receives an ``OperationSource`` and a local target
     path. It should write either a single file or a directory, matching
     ``target_kind``. If it returns metadata, the metadata is merged into
-    ``context.derived_metadata``.
+    ``request.context.derived_metadata``. If it returns an
+    ``ArtifactDescriptor`` or ``ArtifactWriteResult``, that structured result is
+    returned to the operation runner.
 
     Args:
         write_function: Function that writes artifact data.
@@ -117,25 +127,20 @@ class FunctionArtifactWriter:
     source_kind: str | None = None
     write_mode: WriteMode = "write"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Write artifact data and register rollback for the created target."""
+        source = request.source
         if self.source_kind is not None and source.kind != self.source_kind:
             raise ValueError(f"writer requires source kind {self.source_kind!r}, got {source.kind!r}")
 
-        target_path = _target_path(target)
+        target_path = _target_path(request.locator)
         _prepare_empty_target(target_path, self.target_kind)
-        context.rollback(
+        request.context.rollback(
             lambda path=target_path, target_kind=self.target_kind: _remove_target(path, target_kind),
             description=f"remove written {self.target_kind} artifact {target_path}",
         )
-        metadata = self.write_function(source, target_path)
-        if metadata is not None:
-            context.derived_metadata.update(metadata)
+        result = self.write_function(source, target_path)
+        return _adapt_function_write_result(result, request=request)
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,21 +151,18 @@ class CopyArtifactWriter:
     target_kind: ClassVar[TargetKind] = "file"
     write_mode: ClassVar[WriteMode] = "copy"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Copy a local source path to the target and register rollback."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(f"copy writer requires OperationSource(kind={self.source_kind!r}, path=...)")
         if self.target_kind != "file":
             raise ValueError("copy writer currently supports file targets only")
+        target = request.locator
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         ensure_parent_directory(target, adapter=adapter)
-        context.rollback(
+        request.context.rollback(
             lambda locator=target, target_kind=self.target_kind, storage=adapter: remove_target(
                 locator,
                 target_kind=target_kind,
@@ -169,6 +171,7 @@ class CopyArtifactWriter:
             description=f"remove copied {self.target_kind} artifact {target.value}",
         )
         adapter.copy_from_path(source.path, target)
+        return ArtifactWriteResult.from_artifact(request.target)
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,26 +182,23 @@ class CopyDirectoryArtifactWriter:
     target_kind: ClassVar[TargetKind] = "directory"
     write_mode: ClassVar[WriteMode] = "copy"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Copy a local source directory to the target and register rollback."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
                 f"copy directory writer requires OperationSource(kind={self.source_kind!r}, path=...)"
             )
         if not source.path.is_dir():
             raise ValueError(f"copy directory writer requires an existing directory: {source.path}")
+        target = request.locator
         if target.kind != "path":
             raise ValueError("copy directory writer currently requires a path-backed target")
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
         ensure_parent_directory(target, adapter=adapter)
-        context.rollback(
+        request.context.rollback(
             lambda locator=target, storage=adapter: remove_target(
                 locator,
                 target_kind=self.target_kind,
@@ -207,6 +207,7 @@ class CopyDirectoryArtifactWriter:
             description=f"remove copied {self.target_kind} artifact {target.value}",
         )
         shutil.copytree(source.path, target_path)
+        return ArtifactWriteResult.from_artifact(request.target)
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,15 +218,12 @@ class MoveArtifactWriter:
     target_kind: ClassVar[TargetKind] = "file"
     write_mode: ClassVar[WriteMode] = "move"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Move a local source path to the target and register rollback."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(f"move writer requires OperationSource(kind={self.source_kind!r}, path=...)")
+        target = request.locator
         if target.kind != "path":
             raise ValueError("move writer currently requires a path-backed target for rollback-safe moves")
         if self.target_kind != "file":
@@ -234,7 +232,7 @@ class MoveArtifactWriter:
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
         ensure_parent_directory(target, adapter=adapter)
-        context.rollback(
+        request.context.rollback(
             lambda source_path=source.path, stored_path=target_path: _rollback_moved_file(
                 source_path=source_path,
                 target_path=stored_path,
@@ -242,6 +240,7 @@ class MoveArtifactWriter:
             description=f"restore moved file from {target_path} to {source.path}",
         )
         adapter.move_from_path(source.path, target)
+        return ArtifactWriteResult.from_artifact(request.target)
 
 
 @dataclass(frozen=True, slots=True)
@@ -252,26 +251,23 @@ class MoveDirectoryArtifactWriter:
     target_kind: ClassVar[TargetKind] = "directory"
     write_mode: ClassVar[WriteMode] = "move"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Move a local source directory to the target and register rollback."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
                 f"move directory writer requires OperationSource(kind={self.source_kind!r}, path=...)"
             )
         if not source.path.is_dir():
             raise ValueError(f"move directory writer requires an existing directory: {source.path}")
+        target = request.locator
         if target.kind != "path":
             raise ValueError("move directory writer currently requires a path-backed target")
         adapter = adapter_for_locator(target)
         ensure_target_absent(target, adapter=adapter)
         target_path = require_local_path(target)
         ensure_parent_directory(target, adapter=adapter)
-        context.rollback(
+        request.context.rollback(
             lambda source_path=source.path, stored_path=target_path: _rollback_moved_target(
                 source_path=source_path,
                 target_path=stored_path,
@@ -280,6 +276,7 @@ class MoveDirectoryArtifactWriter:
             description=f"restore moved {self.target_kind} from {target_path} to {source.path}",
         )
         shutil.move(str(source.path), str(target_path))
+        return ArtifactWriteResult.from_artifact(request.target)
 
 
 def source_writer(
@@ -304,7 +301,7 @@ def memory_writer(
 ) -> FunctionArtifactWriter:
     """Wrap a function that writes an in-memory payload to a target path."""
 
-    def write_from_memory(source: OperationSource, target: Path) -> MetadataDict | None:
+    def write_from_memory(source: OperationSource, target: Path) -> FunctionWriteResult:
         """Write the source payload to the target path."""
         return write_function(source.payload, target)
 
@@ -319,13 +316,36 @@ def path_writer(
 ) -> FunctionArtifactWriter:
     """Wrap a function that writes from a source path to a target path."""
 
-    def write_from_path(source: OperationSource, target: Path) -> MetadataDict | None:
+    def write_from_path(source: OperationSource, target: Path) -> FunctionWriteResult:
         """Write the source path to the target path."""
         if source.path is None:
             raise ValueError("path writer requires source.path")
         return write_function(source.path, target)
 
     return source_writer(write_from_path, target_kind=target_kind, source_kind=source_kind)
+
+
+def _adapt_function_write_result(
+    result: FunctionWriteResult,
+    *,
+    request: ArtifactWriteRequest,
+) -> ArtifactWriteResult:
+    """Adapt a convenience function return value to a structured writer result."""
+    if isinstance(result, ArtifactWriteResult):
+        return result
+    if isinstance(result, ArtifactDescriptor):
+        return ArtifactWriteResult.from_artifact(result)
+    if result is None:
+        return ArtifactWriteResult.from_artifact(request.target)
+    if isinstance(result, Mapping):
+        request.context.derived_metadata.update(
+            normalize_metadata(result, field_name="writer_metadata"),
+        )
+        return ArtifactWriteResult.from_artifact(request.target)
+    raise TypeError(
+        "writer function must return None, metadata, an ArtifactDescriptor, "
+        f"or an ArtifactWriteResult; got {type(result).__name__}"
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -336,19 +356,15 @@ class UnzipArtifactWriter:
     target_kind: ClassVar[TargetKind] = "directory"
     write_mode: ClassVar[WriteMode] = "write"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Extract a zip source into the target directory."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(f"unzip writer requires OperationSource(kind={self.source_kind!r}, path=...)")
 
-        target_dir = _target_path(target)
+        target_dir = _target_path(request.locator)
         _prepare_empty_target(target_dir, "directory")
-        context.rollback(
+        request.context.rollback(
             lambda path=target_dir: shutil.rmtree(path, ignore_errors=True),
             description=f"remove extracted directory {target_dir}",
         )
@@ -368,8 +384,15 @@ class UnzipArtifactWriter:
                     shutil.copyfileobj(source_file, target_file)
 
         extracted_names: list[JsonValue] = list(names)
-        context.derived_metadata["extracted_file_count"] = len(names)
-        context.derived_metadata["extracted_names"] = extracted_names
+        request.context.derived_metadata["extracted_file_count"] = len(names)
+        request.context.derived_metadata["extracted_names"] = extracted_names
+        return ArtifactWriteResult.from_artifact(
+            request.target,
+            diagnostics={
+                "extracted_file_count": len(names),
+                "extracted_names": extracted_names,
+            },
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -387,21 +410,17 @@ class UnzipSingleFileArtifactWriter:
     target_kind: ClassVar[TargetKind] = "file"
     write_mode: ClassVar[WriteMode] = "write"
 
-    def write(
-        self,
-        context: OperationContext,
-        source: OperationSource,
-        target: ArtifactLocator,
-    ) -> None:
+    def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         """Extract one zip source member to the target file."""
+        source = request.source
         if source.kind != self.source_kind or source.path is None:
             raise ValueError(
                 f"single-file unzip writer requires OperationSource(kind={self.source_kind!r}, path=...)"
             )
 
-        target_path = _target_path(target)
+        target_path = _target_path(request.locator)
         _prepare_empty_target(target_path, "file")
-        context.rollback(
+        request.context.rollback(
             lambda path=target_path: path.unlink(missing_ok=True),
             description=f"remove extracted file {target_path}",
         )
@@ -410,9 +429,17 @@ class UnzipSingleFileArtifactWriter:
             with archive.open(member) as source_file, target_path.open("wb") as target_file:
                 shutil.copyfileobj(source_file, target_file)
 
-        context.derived_metadata["extracted_file_count"] = 1
-        context.derived_metadata["extracted_name"] = member.filename
-        context.derived_metadata["extracted_size"] = member.file_size
+        request.context.derived_metadata["extracted_file_count"] = 1
+        request.context.derived_metadata["extracted_name"] = member.filename
+        request.context.derived_metadata["extracted_size"] = member.file_size
+        return ArtifactWriteResult.from_artifact(
+            request.target,
+            diagnostics={
+                "extracted_file_count": 1,
+                "extracted_name": member.filename,
+                "extracted_size": member.file_size,
+            },
+        )
 
 
 def _select_zip_member(archive: zipfile.ZipFile, *, member_name: str | None) -> zipfile.ZipInfo:
@@ -485,6 +512,7 @@ __all__ = [
     "CopyArtifactWriter",
     "CopyDirectoryArtifactWriter",
     "FunctionArtifactWriter",
+    "FunctionWriteResult",
     "MemoryWriteFunction",
     "MoveArtifactWriter",
     "MoveDirectoryArtifactWriter",

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -65,11 +65,13 @@ def memory_source(
 
     Args:
         data: In-memory object to pass to a memory writer.
-        kind: Legacy source kind used for materializer validation.
+        kind: Compatibility source label used for materializer validation.
         descriptor: Optional human-readable source description.
         metadata: Optional JSON-compatible source metadata.
         artifact: Optional descriptor for claim/facet-based capability
             selection when the payload represents an artifact-like source.
+            Runtime value/interface declarations are the expected replacement
+            for this helper when pipeline composition is implemented.
 
     Returns:
         An operation source with ``payload`` set to ``data``.
@@ -95,7 +97,7 @@ def path_source(
 
     Args:
         path: Local source path.
-        kind: Legacy source kind used for materializer validation.
+        kind: Compatibility source label used for materializer validation.
         descriptor: Optional human-readable source description. Defaults to the
             resolved source path string.
         metadata: Optional JSON-compatible source metadata.

--- a/src/ogcat/writers.py
+++ b/src/ogcat/writers.py
@@ -59,14 +59,17 @@ def memory_source(
     kind: str = "memory",
     descriptor: str | None = None,
     metadata: MetadataDict | None = None,
+    artifact: ArtifactDescriptor | None = None,
 ) -> OperationSource:
     """Build an operation source carrying an in-memory Python object.
 
     Args:
         data: In-memory object to pass to a memory writer.
-        kind: Source kind used for writer validation.
+        kind: Legacy source kind used for materializer validation.
         descriptor: Optional human-readable source description.
         metadata: Optional JSON-compatible source metadata.
+        artifact: Optional descriptor for claim/facet-based capability
+            selection when the payload represents an artifact-like source.
 
     Returns:
         An operation source with ``payload`` set to ``data``.
@@ -76,6 +79,7 @@ def memory_source(
         descriptor=descriptor,
         metadata={} if metadata is None else dict(metadata),
         payload=data,
+        artifact=artifact,
     )
 
 
@@ -85,15 +89,18 @@ def path_source(
     kind: str = "path",
     descriptor: str | None = None,
     metadata: MetadataDict | None = None,
+    artifact: ArtifactDescriptor | None = None,
 ) -> OperationSource:
     """Build an operation source carrying a local path.
 
     Args:
         path: Local source path.
-        kind: Source kind used for writer validation.
+        kind: Legacy source kind used for materializer validation.
         descriptor: Optional human-readable source description. Defaults to the
             resolved source path string.
         metadata: Optional JSON-compatible source metadata.
+        artifact: Optional descriptor for claim/facet-based reader, converter,
+            or writer capability selection.
 
     Returns:
         An operation source with ``path`` set to the resolved local path.
@@ -104,6 +111,7 @@ def path_source(
         path=source_path,
         descriptor=descriptor or str(source_path),
         metadata={} if metadata is None else dict(metadata),
+        artifact=artifact,
     )
 
 

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -108,7 +108,7 @@ def test_run_add_operation_delegates_to_operation_runner(
     assert request.operation_type == "add_artifact"
     assert request.record_type == "external_reference"
     assert request.metadata == {"title": "Delegated"}
-    assert request.materialization_intent.writer is None
+    assert request.materialization_intent.materializer is None
     assert request.materialization_intent.write_mode == "reference"
     assert request.materialization_intent.ogcat_owned is False
     assert record.id == "runner"
@@ -150,7 +150,7 @@ def test_add_file_application_request_uses_copy_materialization(
     assert request.materialization_intent.target_kind == "file"
     assert request.materialization_intent.write_mode == "copy"
     assert request.materialization_intent.ogcat_owned is True
-    assert type(request.materialization_intent.writer).__name__ == "CopyArtifactWriter"
+    assert type(request.materialization_intent.materializer).__name__ == "CopyArtifactWriter"
     assert len(request.secondary_artifact_operations) == 1
     assert request.secondary_artifact_operations[0].role == "template_link"
 
@@ -227,19 +227,19 @@ def test_add_file_uuid_primary_can_skip_template_link_secondary(
     assert request.secondary_artifact_operations == ()
 
 
-def test_add_artifact_application_request_uses_writer_materialization(
+def test_add_artifact_application_request_uses_materializer_intent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Writer-backed artifact requests carry target kind and write mode intent."""
+    """Materializer-backed artifact requests carry target kind and write mode intent."""
     requests: list[AddOperationRequest] = []
 
-    class DirectoryWriter:
+    class DirectoryMaterializer:
         target_kind = "directory"
         write_mode = "write"
 
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
-            raise AssertionError("fake runner should not invoke writer")
+            raise AssertionError("fake runner should not invoke materializer")
 
     class FakeRunner(OperationRunner):
         def __init__(self, request: AddOperationRequest) -> None:
@@ -258,7 +258,7 @@ def test_add_artifact_application_request_uses_writer_materialization(
         requests.append(request)
         return FakeRunner(request)
 
-    writer = DirectoryWriter()
+    materializer = DirectoryMaterializer()
     monkeypatch.setattr(Catalog, "_build_add_operation_runner", build_fake_runner)
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
@@ -266,12 +266,12 @@ def test_add_artifact_application_request_uses_writer_materialization(
         record_type="zarr_store",
         locator=ArtifactLocator.path(tmp_path / "store.zarr"),
         source=OperationSource(kind="memory", descriptor="generated"),
-        artifact_writer=writer,
+        artifact_writer=materializer,
     )
 
     request = requests[0]
     assert request.operation_type == "add_artifact"
-    assert request.materialization_intent.writer is writer
+    assert request.materialization_intent.materializer is materializer
     assert request.materialization_intent.target_kind == "directory"
     assert request.materialization_intent.write_mode == "write"
     assert request.materialization_intent.ogcat_owned is True
@@ -446,15 +446,15 @@ def test_record_only_add_artifact_skips_artifact_write(tmp_path: Path) -> None:
     assert catalog.repository.all() == [record]
 
 
-def test_explicit_reference_storage_plan_skips_artifact_writer(tmp_path: Path) -> None:
-    """Explicit reference plans are authoritative and do not run supplied writers."""
+def test_explicit_reference_storage_plan_skips_materializer(tmp_path: Path) -> None:
+    """Explicit reference plans are authoritative and do not run supplied materializers."""
 
-    class ExplodingWriter:
+    class ExplodingMaterializer:
         target_kind = "file"
         write_mode = "write"
 
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
-            raise AssertionError("reference storage plan should skip the writer")
+            raise AssertionError("reference storage plan should skip the materializer")
 
     target = tmp_path / "planned.txt"
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
@@ -463,29 +463,29 @@ def test_explicit_reference_storage_plan_skips_artifact_writer(tmp_path: Path) -
         record_type="planned_reference",
         storage_plan=StoragePlan(locator=ArtifactLocator.path(target), write_mode="reference"),
         source=OperationSource(kind="text", descriptor="record only"),
-        artifact_writer=ExplodingWriter(),
+        artifact_writer=ExplodingMaterializer(),
     )
 
     assert record.locator == ArtifactLocator.path(target)
     assert not target.exists()
 
 
-def test_explicit_storage_plan_rejects_writer_write_mode_mismatch(tmp_path: Path) -> None:
-    """Writer-declared write modes must match authoritative explicit plans."""
+def test_explicit_storage_plan_rejects_materializer_write_mode_mismatch(tmp_path: Path) -> None:
+    """Materializer-declared write modes must match authoritative explicit plans."""
 
-    class CopyDeclaredWriter:
+    class CopyDeclaredMaterializer:
         target_kind = "file"
         write_mode = "copy"
 
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
-            raise AssertionError("mismatched writer should fail before writing")
+            raise AssertionError("mismatched materializer should fail before writing")
 
     target = tmp_path / "planned.txt"
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
     with pytest.raises(
         ValueError,
-        match="Artifact writer write_mode 'copy' does not match storage plan write_mode 'move'",
+        match="Artifact materializer write_mode 'copy' does not match storage plan write_mode 'move'",
     ):
         catalog.add_artifact(
             record_type="planned_move",
@@ -495,22 +495,24 @@ def test_explicit_storage_plan_rejects_writer_write_mode_mismatch(tmp_path: Path
                 ogcat_owned=True,
             ),
             source=OperationSource(kind="text", descriptor="planned move"),
-            artifact_writer=CopyDeclaredWriter(),
+            artifact_writer=CopyDeclaredMaterializer(),
         )
 
     assert not target.exists()
 
 
-def test_writer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path) -> None:
-    """Writer-backed add_artifact writes the target and persists writer metadata."""
+def test_materializer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path) -> None:
+    """Materializer-backed add_artifact writes the target and persists metadata."""
 
-    class TextWriter:
+    class TextMaterializer:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text(str(request.source.metadata["text"]), encoding="utf-8")
-            request.context.derived_metadata["writer_text_length"] = len(str(request.source.metadata["text"]))
+            request.context.derived_metadata["materialized_text_length"] = len(
+                str(request.source.metadata["text"])
+            )
             return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "outputs" / "generated.txt"
@@ -520,18 +522,18 @@ def test_writer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path)
         record_type="generated_text",
         locator=ArtifactLocator.path(target),
         source=OperationSource(kind="text", descriptor="inline text", metadata={"text": "hello"}),
-        artifact_writer=TextWriter(),
+        artifact_writer=TextMaterializer(),
     )
 
     assert target.read_text(encoding="utf-8") == "hello"
-    assert record.derived_metadata["writer_text_length"] == 5
+    assert record.derived_metadata["materialized_text_length"] == 5
 
 
-def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path) -> None:
-    """A post-write hook failure rolls back writer cleanup and the staged record."""
+def test_hook_failure_after_materializer_rolls_back_artifact_and_record(tmp_path: Path) -> None:
+    """A post-write hook failure rolls back materializer cleanup and the staged record."""
     rollback_calls: list[str] = []
 
-    class TextWriter:
+    class TextMaterializer:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             target_path = request.locator.as_path()
             assert target_path is not None
@@ -539,7 +541,7 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
             target_path.write_text("created", encoding="utf-8")
 
             def rollback() -> None:
-                rollback_calls.append("writer")
+                rollback_calls.append("materializer")
                 target_path.unlink(missing_ok=True)
 
             request.context.rollback(rollback, description="remove generated text")
@@ -547,7 +549,7 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
 
     class FailingHook:
         def before_record_write(self, context: OperationContext) -> None:
-            raise RuntimeError("stop after writer")
+            raise RuntimeError("stop after materializer")
 
     target = tmp_path / "outputs" / "generated.txt"
     catalog = Catalog.create(
@@ -556,15 +558,15 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
         plugins=PluginRegistry([FailingHook()]),
     )
 
-    with pytest.raises(RuntimeError, match="stop after writer"):
+    with pytest.raises(RuntimeError, match="stop after materializer"):
         catalog.add_artifact(
             record_type="generated_text",
             locator=ArtifactLocator.path(target),
             source=OperationSource(kind="text", descriptor="inline text"),
-            artifact_writer=TextWriter(),
+            artifact_writer=TextMaterializer(),
         )
 
-    assert rollback_calls == ["writer"]
+    assert rollback_calls == ["materializer"]
     assert not target.exists()
     assert catalog.repository.all() == []
 
@@ -667,9 +669,9 @@ def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path:
         def resolve_artifact_locator(self, context: OperationContext) -> None:
             calls.append("resolve_artifact_locator")
 
-    class TextWriter:
+    class TextMaterializer:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
-            calls.append("writer")
+            calls.append("materializer")
             target_path = request.locator.as_path()
             assert target_path is not None
             target_path.write_text("should not happen", encoding="utf-8")
@@ -699,7 +701,7 @@ def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path:
             locator=ArtifactLocator.path(target),
             metadata={},
             source=OperationSource(kind="text", descriptor="inline text"),
-            artifact_writer=TextWriter(),
+            artifact_writer=TextMaterializer(),
         )
 
     assert calls == ["before_validate_metadata", "after_validate_metadata:False"]
@@ -707,7 +709,7 @@ def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path:
     assert catalog.repository.all() == []
 
 
-def test_derived_metadata_from_writer_extract_hook_and_record_hook_persists(tmp_path: Path) -> None:
+def test_derived_metadata_from_materializer_extract_hook_and_record_hook_persists(tmp_path: Path) -> None:
     """Derived metadata mutations from write, extract, and record phases persist."""
 
     class MetadataHook:
@@ -717,13 +719,13 @@ def test_derived_metadata_from_writer_extract_hook_and_record_hook_persists(tmp_
         def before_record_write(self, context: OperationContext) -> None:
             context.derived_metadata["record_hook"] = context.record_type
 
-    class TextWriter:
+    class TextMaterializer:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text("payload", encoding="utf-8")
-            request.context.derived_metadata["writer"] = request.source.kind
+            request.context.derived_metadata["materializer"] = request.source.kind
             return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "outputs" / "metadata.txt"
@@ -737,19 +739,19 @@ def test_derived_metadata_from_writer_extract_hook_and_record_hook_persists(tmp_
         record_type="generated_text",
         locator=ArtifactLocator.path(target),
         source=OperationSource(kind="text", descriptor="inline text"),
-        artifact_writer=TextWriter(),
+        artifact_writer=TextMaterializer(),
     )
 
-    assert record.derived_metadata["writer"] == "text"
+    assert record.derived_metadata["materializer"] == "text"
     assert record.derived_metadata["extract_hook"] is True
     assert record.derived_metadata["record_hook"] == "generated_text"
 
 
-def test_writer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: Path) -> None:
-    """A failing writer rolls back registered cleanup before any record exists."""
+def test_materializer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: Path) -> None:
+    """A failing materializer rolls back registered cleanup before any record exists."""
     rollback_calls: list[str] = []
 
-    class FailingWriter:
+    class FailingMaterializer:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             target_path = request.locator.as_path()
             assert target_path is not None
@@ -757,23 +759,23 @@ def test_writer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: 
             target_path.write_text("partial", encoding="utf-8")
 
             def rollback() -> None:
-                rollback_calls.append("writer")
+                rollback_calls.append("materializer")
                 target_path.unlink(missing_ok=True)
 
-            request.context.rollback(rollback, description="remove partial writer output")
-            raise OSError("writer failed")
+            request.context.rollback(rollback, description="remove partial materializer output")
+            raise OSError("materializer failed")
 
     target = tmp_path / "outputs" / "partial.txt"
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
 
-    with pytest.raises(OSError, match="writer failed"):
+    with pytest.raises(OSError, match="materializer failed"):
         catalog.add_artifact(
             record_type="generated_text",
             locator=ArtifactLocator.path(target),
             source=OperationSource(kind="text", descriptor="inline text"),
-            artifact_writer=FailingWriter(),
+            artifact_writer=FailingMaterializer(),
         )
 
-    assert rollback_calls == ["writer"]
+    assert rollback_calls == ["materializer"]
     assert not target.exists()
     assert catalog.repository.all() == []

--- a/tests/test_add_operation_lifecycle.py
+++ b/tests/test_add_operation_lifecycle.py
@@ -6,6 +6,8 @@ import pytest
 
 from ogcat import (
     ArtifactLocator,
+    ArtifactWriteRequest,
+    ArtifactWriteResult,
     Catalog,
     CatalogRecord,
     CatalogSpec,
@@ -236,12 +238,7 @@ def test_add_artifact_application_request_uses_writer_materialization(
         target_kind = "directory"
         write_mode = "write"
 
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             raise AssertionError("fake runner should not invoke writer")
 
     class FakeRunner(OperationRunner):
@@ -456,12 +453,7 @@ def test_explicit_reference_storage_plan_skips_artifact_writer(tmp_path: Path) -
         target_kind = "file"
         write_mode = "write"
 
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             raise AssertionError("reference storage plan should skip the writer")
 
     target = tmp_path / "planned.txt"
@@ -485,12 +477,7 @@ def test_explicit_storage_plan_rejects_writer_write_mode_mismatch(tmp_path: Path
         target_kind = "file"
         write_mode = "copy"
 
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             raise AssertionError("mismatched writer should fail before writing")
 
     target = tmp_path / "planned.txt"
@@ -518,17 +505,13 @@ def test_writer_backed_add_artifact_writes_and_persists_metadata(tmp_path: Path)
     """Writer-backed add_artifact writes the target and persists writer metadata."""
 
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
-            target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
-            context.derived_metadata["writer_text_length"] = len(str(source.metadata["text"]))
+            target_path.write_text(str(request.source.metadata["text"]), encoding="utf-8")
+            request.context.derived_metadata["writer_text_length"] = len(str(request.source.metadata["text"]))
+            return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "outputs" / "generated.txt"
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
@@ -549,13 +532,8 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
     rollback_calls: list[str] = []
 
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text("created", encoding="utf-8")
@@ -564,7 +542,8 @@ def test_hook_failure_after_writer_rolls_back_artifact_and_record(tmp_path: Path
                 rollback_calls.append("writer")
                 target_path.unlink(missing_ok=True)
 
-            context.rollback(rollback, description="remove generated text")
+            request.context.rollback(rollback, description="remove generated text")
+            return ArtifactWriteResult.from_artifact(request.target)
 
     class FailingHook:
         def before_record_write(self, context: OperationContext) -> None:
@@ -689,16 +668,12 @@ def test_validation_failure_runs_after_validate_and_stops_before_write(tmp_path:
             calls.append("resolve_artifact_locator")
 
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
             calls.append("writer")
-            target_path = target.as_path()
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.write_text("should not happen", encoding="utf-8")
+            return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "outputs" / "generated.txt"
     catalog = Catalog.create(
@@ -743,17 +718,13 @@ def test_derived_metadata_from_writer_extract_hook_and_record_hook_persists(tmp_
             context.derived_metadata["record_hook"] = context.record_type
 
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text("payload", encoding="utf-8")
-            context.derived_metadata["writer"] = source.kind
+            request.context.derived_metadata["writer"] = request.source.kind
+            return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "outputs" / "metadata.txt"
     catalog = Catalog.create(
@@ -779,13 +750,8 @@ def test_writer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: 
     rollback_calls: list[str] = []
 
     class FailingWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text("partial", encoding="utf-8")
@@ -794,7 +760,7 @@ def test_writer_failure_runs_registered_rollback_and_leaves_no_record(tmp_path: 
                 rollback_calls.append("writer")
                 target_path.unlink(missing_ok=True)
 
-            context.rollback(rollback, description="remove partial writer output")
+            request.context.rollback(rollback, description="remove partial writer output")
             raise OSError("writer failed")
 
     target = tmp_path / "outputs" / "partial.txt"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -8,6 +8,8 @@ import pytest
 
 from ogcat import (
     ArtifactLocator,
+    ArtifactWriteRequest,
+    ArtifactWriteResult,
     Catalog,
     CatalogSpec,
     HookManager,
@@ -702,20 +704,19 @@ def test_add_artifact_is_record_only_without_writer(tmp_path: Path) -> None:
 
 def test_plugin_writer_receives_source_and_target_and_persists_metadata(tmp_path: Path) -> None:
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
-            assert source.kind == "text"
+            assert request.source.kind == "text"
             target_path.parent.mkdir(parents=True, exist_ok=True)
-            target_path.write_text(str(source.metadata["text"]), encoding="utf-8")
-            context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove text")
-            context.derived_metadata["writer_source_kind"] = source.kind
-            context.derived_metadata["writer_target_name"] = target_path.name
+            target_path.write_text(str(request.source.metadata["text"]), encoding="utf-8")
+            request.context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description="remove text",
+            )
+            request.context.derived_metadata["writer_source_kind"] = request.source.kind
+            request.context.derived_metadata["writer_target_name"] = target_path.name
+            return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "out" / "artifact.txt"
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
@@ -734,17 +735,16 @@ def test_plugin_writer_receives_source_and_target_and_persists_metadata(tmp_path
 
 def test_plugin_writer_rollback_removes_created_artifact_after_hook_failure(tmp_path: Path) -> None:
     class TextWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text("created", encoding="utf-8")
-            context.rollback(lambda path=target_path: path.unlink(missing_ok=True), description="remove text")
+            request.context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description="remove text",
+            )
+            return ArtifactWriteResult.from_artifact(request.target)
 
     class FailingHook:
         def before_record_write(self, context: OperationContext) -> None:
@@ -773,15 +773,11 @@ def test_unzip_style_writer_persists_directory_metadata_and_rolls_back(tmp_path:
                 raise RuntimeError("fail after unzip")
 
     class UnzipWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            source = request.source
             if source.path is None:
                 raise ValueError("zip source path is required")
-            target_path = target.as_path()
+            target_path = request.locator.as_path()
             if target_path is None:
                 raise ValueError("zip target path is required")
 
@@ -790,13 +786,14 @@ def test_unzip_style_writer_persists_directory_metadata_and_rolls_back(tmp_path:
                 archive.extractall(target_path)
                 names = sorted(archive.namelist())
 
-            context.rollback(
+            request.context.rollback(
                 lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
                 description=f"remove extracted directory {target_path}",
             )
-            context.derived_metadata["file_count"] = len(names)
+            request.context.derived_metadata["file_count"] = len(names)
             extracted_names: list[JsonValue] = list(names)
-            context.derived_metadata["extracted_names"] = extracted_names
+            request.context.derived_metadata["extracted_names"] = extracted_names
+            return ArtifactWriteResult.from_artifact(request.target)
 
     archive_path = tmp_path / "source.zip"
     with zipfile.ZipFile(archive_path, "w") as archive:

--- a/tests/test_stdlib_io_capabilities.py
+++ b/tests/test_stdlib_io_capabilities.py
@@ -9,6 +9,7 @@ import pytest
 
 from ogcat.artifact_claims import has_claim, has_facet
 from ogcat.bundled_plugins.stdlib_io import (
+    DEFAULT_TEXT_ENCODING,
     bytes_artifact_descriptor,
     delimited_table_artifact_descriptor,
     delimiter_from_descriptor,
@@ -21,7 +22,14 @@ from ogcat.bundled_plugins.stdlib_io import (
     text_artifact_descriptor,
 )
 from ogcat.capabilities import ArtifactCapability, CapabilityKind, CapabilityRegistry, MissingCapabilityError
-from ogcat.models import ArtifactDescriptor, ArtifactFacet, ArtifactLocator, DataTypeClaim, InterfaceClaim
+from ogcat.models import (
+    ArtifactDescriptor,
+    ArtifactFacet,
+    ArtifactLocator,
+    ArtifactWriteResult,
+    DataTypeClaim,
+    InterfaceClaim,
+)
 from ogcat.plugins import PluginRegistry
 
 
@@ -32,9 +40,11 @@ def test_bytes_reader_and_writer_examples_round_trip_bytes(tmp_path: Path) -> No
     registry = _registry()
 
     writer = _implementation(_select(registry, descriptor, operation="write", interface="bytes"))
-    result = writer.write(descriptor, b"abc\x00def")
+    write_result = writer.write(descriptor, b"abc\x00def")
+    result = write_result.artifact
     reader = _implementation(_select(registry, result, operation="read", interface="bytes"))
 
+    assert isinstance(write_result, ArtifactWriteResult)
     assert path.read_bytes() == b"abc\x00def"
     assert reader.read(result) == b"abc\x00def"
     assert has_facet(result, kind="locator", name="path", namespace="ogcat.stdlib")
@@ -48,9 +58,9 @@ def test_text_reader_and_writer_examples_use_encoding_facets(tmp_path: Path) -> 
     override_descriptor = text_artifact_descriptor(tmp_path / "override.txt", encoding="ascii")
 
     writer = _implementation(_select(registry, ascii_descriptor, operation="write", interface="text"))
-    ascii_result = writer.write(ascii_descriptor, "plain ascii")
-    utf8_result = writer.write(utf8_descriptor, "hello 🙂")
-    override_result = writer.write(override_descriptor, "hello 🙂", encoding="utf-8")
+    ascii_result = writer.write(ascii_descriptor, "plain ascii").artifact
+    utf8_result = writer.write(utf8_descriptor, "hello 🙂").artifact
+    override_result = writer.write(override_descriptor, "hello 🙂", encoding="utf-8").artifact
     reader = _implementation(_select(registry, utf8_result, operation="read", interface="text"))
 
     assert (tmp_path / "ascii.txt").read_bytes() == b"plain ascii"
@@ -74,9 +84,9 @@ def test_delimited_table_reader_and_writer_examples_support_csv_and_options(
     rows = [{"station": "mhd", "value": "410.2"}, {"station": "tac", "value": "419.5"}]
 
     writer = _implementation(_select(registry, csv_descriptor, operation="write", interface="table"))
-    csv_result = writer.write(csv_descriptor, rows)
-    pipe_result = writer.write(pipe_descriptor, rows, delimiter="|")
-    override_result = writer.write(override_descriptor, rows, delimiter="|")
+    csv_result = writer.write(csv_descriptor, rows).artifact
+    pipe_result = writer.write(pipe_descriptor, rows, delimiter="|").artifact
+    override_result = writer.write(override_descriptor, rows, delimiter="|").artifact
     reader = _implementation(_select(registry, csv_result, operation="read", interface="table"))
     pipe_reader = _implementation(_select(registry, pipe_result, operation="read", interface="table"))
     override_reader = _implementation(_select(registry, override_result, operation="read", interface="table"))
@@ -124,11 +134,50 @@ def test_json_reader_and_writer_examples_round_trip_documents(tmp_path: Path) ->
     document = {"name": "example", "values": [1, 2, 3], "unicode": "🙂"}
 
     writer = _implementation(_select(registry, descriptor, operation="write", interface="json"))
-    result = writer.write(descriptor, document)
+    result = writer.write(descriptor, document).artifact
     reader = _implementation(_select(registry, result, operation="read", interface="json"))
 
     assert reader.read(result) == document
     assert has_claim(result, kind="data_type", name="json", namespace="iana.media-types")
+
+
+def test_delimited_table_to_json_converter_composes_reader_and_writer(tmp_path: Path) -> None:
+    """A CSV table can be read through table claims and written as JSON."""
+    registry = _registry()
+    source = delimited_table_artifact_descriptor(tmp_path / "input.csv")
+    source_path = source.locator.as_path() if source.locator is not None else None
+    assert source_path is not None
+    source_path.write_text("station,value\nmhd,410.2\ntac,419.5\n", encoding="utf-8")
+    output = json_artifact_descriptor(tmp_path / "output.json", id="json-output")
+
+    converter = _implementation(
+        registry.select(
+            kind=CapabilityKind.CONVERTER,
+            name="delimited-table-to-json-converter",
+            descriptor=source,
+            input_claims=[InterfaceClaim("table")],
+            output_claims=[InterfaceClaim("json")],
+        )
+    )
+    source_reader = _implementation(_select(registry, source, operation="read", interface="table"))
+    json_writer = _implementation(_select(registry, output, operation="write", interface="json"))
+    json_document = converter.convert(source_reader.read(source))
+    write_result = json_writer.write(
+        output,
+        json_document,
+        encoding=encoding_from_descriptor(output),
+    )
+    result = write_result.artifact
+    reader = _implementation(_select(registry, result, operation="read", interface="json"))
+
+    assert isinstance(write_result, ArtifactWriteResult)
+    assert reader.read(result) == [
+        {"station": "mhd", "value": "410.2"},
+        {"station": "tac", "value": "419.5"},
+    ]
+    assert has_claim(result, kind="data_type", name="json", namespace="iana.media-types")
+    assert has_claim(result, kind="interface", name="json")
+    assert has_facet(result, kind="locator", name="path", namespace="ogcat.stdlib")
 
 
 def test_emoticon_to_emoji_converter_writes_utf8_selectable_text(tmp_path: Path) -> None:
@@ -149,13 +198,15 @@ def test_emoticon_to_emoji_converter_writes_utf8_selectable_text(tmp_path: Path)
             name="emoticon-to-emoji-text-converter",
         )
     )
-    result = converter.convert(source, output)
+    source_reader = _implementation(_select(registry, source, operation="read", interface="text"))
+    writer = _implementation(_select(registry, output, operation="write", interface="text"))
+    converted = converter.convert(source_reader.read(source))
+    result = writer.write(output, converted, encoding=DEFAULT_TEXT_ENCODING).artifact
     reader = _implementation(_select(registry, result, operation="read", interface="text"))
 
     assert (tmp_path / "output.txt").read_text(encoding="utf-8") == "done 🙂"
     assert reader.read(result) == "done 🙂"
     assert result.relationship["catalogued"] is False
-    assert result.relationship["generated_by"] == "ogcat.stdlib.emoticon_to_emoji"
     assert has_claim(result, kind="interface", name="text")
     assert has_facet(result, kind="encoding", name="charset", namespace="ogcat.stdlib")
 
@@ -178,13 +229,40 @@ def test_pig_latin_converter_writes_utf8_selectable_text(tmp_path: Path) -> None
             name="pig-latin-text-converter",
         )
     )
-    result = converter.convert(source, output)
+    source_reader = _implementation(_select(registry, source, operation="read", interface="text"))
+    writer = _implementation(_select(registry, output, operation="write", interface="text"))
+    converted = converter.convert(source_reader.read(source))
+    result = writer.write(output, converted, encoding=DEFAULT_TEXT_ENCODING).artifact
     reader = _implementation(_select(registry, result, operation="read", interface="text"))
 
     assert reader.read(result) == "ellohay appleway skyay"
-    assert result.relationship["generated_by"] == "ogcat.stdlib.pig_latin"
     assert has_claim(result, kind="interface", name="text")
     assert has_facet(result, kind="encoding", name="charset", namespace="ogcat.stdlib")
+
+
+def test_text_converters_return_composable_runtime_values() -> None:
+    """Text converters should compose before a writer sinks the final value."""
+    registry = _registry()
+    emoji_converter = _implementation(
+        registry.select(
+            kind=CapabilityKind.CONVERTER,
+            name="emoticon-to-emoji-text-converter",
+            input_claims=[InterfaceClaim("text")],
+            output_claims=[InterfaceClaim("text")],
+        )
+    )
+    pig_latin_converter = _implementation(
+        registry.select(
+            kind=CapabilityKind.CONVERTER,
+            name="pig-latin-text-converter",
+            input_claims=[InterfaceClaim("text")],
+            output_claims=[InterfaceClaim("text")],
+        )
+    )
+
+    converted = pig_latin_converter.convert(emoji_converter.convert("hello :)"))
+
+    assert converted == "ellohay 🙂"
 
 
 def test_pig_latin_can_filter_csv_text_but_not_claim_table_output(tmp_path: Path) -> None:
@@ -205,7 +283,10 @@ def test_pig_latin_can_filter_csv_text_but_not_claim_table_output(tmp_path: Path
             name="pig-latin-text-converter",
         )
     )
-    result = converter.convert(source, output)
+    source_reader = _implementation(_select(registry, source, operation="read", interface="text"))
+    writer = _implementation(_select(registry, output, operation="write", interface="text"))
+    converted = converter.convert(source_reader.read(source))
+    result = writer.write(output, converted, encoding=DEFAULT_TEXT_ENCODING).artifact
     reader = _implementation(_select(registry, result, operation="read", interface="text"))
 
     assert reader.read(result) == "amenay,aluevay\nellohay,orldway\n"
@@ -320,7 +401,7 @@ def test_temporary_artifact_descriptor_can_be_used_for_selection(tmp_path: Path)
 
     selected = _select(registry, descriptor, operation="write", interface="text")
     writer = _implementation(selected)
-    result = writer.write(descriptor, "scratch")
+    result = writer.write(descriptor, "scratch").artifact
 
     assert descriptor.relationship == {"catalogued": False, "temporary": True}
     result_path = result.locator.as_path() if result.locator is not None else None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -164,7 +164,7 @@ def test_primary_storage_planner_builds_materialization_target(tmp_path: Path) -
     plan = MaterializationPlan(
         primary_target=target,
         intent=MaterializationIntent(
-            writer=None,
+            materializer=None,
             target_kind="directory",
             write_mode="write",
             ogcat_owned=True,
@@ -271,10 +271,10 @@ def test_primary_storage_planner_uuid_urlpath_root_has_remote_plan_metadata(tmp_
     assert plan.primary_location == "uuid"
 
 
-def test_locator_materialization_plan_supports_directory_writer_intent() -> None:
-    """Locator-backed writer materialization preserves target kind and adapter metadata."""
+def test_locator_materialization_plan_supports_directory_materializer_intent() -> None:
+    """Locator-backed materialization preserves target kind and adapter metadata."""
     intent = MaterializationIntent(
-        writer=None,
+        materializer=None,
         target_kind="directory",
         write_mode="write",
         ogcat_owned=True,
@@ -791,7 +791,7 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
     def fake_write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
         assert request.source.path == source_file
         assert request.locator.kind == "urlpath"
-        request.context.derived_metadata["writer"] = "redirected"
+        request.context.derived_metadata["materializer"] = "redirected"
         return ArtifactWriteResult.from_artifact(request.target)
 
     def fail_extract(path: Path) -> dict[str, object]:
@@ -810,7 +810,7 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
     record = catalog.add_file(source_file, operation="copy")
 
     assert record.locator.kind == "urlpath"
-    assert record.derived_metadata["writer"] == "redirected"
+    assert record.derived_metadata["materializer"] == "redirected"
     assert record.naming_metadata["storage_relative_path"] == "copied.nc"
     assert record.naming_metadata["resolved_directory"] == ""
     assert record.naming_metadata["resolved_filename"] == "copied.nc"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,8 +8,16 @@ import pytest
 
 import ogcat.catalog_application as catalog_application_module
 import ogcat.storage_planning as storage_planning
-from ogcat import ArtifactLocator, Catalog, CatalogSpec, PluginRegistry, RecordSchema
-from ogcat.hooks import OperationContext, OperationSource
+from ogcat import (
+    ArtifactLocator,
+    ArtifactWriteRequest,
+    ArtifactWriteResult,
+    Catalog,
+    CatalogSpec,
+    PluginRegistry,
+    RecordSchema,
+)
+from ogcat.hooks import OperationContext
 from ogcat.materialization import (
     MaterializationIntent,
     MaterializationPlan,
@@ -780,10 +788,11 @@ def test_add_file_hook_urlpath_redirect_updates_plan_and_skips_path_extractor(
             assert context.storage_plan.locator.kind == "urlpath"
             assert context.storage_plan.adapter == "fsspec"
 
-    def fake_write(self, context: OperationContext, source: OperationSource, target: ArtifactLocator) -> None:
-        assert source.path == source_file
-        assert target.kind == "urlpath"
-        context.derived_metadata["writer"] = "redirected"
+    def fake_write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+        assert request.source.path == source_file
+        assert request.locator.kind == "urlpath"
+        request.context.derived_metadata["writer"] = "redirected"
+        return ArtifactWriteResult.from_artifact(request.target)
 
     def fail_extract(path: Path) -> dict[str, object]:
         raise AssertionError(f"path extractor should not run for redirected target {path}")

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -2,20 +2,27 @@ from __future__ import annotations
 
 import shutil
 import zipfile
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
 
 import ogcat.writers as writers_module
 from ogcat import (
+    ArtifactDescriptor,
+    ArtifactFacet,
     ArtifactLocator,
+    ArtifactWriteRequest,
+    ArtifactWriteResult,
     Catalog,
     CatalogSpec,
     CopyArtifactWriter,
+    InterfaceClaim,
     MoveArtifactWriter,
     OperationSource,
     PluginRegistry,
     RecordSchema,
+    RepresentationClaim,
     UnzipArtifactWriter,
     UnzipSingleFileArtifactWriter,
     memory_source,
@@ -135,6 +142,300 @@ def test_source_writer_receives_full_operation_source(tmp_path: Path) -> None:
 
     assert target.read_text(encoding="utf-8") == "example"
     assert record.derived_metadata["source_kind"] == "structured"
+
+
+def test_memory_writer_adapts_none_return_to_base_result(tmp_path: Path) -> None:
+    """Convenience writers can wrap one-off functions that return None."""
+
+    def write_text(data: object, target: Path) -> None:
+        target.write_text(str(data), encoding="utf-8")
+
+    target = tmp_path / "none-result.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("hello"),
+        artifact_writer=memory_writer(write_text, target_kind="file"),
+    )
+
+    assert target.read_text(encoding="utf-8") == "hello"
+    assert [artifact.id for artifact in record.artifacts] == ["data"]
+    assert record.artifacts[0].locator == ArtifactLocator.path(target)
+
+
+def test_memory_writer_adapts_descriptor_return(tmp_path: Path) -> None:
+    """Convenience writers can wrap functions that return descriptor facts."""
+
+    def write_text(data: object, target: Path) -> ArtifactDescriptor:
+        target.write_text(str(data), encoding="utf-8")
+        return ArtifactDescriptor(
+            id="data",
+            role="data_artifact",
+            claims=[InterfaceClaim("text")],
+        )
+
+    target = tmp_path / "descriptor-result.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("hello"),
+        artifact_writer=memory_writer(write_text, target_kind="file"),
+    )
+
+    assert record.artifacts[0].claims == [
+        {
+            "kind": "interface",
+            "name": "text",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {},
+        }
+    ]
+
+
+def test_writer_result_merges_claims_facets_diagnostics_and_provenance(tmp_path: Path) -> None:
+    """Structured writer results enrich the data descriptor and audit event."""
+
+    class TextWriter:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
+            assert target_path is not None
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(str(request.source.payload), encoding="utf-8")
+            request.context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description="remove text result",
+            )
+            return ArtifactWriteResult.for_data_artifact(
+                relationship={"kind": "generated_from", "source": request.source.kind},
+                claims=[
+                    InterfaceClaim("text", evidence="inferred", metadata={"encoding": "unknown"}),
+                    InterfaceClaim("text", evidence="validated", metadata={"encoding": "utf-8"}),
+                ],
+                facets=[
+                    ArtifactFacet(kind="encoding", name="charset", metadata={"encoding": "ascii"}),
+                    ArtifactFacet(kind="encoding", name="charset", metadata={"encoding": "utf-8"}),
+                ],
+                diagnostics={"target_path": target_path, "checks": {"written", "encoded"}},
+                provenance={"source_descriptor": request.source.descriptor},
+            )
+
+    target = tmp_path / "structured.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("hello", kind="memory_text", descriptor="inline text"),
+        artifact_writer=TextWriter(),
+    )
+
+    data = record.artifacts[0]
+    assert data.relationship == {"kind": "generated_from", "source": "memory_text"}
+    assert data.claims == [
+        {
+            "kind": "interface",
+            "name": "text",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "validated",
+            "confidence": "validated",
+            "metadata": {"encoding": "utf-8"},
+        }
+    ]
+    assert data.facets == [
+        {
+            "kind": "encoding",
+            "name": "charset",
+            "namespace": "ogcat.core",
+            "version": "1",
+            "evidence": "declared",
+            "confidence": "declared",
+            "metadata": {"encoding": "utf-8"},
+        }
+    ]
+    write_event = [
+        event
+        for event in catalog.audit_events(event_type="write")
+        if event.details.get("write_phase") == "artifact-write"
+    ][0]
+    assert write_event.details["writer_diagnostics"] == {
+        "target_path": str(target),
+        "checks": ["encoded", "written"],
+    }
+    assert write_event.details["writer_provenance"] == {"source_descriptor": "inline text"}
+
+
+def test_writer_result_with_only_auxiliary_artifact_preserves_data_descriptor(tmp_path: Path) -> None:
+    """Auxiliary-only results keep the planned base data descriptor."""
+
+    class PreviewWriter:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
+            assert target_path is not None
+            target_path.write_text("data", encoding="utf-8")
+            preview = target_path.with_suffix(".preview.txt")
+            preview.write_text("preview", encoding="utf-8")
+
+            def remove_outputs() -> None:
+                target_path.unlink(missing_ok=True)
+                preview.unlink(missing_ok=True)
+
+            request.context.rollback(
+                remove_outputs,
+                description="remove data and preview",
+            )
+            return ArtifactWriteResult.from_artifact(
+                ArtifactDescriptor(
+                    id="preview",
+                    role="preview",
+                    locator=ArtifactLocator.path(preview),
+                    relationship={"kind": "preview_of", "target_artifact_id": "data"},
+                    claims=[InterfaceClaim("text")],
+                )
+            )
+
+    target = tmp_path / "data.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="generated_text",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("payload"),
+        artifact_writer=PreviewWriter(),
+    )
+
+    assert [artifact.id for artifact in record.artifacts] == ["data", "preview"]
+    assert record.artifacts[0].locator == ArtifactLocator.path(target)
+    assert record.artifacts[1].relationship["target_artifact_id"] == "data"
+
+
+def test_writer_result_locator_conflict_rolls_back_written_artifact(tmp_path: Path) -> None:
+    """A conflicting data locator is rejected after writer cleanup is registered."""
+
+    class ConflictingLocatorWriter:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
+            assert target_path is not None
+            target_path.write_text("data", encoding="utf-8")
+            request.context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description="remove conflicting data",
+            )
+            return ArtifactWriteResult.for_data_artifact(
+                locator=ArtifactLocator.path(target_path.with_name("other.txt")),
+            )
+
+    target = tmp_path / "data.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(ValueError, match="locator must match the planned locator"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            source=memory_source("payload"),
+            artifact_writer=ConflictingLocatorWriter(),
+        )
+
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_writer_result_duplicate_auxiliary_id_rolls_back_written_artifact(tmp_path: Path) -> None:
+    """Duplicate returned artifact ids fail before commit and trigger rollback."""
+
+    class DuplicateAuxiliaryWriter:
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
+            assert target_path is not None
+            target_path.write_text("data", encoding="utf-8")
+            request.context.rollback(
+                lambda path=target_path: path.unlink(missing_ok=True),
+                description="remove duplicate auxiliary data",
+            )
+            return ArtifactWriteResult(
+                artifacts=(
+                    ArtifactDescriptor(id="preview", role="preview"),
+                    ArtifactDescriptor(id="preview", role="preview"),
+                )
+            )
+
+    target = tmp_path / "data.txt"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    with pytest.raises(ValueError, match="duplicate artifact id"):
+        catalog.add_artifact(
+            record_type="generated_text",
+            locator=ArtifactLocator.path(target),
+            source=memory_source("payload"),
+            artifact_writer=DuplicateAuxiliaryWriter(),
+        )
+
+    assert not target.exists()
+    assert catalog.repository.all() == []
+
+
+def test_writer_result_can_describe_directory_collection_shape(tmp_path: Path) -> None:
+    """Writers can attach collection claims/facets without a collection API."""
+
+    class CollectionDirectoryWriter:
+        target_kind = "directory"
+
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            target_path = request.locator.as_path()
+            assert target_path is not None
+            target_path.mkdir(parents=True, exist_ok=False)
+            (target_path / "co2_202401.nc").write_text("not netcdf", encoding="utf-8")
+            request.context.rollback(
+                lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
+                description="remove collection directory",
+            )
+            return ArtifactWriteResult.for_data_artifact(
+                claims=[
+                    RepresentationClaim("directory"),
+                    InterfaceClaim("collection"),
+                ],
+                facets=[
+                    ArtifactFacet(
+                        kind="collection",
+                        name="members",
+                        metadata={
+                            "pattern": "*.nc",
+                            "member_format": "netcdf",
+                            "member_suffixes": [".nc"],
+                            "reader_hint": "xarray.open_mfdataset",
+                        },
+                    )
+                ],
+            )
+
+    target = tmp_path / "collection"
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
+
+    record = catalog.add_artifact(
+        record_type="netcdf_collection",
+        locator=ArtifactLocator.path(target),
+        source=memory_source("payload"),
+        artifact_writer=CollectionDirectoryWriter(),
+    )
+
+    first_claim = record.artifacts[0].claims[0]
+    second_claim = record.artifacts[0].claims[1]
+    collection_facet = record.artifacts[0].facets[0]
+    assert isinstance(first_claim, Mapping)
+    assert isinstance(second_claim, Mapping)
+    assert isinstance(collection_facet, Mapping)
+    facet_metadata = collection_facet["metadata"]
+    assert isinstance(facet_metadata, Mapping)
+    assert first_claim["name"] == "directory"
+    assert second_claim["name"] == "collection"
+    assert facet_metadata["pattern"] == "*.nc"
 
 
 def test_unzip_artifact_writer_extracts_metadata(tmp_path: Path) -> None:
@@ -370,23 +671,19 @@ def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: 
             raise RuntimeError("stop after planned write")
 
     class PlanAwareDirectoryWriter:
-        def write(
-            self,
-            context: OperationContext,
-            source: OperationSource,
-            target: ArtifactLocator,
-        ) -> None:
-            assert context.storage_plan is not None
-            assert context.storage_plan.target_kind == "directory"
-            assert context.storage_plan.locator == target
-            target_path = target.as_path()
+        def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
+            assert request.context.storage_plan is not None
+            assert request.context.storage_plan.target_kind == "directory"
+            assert request.context.storage_plan.locator == request.locator
+            target_path = request.locator.as_path()
             assert target_path is not None
             target_path.mkdir(parents=True, exist_ok=False)
-            (target_path / "payload.txt").write_text(str(source.payload), encoding="utf-8")
-            context.rollback(
+            (target_path / "payload.txt").write_text(str(request.source.payload), encoding="utf-8")
+            request.context.rollback(
                 lambda path=target_path: shutil.rmtree(path, ignore_errors=True),
                 description="remove planned directory",
             )
+            return ArtifactWriteResult.from_artifact(request.target)
 
     target = tmp_path / "catalog" / "files" / "stores" / "example.zarr"
     plan = plan_storage(

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -37,7 +37,7 @@ from ogcat.models import MetadataDict
 
 
 def test_memory_writer_writes_file_and_persists_metadata(tmp_path: Path) -> None:
-    """Memory writer writes file data and records returned metadata."""
+    """Memory writer helper writes file data and records returned metadata."""
 
     def write_text(data: object, target: Path) -> MetadataDict:
         text = str(data)
@@ -59,7 +59,7 @@ def test_memory_writer_writes_file_and_persists_metadata(tmp_path: Path) -> None
 
 
 def test_path_writer_writes_directory_and_rolls_back_on_hook_failure(tmp_path: Path) -> None:
-    """Path writer directory targets are cleaned up on later hook failure."""
+    """Path writer helper directory targets are cleaned up on later hook failure."""
 
     def copy_tree(source: Path, target: Path) -> MetadataDict:
         (target / "copied.txt").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
@@ -87,8 +87,8 @@ def test_path_writer_writes_directory_and_rolls_back_on_hook_failure(tmp_path: P
     assert catalog.repository.all() == []
 
 
-def test_locator_writer_fallback_plan_uses_writer_intent(tmp_path: Path) -> None:
-    """Plain locator-plus-writer calls expose writer storage intent in context."""
+def test_locator_materializer_fallback_plan_uses_materializer_intent(tmp_path: Path) -> None:
+    """Plain locator-plus-materializer calls expose storage intent in context."""
     seen: list[tuple[str, str]] = []
 
     def copy_tree(source: Path, target: Path) -> MetadataDict:
@@ -117,7 +117,7 @@ def test_locator_writer_fallback_plan_uses_writer_intent(tmp_path: Path) -> None
 
 
 def test_source_writer_receives_full_operation_source(tmp_path: Path) -> None:
-    """Source writer receives the full OperationSource object."""
+    """Source writer helper receives the full OperationSource object."""
 
     def write_source(source: OperationSource, target: Path) -> MetadataDict:
         assert source.path is None
@@ -145,7 +145,7 @@ def test_source_writer_receives_full_operation_source(tmp_path: Path) -> None:
 
 
 def test_memory_writer_adapts_none_return_to_base_result(tmp_path: Path) -> None:
-    """Convenience writers can wrap one-off functions that return None."""
+    """Convenience materializer helpers can wrap one-off functions that return None."""
 
     def write_text(data: object, target: Path) -> None:
         target.write_text(str(data), encoding="utf-8")
@@ -166,7 +166,7 @@ def test_memory_writer_adapts_none_return_to_base_result(tmp_path: Path) -> None
 
 
 def test_memory_writer_adapts_descriptor_return(tmp_path: Path) -> None:
-    """Convenience writers can wrap functions that return descriptor facts."""
+    """Convenience materializer helpers can wrap functions that return descriptor facts."""
 
     def write_text(data: object, target: Path) -> ArtifactDescriptor:
         target.write_text(str(data), encoding="utf-8")
@@ -199,8 +199,8 @@ def test_memory_writer_adapts_descriptor_return(tmp_path: Path) -> None:
     ]
 
 
-def test_writer_result_merges_claims_facets_diagnostics_and_provenance(tmp_path: Path) -> None:
-    """Structured writer results enrich the data descriptor and audit event."""
+def test_materializer_result_merges_claims_facets_diagnostics_and_provenance(tmp_path: Path) -> None:
+    """Structured materializer results enrich the data descriptor and audit event."""
 
     class TextWriter:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
@@ -265,14 +265,14 @@ def test_writer_result_merges_claims_facets_diagnostics_and_provenance(tmp_path:
         for event in catalog.audit_events(event_type="write")
         if event.details.get("write_phase") == "artifact-write"
     ][0]
-    assert write_event.details["writer_diagnostics"] == {
+    assert write_event.details["materializer_diagnostics"] == {
         "target_path": str(target),
         "checks": ["encoded", "written"],
     }
-    assert write_event.details["writer_provenance"] == {"source_descriptor": "inline text"}
+    assert write_event.details["materializer_provenance"] == {"source_descriptor": "inline text"}
 
 
-def test_writer_result_with_only_auxiliary_artifact_preserves_data_descriptor(tmp_path: Path) -> None:
+def test_materializer_result_with_only_auxiliary_artifact_preserves_data_descriptor(tmp_path: Path) -> None:
     """Auxiliary-only results keep the planned base data descriptor."""
 
     class PreviewWriter:
@@ -316,8 +316,8 @@ def test_writer_result_with_only_auxiliary_artifact_preserves_data_descriptor(tm
     assert record.artifacts[1].relationship["target_artifact_id"] == "data"
 
 
-def test_writer_result_locator_conflict_rolls_back_written_artifact(tmp_path: Path) -> None:
-    """A conflicting data locator is rejected after writer cleanup is registered."""
+def test_materializer_result_locator_conflict_rolls_back_written_artifact(tmp_path: Path) -> None:
+    """A conflicting data locator is rejected after materializer cleanup is registered."""
 
     class ConflictingLocatorWriter:
         def write(self, request: ArtifactWriteRequest) -> ArtifactWriteResult:
@@ -347,7 +347,7 @@ def test_writer_result_locator_conflict_rolls_back_written_artifact(tmp_path: Pa
     assert catalog.repository.all() == []
 
 
-def test_writer_result_duplicate_auxiliary_id_rolls_back_written_artifact(tmp_path: Path) -> None:
+def test_materializer_result_duplicate_auxiliary_id_rolls_back_written_artifact(tmp_path: Path) -> None:
     """Duplicate returned artifact ids fail before commit and trigger rollback."""
 
     class DuplicateAuxiliaryWriter:
@@ -381,8 +381,8 @@ def test_writer_result_duplicate_auxiliary_id_rolls_back_written_artifact(tmp_pa
     assert catalog.repository.all() == []
 
 
-def test_writer_result_can_describe_directory_collection_shape(tmp_path: Path) -> None:
-    """Writers can attach collection claims/facets without a collection API."""
+def test_materializer_result_can_describe_directory_collection_shape(tmp_path: Path) -> None:
+    """Materializers can attach collection claims/facets without a collection API."""
 
     class CollectionDirectoryWriter:
         target_kind = "directory"
@@ -566,7 +566,7 @@ def test_unzip_single_file_artifact_writer_rejects_path_traversal(tmp_path: Path
     assert not (tmp_path / "escape.nc").exists()
 
 
-def test_non_reference_storage_plan_requires_writer(tmp_path: Path) -> None:
+def test_non_reference_storage_plan_requires_materializer(tmp_path: Path) -> None:
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="artifacts"))
     target = tmp_path / "catalog" / "files" / "generated.txt"
     plan = plan_storage(
@@ -665,7 +665,7 @@ def test_move_artifact_writer_rejects_urlpath_before_adapter_lookup(
     assert catalog.repository.all() == []
 
 
-def test_writer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: Path) -> None:
+def test_materializer_receives_storage_plan_and_rolls_back_directory_target(tmp_path: Path) -> None:
     class FailingHook:
         def before_record_write(self, context: OperationContext) -> None:
             raise RuntimeError("stop after planned write")


### PR DESCRIPTION
## Summary
- Add structured `ArtifactWriteResult` support and a descriptor-first write request/result flow.
- Update bundled stdlib I/O examples, managed add-operation plumbing, and writer adapters to use the new result model.
- Refresh API docs, design notes, glossary entries, and the current architecture report to match the updated artifact model.

## Testing
- Focused pytest coverage was added and updated for writers, add-operation lifecycle, hooks, storage, and stdlib I/O capability composition.
- Linting and formatting checks passed.
- Sphinx docs build passed.