### PR TITLE
Codex/trash record deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,10 @@ uv run ogcat search --catalog ./example-catalog --where species=CO2 --all
 Delete records with trash-style semantics. ``delete`` tombstones a record and
 hides it from normal search; ``restore`` makes it active again; ``purge``
 permanently removes a tombstoned record after removing managed catalog-local
-artifacts.
+artifacts. Purge is best-effort across artifacts: if cleanup is incomplete,
+the tombstone is retained with purge metadata instead of reporting success.
+``--include-deleted`` and ``--only-deleted`` are mutually exclusive search
+options.
 
 ```bash
 uv run ogcat delete 1 --catalog ./example-catalog --reason superseded
@@ -262,6 +265,10 @@ uv run ogcat search --catalog ./example-catalog --only-deleted --ids
 uv run ogcat restore 1 --catalog ./example-catalog
 uv run ogcat purge 1 --catalog ./example-catalog --yes
 ```
+
+``status`` and ``lifecycle_metadata`` are reserved top-level lifecycle fields in
+search. If your domain metadata uses the same names, query it explicitly with a
+path such as ``user_metadata.status``.
 
 Show a record or print its stored path:
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,18 @@ uv run ogcat search --catalog ./example-catalog --where species=CO2 --fields id,
 uv run ogcat search --catalog ./example-catalog --where species=CO2 --all
 ```
 
+Delete records with trash-style semantics. ``delete`` tombstones a record and
+hides it from normal search; ``restore`` makes it active again; ``purge``
+permanently removes a tombstoned record after removing managed catalog-local
+artifacts.
+
+```bash
+uv run ogcat delete 1 --catalog ./example-catalog --reason superseded
+uv run ogcat search --catalog ./example-catalog --only-deleted --ids
+uv run ogcat restore 1 --catalog ./example-catalog
+uv run ogcat purge 1 --catalog ./example-catalog --yes
+```
+
 Show a record or print its stored path:
 
 ```bash

--- a/docs/api/catalog.rst
+++ b/docs/api/catalog.rst
@@ -9,7 +9,9 @@ record-set helpers are documented with search.
 Record deletion is trash-style by default: ``Catalog.delete()`` tombstones a
 record and hides it from normal search, ``Catalog.restore()`` makes the record
 active again, and ``Catalog.purge()`` permanently removes a tombstoned record
-after removing managed catalog-local artifacts.
+after removing managed catalog-local artifacts. Purge is best-effort across
+artifacts; incomplete cleanup raises ``PurgeIncompleteError`` after retaining
+the tombstone with purge outcome metadata.
 
 .. autoclass:: ogcat.Catalog
    :members:

--- a/docs/api/catalog.rst
+++ b/docs/api/catalog.rst
@@ -6,6 +6,11 @@ handling, schema selection, and delegation into internal application services.
 Search results are returned as :class:`ogcat.CatalogRecordSet` by default; the
 record-set helpers are documented with search.
 
+Record deletion is trash-style by default: ``Catalog.delete()`` tombstones a
+record and hides it from normal search, ``Catalog.restore()`` makes the record
+active again, and ``Catalog.purge()`` permanently removes a tombstoned record
+after removing managed catalog-local artifacts.
+
 .. autoclass:: ogcat.Catalog
    :members:
    :member-order: bysource

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,8 @@ ogcat search --catalog <root> [FILTER ...] [OPTIONS]
 | ``--format table\|plain\|csv\|tsv\|pipe`` | Table format |
 | ``--limit N`` | Cap on displayed results |
 | ``--all`` | Show every match (no cap) |
+| ``--include-deleted`` | Include tombstoned records |
+| ``--only-deleted`` | Show only tombstoned records |
 
 **Compatibility flags** (also available):
 ``--where``, ``--contains``, ``--match``, ``--regex``, ``--exists``, ``--missing``, ``--ignore-case``
@@ -94,12 +96,42 @@ Print a single record.
 ogcat show <id> --catalog <root>
 ```
 
+``show`` resolves records by id and can inspect tombstoned records.
+
 ### ``ogcat path``
 
 Print the stored path of a record.
 
 ```
 ogcat path <id> --catalog <root>
+```
+
+### ``ogcat delete``
+
+Tombstone a record. Tombstoned records are hidden from normal search but remain
+inspectable by id and can be restored or purged.
+
+```
+ogcat delete <id> --catalog <root> [--reason TEXT] [--json]
+```
+
+### ``ogcat restore``
+
+Restore a tombstoned record to normal search visibility.
+
+```
+ogcat restore <id> --catalog <root> [--reason TEXT] [--json]
+```
+
+### ``ogcat purge``
+
+Permanently remove a tombstoned record and any managed catalog-local
+path-backed artifacts. External references and user-owned paths are skipped and
+audited. Purging an active record requires ``--force``. The command always
+requires ``--yes`` because the operation is irreversible.
+
+```
+ogcat purge <id> --catalog <root> --yes [--force] [--json]
 ```
 
 ### ``ogcat info``

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -77,6 +77,11 @@ ogcat search --catalog <root> [FILTER ...] [OPTIONS]
 | ``--include-deleted`` | Include tombstoned records |
 | ``--only-deleted`` | Show only tombstoned records |
 
+``--include-deleted`` and ``--only-deleted`` are mutually exclusive. Lifecycle
+fields such as ``status`` and ``lifecycle_metadata`` are reserved top-level
+search fields; use ``user_metadata.status`` for a domain metadata key named
+``status``.
+
 **Compatibility flags** (also available):
 ``--where``, ``--contains``, ``--match``, ``--regex``, ``--exists``, ``--missing``, ``--ignore-case``
 
@@ -129,6 +134,8 @@ Permanently remove a tombstoned record and any managed catalog-local
 path-backed artifacts. External references and user-owned paths are skipped and
 audited. Purging an active record requires ``--force``. The command always
 requires ``--yes`` because the operation is irreversible.
+If cleanup is incomplete, the command exits non-zero and leaves the tombstoned
+record with purge outcome metadata.
 
 ```
 ogcat purge <id> --catalog <root> --yes [--force] [--json]

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -20,8 +20,8 @@ continues to work for ordinary single-artifact records.
 | ``locator`` | Compatibility shortcut to the data artifact locator (see [Locators and storage](locators-and-storage.md)). |
 | ``artifacts`` | Inline descriptors for the data artifact plus optional auxiliary artifacts, view links, manifests, previews, logs, or derived artifacts. |
 | ``storage_mode`` | How the artifact was stored, e.g. ``copy``, ``move``, or ``external``. |
-| ``status`` | Record lifecycle status. ``active`` records are returned by normal search; ``deleted`` records are tombstones. |
-| ``lifecycle_metadata`` | Internal lifecycle metadata such as delete/restore operation ids and timestamps. |
+| ``status`` | Reserved record lifecycle status. ``active`` records are returned by normal search; ``deleted`` records are tombstones. |
+| ``lifecycle_metadata`` | Reserved lifecycle metadata such as delete/restore operation ids, timestamps, and incomplete purge attempt details. |
 | ``original_filename`` | Source filename at ingest time. |
 | ``suffixes`` | File suffix list derived from the source path. |
 | ``time_added`` | ISO 8601 timestamp when the record was created. |
@@ -174,8 +174,9 @@ Normal search returns only active records. ``Catalog.delete(id)`` tombstones a
 record by setting its status to ``deleted`` while keeping locators and artifact
 descriptors attached for audit and restore workflows. Pass
 ``include_deleted=True`` to include tombstones in search results, or
-``only_deleted=True`` to inspect just tombstoned records. Direct id lookup with
-``Catalog.get(id)`` still returns tombstoned records.
+``only_deleted=True`` to inspect just tombstoned records. These two flags are
+mutually exclusive. Direct id lookup with ``Catalog.get(id)`` still returns
+tombstoned records.
 
 When you search with an unqualified field name such as ``species``, ogcat
 looks in this order:
@@ -187,6 +188,9 @@ looks in this order:
 Use an explicit dotted path to target a specific namespace:
 ``user_metadata.species``, ``derived_metadata.netcdf.dims.time``, or the
 short aliases ``user.species`` and ``derived.netcdf.dims.time``.
+``status`` and ``lifecycle_metadata`` are reserved top-level lifecycle fields;
+use ``user_metadata.status`` when you need a domain metadata key named
+``status``.
 
 Selected classification fields also have a flattened fallback after ordinary
 ``derived_metadata`` lookup, so searches such as ``where={"format": "zip"}``,
@@ -222,5 +226,5 @@ restored = catalog.restore(record.id)
 assert restored.status == "active"
 
 catalog.delete(record.id)
-catalog.purge(record.id)  # permanent; removes managed catalog-local artifacts first
+catalog.purge(record.id)  # permanent; best-effort managed artifact cleanup
 ```

--- a/docs/concepts/catalog-records.md
+++ b/docs/concepts/catalog-records.md
@@ -20,6 +20,8 @@ continues to work for ordinary single-artifact records.
 | ``locator`` | Compatibility shortcut to the data artifact locator (see [Locators and storage](locators-and-storage.md)). |
 | ``artifacts`` | Inline descriptors for the data artifact plus optional auxiliary artifacts, view links, manifests, previews, logs, or derived artifacts. |
 | ``storage_mode`` | How the artifact was stored, e.g. ``copy``, ``move``, or ``external``. |
+| ``status`` | Record lifecycle status. ``active`` records are returned by normal search; ``deleted`` records are tombstones. |
+| ``lifecycle_metadata`` | Internal lifecycle metadata such as delete/restore operation ids and timestamps. |
 | ``original_filename`` | Source filename at ingest time. |
 | ``suffixes`` | File suffix list derived from the source path. |
 | ``time_added`` | ISO 8601 timestamp when the record was created. |
@@ -168,6 +170,13 @@ single NetCDF files, and grouped NetCDF/HDF5 files.
 
 ## Searching across namespaces
 
+Normal search returns only active records. ``Catalog.delete(id)`` tombstones a
+record by setting its status to ``deleted`` while keeping locators and artifact
+descriptors attached for audit and restore workflows. Pass
+``include_deleted=True`` to include tombstones in search results, or
+``only_deleted=True`` to inspect just tombstoned records. Direct id lookup with
+``Catalog.get(id)`` still returns tombstoned records.
+
 When you search with an unqualified field name such as ``species``, ogcat
 looks in this order:
 
@@ -199,4 +208,19 @@ print(record.record_type)          # "managed_file"
 print(record.user_metadata)        # {"species": "CO2", ...}
 print(record.path())               # stored Path
 print(record.artifacts[0].role)    # "data_artifact"
+```
+
+Trash-style lifecycle operations are available from the catalog facade:
+
+```python
+deleted = catalog.delete(record.id, reason="superseded")
+assert deleted.status == "deleted"
+assert catalog.search(where={"species": "CO2"}) == []
+assert catalog.get(record.id) is not None
+
+restored = catalog.restore(record.id)
+assert restored.status == "active"
+
+catalog.delete(record.id)
+catalog.purge(record.id)  # permanent; removes managed catalog-local artifacts first
 ```

--- a/docs/concepts/transactions-and-logging.md
+++ b/docs/concepts/transactions-and-logging.md
@@ -25,9 +25,12 @@ operation ran, which user ran it, which record was touched, and where a failure
 occurred.
 
 Add operations emit lifecycle events for operation start, validation, storage
-or record writes, commit, failure, and rollback. Events include an
-``operation_id``; CLI add failures include that id in the user-facing error
-message when available:
+or record writes, commit, failure, and rollback. Delete and restore operations
+emit the same operation-start, lifecycle, commit, failure, and rollback events.
+Purge operations additionally emit one ``purge_artifact`` event for each
+managed artifact removed or skipped, then hard-delete the record after artifact
+cleanup succeeds. Events include an ``operation_id``; CLI operation failures
+include that id in the user-facing error message when available:
 
 ```bash
 ogcat logs --catalog ./catalog --operation OPERATION_ID --json
@@ -44,6 +47,13 @@ redacted when values are included in audit details.
 
 Rollback is best-effort.  Each rollback action is tried in turn; if one
 fails, the remaining actions still run and the original error is preserved.
+
+``Catalog.delete()`` and ``Catalog.restore()`` update record lifecycle state
+through the same unit-of-work rollback model used by metadata updates, so an
+uncommitted caller-owned transaction restores the previous record state.
+``Catalog.purge()`` is permanent and best-effort: it removes only managed
+catalog-local path-backed artifacts through storage adapters, audits skipped
+external or user-owned locators, and hard-deletes the repository record last.
 
 You can register rollback actions from within a hook:
 

--- a/docs/concepts/transactions-and-logging.md
+++ b/docs/concepts/transactions-and-logging.md
@@ -29,7 +29,10 @@ or record writes, commit, failure, and rollback. Delete and restore operations
 emit the same operation-start, lifecycle, commit, failure, and rollback events.
 Purge operations additionally emit one ``purge_artifact`` event for each
 managed artifact removed or skipped, then hard-delete the record after artifact
-cleanup succeeds. Events include an ``operation_id``; CLI operation failures
+cleanup succeeds. If one artifact removal fails, purge continues with later
+artifacts, audits the failures, retains the tombstoned record with incomplete
+purge metadata, and reports failure to the caller. Events include an
+``operation_id``; CLI operation failures
 include that id in the user-facing error message when available:
 
 ```bash
@@ -53,7 +56,10 @@ through the same unit-of-work rollback model used by metadata updates, so an
 uncommitted caller-owned transaction restores the previous record state.
 ``Catalog.purge()`` is permanent and best-effort: it removes only managed
 catalog-local path-backed artifacts through storage adapters, audits skipped
-external or user-owned locators, and hard-deletes the repository record last.
+external or user-owned locators, and hard-deletes the repository record last
+only when cleanup succeeds. Partial purge failures cannot restore artifacts
+that were already removed, so ogcat commits an updated tombstone describing the
+incomplete attempt before raising the error.
 
 You can register rollback actions from within a hook:
 

--- a/docs/tutorials/basic-catalog.md
+++ b/docs/tutorials/basic-catalog.md
@@ -173,3 +173,41 @@ uv run ogcat search --catalog /tmp/tutorial-catalog species=CH4 --ids
 uv run ogcat fields --catalog /tmp/tutorial-catalog --stored
 uv run ogcat fields --catalog /tmp/tutorial-catalog --values species
 ```
+
+## Delete records and managed artifacts
+
+Use `Catalog.delete()` when you want trash-style deletion. It marks the record
+as deleted, hides it from normal search, and keeps the record, locators, and
+artifact descriptors available for direct inspection or restore.
+
+```python
+    deleted = catalog.delete(measurement.id, reason="superseded by corrected data")
+    assert deleted.status == "deleted"
+    assert catalog.search(where={"species": "CH4"}) == []
+    assert catalog.get(measurement.id) is not None
+    assert catalog.search(where={"species": "CH4"}, include_deleted=True).ids == [measurement.id]
+
+    restored = catalog.restore(measurement.id, reason="keep original for comparison")
+    assert restored.status == "active"
+    assert catalog.search(where={"species": "CH4"}).ids == [measurement.id]
+```
+
+Use `Catalog.purge()` only when the tombstoned record and any managed
+catalog-local path-backed artifacts should be removed permanently. Purge skips
+external references and user-owned paths, and it raises an error while retaining
+the tombstone if managed cleanup is incomplete.
+
+```python
+    catalog.delete(measurement.id, reason="remove demo record")
+    catalog.purge(measurement.id)
+    assert catalog.get(measurement.id) is None
+```
+
+The CLI exposes the same lifecycle:
+
+```bash
+uv run ogcat delete <id> --catalog /tmp/tutorial-catalog --reason superseded
+uv run ogcat search --catalog /tmp/tutorial-catalog --only-deleted --ids
+uv run ogcat restore <id> --catalog /tmp/tutorial-catalog
+uv run ogcat purge <id> --catalog /tmp/tutorial-catalog --yes
+```

--- a/src/ogcat/__init__.py
+++ b/src/ogcat/__init__.py
@@ -22,6 +22,7 @@ from ogcat.capabilities import (
 )
 from ogcat.catalog import Catalog
 from ogcat.classification import classify_artifact, collection_classification_metadata
+from ogcat.exceptions import PurgeIncompleteError
 from ogcat.hooks import ArtifactWriter, HookManager, HookWarning, OperationContext, OperationSource
 from ogcat.models import (
     ArtifactClaim,
@@ -128,6 +129,7 @@ __all__ = [
     "OperationContext",
     "OperationSource",
     "PluginRegistry",
+    "PurgeIncompleteError",
     "ReplicaApplyResult",
     "ReplicaMode",
     "ReplicaPlanItem",

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -40,6 +40,8 @@ from ogcat.operation_runner import (
     AddOperationRunner,
     OperationRunner,
     OperationServices,
+    RecordLifecycleOperationRequest,
+    RecordLifecycleOperationRunner,
 )
 from ogcat.plugins import PluginRegistry
 from ogcat.record_set import CatalogRecordSet
@@ -837,6 +839,8 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
+        include_deleted: bool = False,
+        only_deleted: bool = False,
         as_record_set: Literal[True] = True,
     ) -> CatalogRecordSet: ...
 
@@ -852,6 +856,8 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
+        include_deleted: bool = False,
+        only_deleted: bool = False,
         as_record_set: Literal[False],
     ) -> list[CatalogRecord]: ...
 
@@ -866,6 +872,8 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
+        include_deleted: bool = False,
+        only_deleted: bool = False,
         as_record_set: bool = True,
     ) -> list[CatalogRecord] | CatalogRecordSet:
         """Search catalog records using backend-neutral query semantics.
@@ -879,6 +887,8 @@ class Catalog:
             exists: Fields that must be present.
             missing: Fields that must be absent.
             ignore_case: Whether string comparisons should be case-insensitive.
+            include_deleted: Include tombstoned records alongside active records.
+            only_deleted: Return only tombstoned records.
             as_record_set: Return a ``CatalogRecordSet``. Pass ``False`` for a list.
 
         Returns:
@@ -895,6 +905,11 @@ class Catalog:
             ignore_case=ignore_case,
             resolution_order=self.spec.field_resolution_order,
         )
+        results = _filter_records_by_status(
+            results,
+            include_deleted=include_deleted,
+            only_deleted=only_deleted,
+        )
         if as_record_set:
             return self.record_set(results)
         return results
@@ -910,6 +925,8 @@ class Catalog:
         exists: Sequence[str] | None = None,
         missing: Sequence[str] | None = None,
         ignore_case: bool = False,
+        include_deleted: bool = False,
+        only_deleted: bool = False,
         allow_many: bool = False,
     ) -> CatalogRecord:
         """Return one matching record, raising clear errors for ambiguous searches."""
@@ -922,6 +939,8 @@ class Catalog:
             exists=exists,
             missing=missing,
             ignore_case=ignore_case,
+            include_deleted=include_deleted,
+            only_deleted=only_deleted,
         )
         if not records:
             raise ValueError("get_one found no records matching the search filters.")
@@ -952,12 +971,19 @@ class Catalog:
             default_display_fields=self.spec.get_schema().display_fields,
         )
 
-    def describe(self) -> dict[str, object]:
+    def describe(self, *, include_deleted: bool = False) -> dict[str, object]:
         """Return a serialisable summary of catalog configuration and contents."""
         db_path = self.root / self.spec.db_path
         files_root = self.root / self.spec.files_root
         objects_root = self.root / self.spec.objects_root
         default_schema = self.spec.get_schema()
+        all_records = self.repository.all()
+        visible_records = _filter_records_by_status(
+            all_records,
+            include_deleted=include_deleted,
+            only_deleted=False,
+        )
+        deleted_count = sum(1 for record in all_records if _record_is_deleted(record))
         return {
             "catalog_name": self.spec.catalog_name,
             "root_path": str(self.root),
@@ -969,7 +995,8 @@ class Catalog:
             "directory_template": default_schema.directory_template,
             "filename_template": default_schema.filename_template,
             "field_resolution_order": list(self.spec.field_resolution_order),
-            "record_count": len(self.repository.all()),
+            "record_count": len(visible_records),
+            "deleted_record_count": deleted_count,
             "has_metadata_fields": self._has_metadata_fields(),
             "record_schemas": self.list_record_schemas(),
         }
@@ -979,13 +1006,25 @@ class Catalog:
         schema = self._select_schema(record_type, require_known=record_type is not None)
         return [field_description.to_dict() for field_description in schema.metadata_fields]
 
-    def list_record_fields(self) -> list[str]:
+    def list_record_fields(self, *, include_deleted: bool = False) -> list[str]:
         """Return discoverable field paths present in stored records."""
-        return self.record_set(self.repository.all()).field_paths()
+        return self.record_set(
+            _filter_records_by_status(
+                self.repository.all(),
+                include_deleted=include_deleted,
+                only_deleted=False,
+            )
+        ).field_paths()
 
-    def unique_values(self, field: str) -> list[JsonValue]:
+    def unique_values(self, field: str, *, include_deleted: bool = False) -> list[JsonValue]:
         """Return unique scalar values present for a field across stored records."""
-        return self.record_set(self.repository.all()).unique_values(field)
+        return self.record_set(
+            _filter_records_by_status(
+                self.repository.all(),
+                include_deleted=include_deleted,
+                only_deleted=False,
+            )
+        ).unique_values(field)
 
     def get_schema(self, record_type: str | None = None) -> dict[str, object]:
         """Return a serialisable schema description."""
@@ -1005,6 +1044,110 @@ class Catalog:
         if record is None:
             return None
         return record.path()
+
+    def delete(
+        self,
+        record_id: object,
+        *,
+        reason: str | None = None,
+        transaction: UnitOfWork | None = None,
+    ) -> CatalogRecord:
+        """Tombstone a record so it is hidden from normal search results.
+
+        The record, artifact descriptors, and locators remain stored so the
+        deletion can be audited, inspected, restored, or purged later.
+
+        Args:
+            record_id: Existing record id.
+            reason: Optional human-readable deletion reason.
+            transaction: Optional caller-owned transaction. When supplied, the
+                previous record version is restored if the transaction rolls
+                back.
+
+        Returns:
+            Tombstoned catalog record.
+
+        Raises:
+            KeyError: If the record id does not exist.
+            ValueError: If the record is already deleted or the transaction
+                belongs to another repository.
+        """
+        application = self._application()
+        if transaction is not None:
+            self._validate_transaction(transaction)
+            return application.delete(
+                record_id=record_id,
+                reason=reason,
+                transaction=transaction,
+                commit=False,
+            )
+        with self.transaction() as unit_of_work:
+            return application.delete(
+                record_id=record_id,
+                reason=reason,
+                transaction=unit_of_work,
+                commit=True,
+            )
+
+    def restore(
+        self,
+        record_id: object,
+        *,
+        reason: str | None = None,
+        transaction: UnitOfWork | None = None,
+    ) -> CatalogRecord:
+        """Restore a tombstoned record to normal search visibility.
+
+        Args:
+            record_id: Existing record id.
+            reason: Optional human-readable restore reason.
+            transaction: Optional caller-owned transaction. When supplied, the
+                previous record version is restored if the transaction rolls
+                back.
+
+        Returns:
+            Restored catalog record.
+        """
+        application = self._application()
+        if transaction is not None:
+            self._validate_transaction(transaction)
+            return application.restore(
+                record_id=record_id,
+                reason=reason,
+                transaction=transaction,
+                commit=False,
+            )
+        with self.transaction() as unit_of_work:
+            return application.restore(
+                record_id=record_id,
+                reason=reason,
+                transaction=unit_of_work,
+                commit=True,
+            )
+
+    def purge(self, record_id: object, *, force: bool = False) -> None:
+        """Permanently remove a record and its managed catalog-local artifacts.
+
+        Purge is irreversible. It only removes path-backed artifacts under this
+        catalog's managed files or objects roots; external or user-owned
+        locators are skipped and audited.
+
+        Args:
+            record_id: Existing record id.
+            force: Allow purging an active record. By default, records must be
+                tombstoned with :meth:`delete` first.
+
+        Raises:
+            KeyError: If the record id does not exist.
+            ValueError: If the record is active and ``force`` is false.
+        """
+        with self.transaction() as unit_of_work:
+            self._application().purge(
+                record_id=record_id,
+                force=force,
+                transaction=unit_of_work,
+                commit=True,
+            )
 
     def update_metadata(
         self,
@@ -1358,6 +1501,16 @@ class Catalog:
         """Build the runner used for one internal add operation."""
         return AddOperationRunner(dependencies=self._operation_runner_dependencies(), request=request)
 
+    def _build_record_lifecycle_operation_runner(
+        self,
+        request: RecordLifecycleOperationRequest,
+    ) -> OperationRunner:
+        """Build the runner used for one record lifecycle operation."""
+        return RecordLifecycleOperationRunner(
+            dependencies=self._operation_runner_dependencies(),
+            request=request,
+        )
+
     def _operation_runner_dependencies(self) -> OperationServices:
         """Build catalog-owned dependencies for an internal operation runner."""
         return OperationServices(
@@ -1449,6 +1602,11 @@ class Catalog:
             raise KeyError(f"Record not found: {resolved_record_id}")
         return record
 
+    def _validate_transaction(self, transaction: UnitOfWork) -> None:
+        """Raise when a caller-owned transaction is for another repository."""
+        if transaction.repository is not self.repository:
+            raise ValueError("Transaction is bound to a different catalog repository.")
+
     def _stage_or_commit_record_update(
         self,
         record: CatalogRecord,
@@ -1512,6 +1670,25 @@ def _utc_timestamp() -> str:
     """Return a stable UTC timestamp string for record creation."""
     timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat()
     return timestamp.replace("+00:00", "Z")
+
+
+def _record_is_deleted(record: CatalogRecord) -> bool:
+    """Return whether a record is tombstoned."""
+    return record.status == "deleted"
+
+
+def _filter_records_by_status(
+    records: Sequence[CatalogRecord],
+    *,
+    include_deleted: bool,
+    only_deleted: bool,
+) -> list[CatalogRecord]:
+    """Return records after applying catalog-level lifecycle visibility rules."""
+    if only_deleted:
+        return [record for record in records if _record_is_deleted(record)]
+    if include_deleted:
+        return list(records)
+    return [record for record in records if not _record_is_deleted(record)]
 
 
 def _coerce_primary_location(value: object) -> PrimaryLocation:

--- a/src/ogcat/catalog.py
+++ b/src/ogcat/catalog.py
@@ -893,7 +893,14 @@ class Catalog:
 
         Returns:
             Matching records, as a record-set view by default or a list when requested.
+
+        Raises:
+            ValueError: If ``include_deleted`` and ``only_deleted`` are both true.
         """
+        _validate_deleted_visibility_flags(
+            include_deleted=include_deleted,
+            only_deleted=only_deleted,
+        )
         results = self.repository.search(
             query=query,
             where=where,
@@ -1128,9 +1135,11 @@ class Catalog:
     def purge(self, record_id: object, *, force: bool = False) -> None:
         """Permanently remove a record and its managed catalog-local artifacts.
 
-        Purge is irreversible. It only removes path-backed artifacts under this
-        catalog's managed files or objects roots; external or user-owned
-        locators are skipped and audited.
+        Purge is irreversible and best-effort across artifacts. It only removes
+        path-backed artifacts under this catalog's managed files or objects
+        roots; external or user-owned locators are skipped and audited. If
+        cleanup is incomplete, the tombstoned record is retained with purge
+        outcome metadata and the method raises ``PurgeIncompleteError``.
 
         Args:
             record_id: Existing record id.
@@ -1140,6 +1149,8 @@ class Catalog:
         Raises:
             KeyError: If the record id does not exist.
             ValueError: If the record is active and ``force`` is false.
+            PurgeIncompleteError: If managed cleanup is incomplete and the
+                tombstone is retained.
         """
         with self.transaction() as unit_of_work:
             self._application().purge(
@@ -1684,11 +1695,21 @@ def _filter_records_by_status(
     only_deleted: bool,
 ) -> list[CatalogRecord]:
     """Return records after applying catalog-level lifecycle visibility rules."""
+    _validate_deleted_visibility_flags(
+        include_deleted=include_deleted,
+        only_deleted=only_deleted,
+    )
     if only_deleted:
         return [record for record in records if _record_is_deleted(record)]
     if include_deleted:
         return list(records)
     return [record for record in records if not _record_is_deleted(record)]
+
+
+def _validate_deleted_visibility_flags(*, include_deleted: bool, only_deleted: bool) -> None:
+    """Reject mutually exclusive deleted-record visibility flags."""
+    if include_deleted and only_deleted:
+        raise ValueError("include_deleted and only_deleted cannot both be true.")
 
 
 def _coerce_primary_location(value: object) -> PrimaryLocation:

--- a/src/ogcat/catalog_application.py
+++ b/src/ogcat/catalog_application.py
@@ -21,6 +21,7 @@ from ogcat.operation_runner import (
     AddOperationRequest,
     ArtifactLocatorFactory,
     DerivedMetadataCollector,
+    RecordLifecycleOperationRequest,
     StoragePlanFactory,
 )
 from ogcat.secondary_artifacts import SecondaryArtifactOperation, TemplateLinkSecondaryArtifact
@@ -266,7 +267,77 @@ class CatalogApplication:
             derived_metadata_collector=derived_metadata_collector,
             secondary_artifact_operations=secondary_artifact_operations,
         )
-        return self.catalog._build_add_operation_runner(request).run()
+        result = self.catalog._build_add_operation_runner(request).run()
+        if result is None:
+            raise RuntimeError("add operation did not return a record.")
+        return result
+
+    def delete(
+        self,
+        *,
+        record_id: object,
+        reason: str | None,
+        transaction: UnitOfWork,
+        commit: bool,
+    ) -> CatalogRecord:
+        """Run the record tombstone operation."""
+        record = self.catalog._require_record(record_id)
+        request = RecordLifecycleOperationRequest(
+            transaction=transaction,
+            commit=commit,
+            operation_type="delete",
+            record=record,
+            reason=reason,
+        )
+        result = self.catalog._build_record_lifecycle_operation_runner(request).run()
+        if result is None:
+            raise RuntimeError("delete operation did not return a record.")
+        return result
+
+    def restore(
+        self,
+        *,
+        record_id: object,
+        reason: str | None,
+        transaction: UnitOfWork,
+        commit: bool,
+    ) -> CatalogRecord:
+        """Run the record restore operation."""
+        record = self.catalog._require_record(record_id)
+        request = RecordLifecycleOperationRequest(
+            transaction=transaction,
+            commit=commit,
+            operation_type="restore",
+            record=record,
+            reason=reason,
+        )
+        result = self.catalog._build_record_lifecycle_operation_runner(request).run()
+        if result is None:
+            raise RuntimeError("restore operation did not return a record.")
+        return result
+
+    def purge(
+        self,
+        *,
+        record_id: object,
+        force: bool,
+        transaction: UnitOfWork,
+        commit: bool,
+    ) -> None:
+        """Run the permanent record purge operation."""
+        record = self.catalog._require_record(record_id)
+        request = RecordLifecycleOperationRequest(
+            transaction=transaction,
+            commit=commit,
+            operation_type="purge",
+            record=record,
+            force=force,
+            managed_roots=(
+                self.catalog.root / self.catalog.spec.files_root,
+                self.catalog.root / self.catalog.spec.objects_root,
+            ),
+        )
+        self.catalog._build_record_lifecycle_operation_runner(request).run()
 
     def _template_link_secondary_artifacts(
         self,

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -87,6 +87,12 @@ def _validate_output_flags(*, json_mode: bool, ids_only: bool = False, paths_onl
         raise typer.BadParameter("Choose only one of --json, --ids, or --paths.")
 
 
+def _validate_deleted_search_flags(*, include_deleted: bool, only_deleted: bool) -> None:
+    """Reject incompatible deleted-record visibility flags."""
+    if include_deleted and only_deleted:
+        raise typer.BadParameter("Use either --include-deleted or --only-deleted, not both.")
+
+
 def _parse_meta_item(item: str) -> dict[str, Any]:
     """Parse one metadata item from KEY=VALUE or a JSON object."""
     stripped = item.strip()
@@ -517,6 +523,7 @@ def search(
 ) -> None:
     """Search records in a catalog."""
     _validate_output_flags(json_mode=json_mode, ids_only=ids_only, paths_only=paths_only)
+    _validate_deleted_search_flags(include_deleted=include_deleted, only_deleted=only_deleted)
     if all_results and limit is not None:
         raise typer.BadParameter("Use either --all or --limit, not both.")
     display_limit = limit if limit is not None else DEFAULT_SEARCH_LIMIT

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -464,6 +464,14 @@ def search(
         bool,
         typer.Option("--ignore-case", help="Case-insensitive matching."),
     ] = False,
+    include_deleted: Annotated[
+        bool,
+        typer.Option("--include-deleted", help="Include tombstoned records in results."),
+    ] = False,
+    only_deleted: Annotated[
+        bool,
+        typer.Option("--only-deleted", help="Show only tombstoned records."),
+    ] = False,
     json_mode: Annotated[
         bool,
         typer.Option(
@@ -529,6 +537,8 @@ def search(
     results = active_catalog.search(
         query=query,
         ignore_case=ignore_case,
+        include_deleted=include_deleted,
+        only_deleted=only_deleted,
         as_record_set=False,
     )
 
@@ -616,6 +626,8 @@ def show(
     table.add_row("stored path", str(record.stored_abspath or ""))
     table.add_row("relative path", str(record.stored_relpath or ""))
     table.add_row("storage mode", str(record.storage_mode or ""))
+    table.add_row("status", record.status)
+    table.add_row("lifecycle metadata", json.dumps(record.lifecycle_metadata, sort_keys=True))
     table.add_row("time added", record.time_added)
     table.add_row("original path", str(record.original_path or ""))
     table.add_row("original filename", str(record.original_filename or ""))
@@ -624,6 +636,85 @@ def show(
     table.add_row("derived metadata", json.dumps(record.derived_metadata, sort_keys=True))
     table.add_row("naming metadata", json.dumps(record.naming_metadata, sort_keys=True))
     console.print(table)
+
+
+@app.command("delete")
+def delete_record(
+    record_id: Annotated[str, typer.Argument(help="Record id.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    reason: Annotated[str | None, typer.Option("--reason", help="Reason to store in audit metadata.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print the tombstoned record as JSON."),
+    ] = False,
+) -> None:
+    """Tombstone a record so default search hides it."""
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        record = active_catalog.delete(record_id, reason=reason)
+    except (KeyError, ValueError) as exc:
+        _fail(_format_exception_message(exc))
+
+    if json_mode:
+        _print_json(record.to_dict())
+        return
+    console.print(f"Deleted {record.id}: tombstoned")
+
+
+@app.command("restore")
+def restore_record(
+    record_id: Annotated[str, typer.Argument(help="Record id.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    reason: Annotated[str | None, typer.Option("--reason", help="Reason to store in audit metadata.")] = None,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print the restored record as JSON."),
+    ] = False,
+) -> None:
+    """Restore a tombstoned record to default search visibility."""
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        record = active_catalog.restore(record_id, reason=reason)
+    except (KeyError, ValueError) as exc:
+        _fail(_format_exception_message(exc))
+
+    if json_mode:
+        _print_json(record.to_dict())
+        return
+    console.print(f"Restored {record.id}: active")
+
+
+@app.command("purge")
+def purge_record(
+    record_id: Annotated[str, typer.Argument(help="Record id.")],
+    catalog: Annotated[Path | None, typer.Option("--catalog", help="Catalog root.")] = None,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", help="Confirm permanent purge without an interactive prompt."),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Allow purging an active record."),
+    ] = False,
+    json_mode: Annotated[
+        bool,
+        typer.Option("--json", help="Print a JSON purge summary."),
+    ] = False,
+) -> None:
+    """Permanently remove a record and managed catalog-local artifacts."""
+    if not yes:
+        _fail("Purge is permanent. Pass --yes to confirm.", code=2)
+    active_catalog = _open_catalog_or_fail(catalog)
+    try:
+        active_catalog.purge(record_id, force=force)
+    except (KeyError, ValueError) as exc:
+        _fail(_format_exception_message(exc))
+
+    payload = {"id": record_id, "purged": True}
+    if json_mode:
+        _print_json(payload)
+        return
+    console.print(f"Purged {record_id}")
 
 
 @app.command()

--- a/src/ogcat/cli.py
+++ b/src/ogcat/cli.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from ogcat.audit import exception_operation_id
 from ogcat.catalog import Catalog
+from ogcat.exceptions import PurgeIncompleteError
 from ogcat.models import CatalogRecord
 from ogcat.record_set import CatalogRecordSet
 from ogcat.search import SearchQuery
@@ -714,6 +715,8 @@ def purge_record(
     active_catalog = _open_catalog_or_fail(catalog)
     try:
         active_catalog.purge(record_id, force=force)
+    except PurgeIncompleteError as exc:
+        _fail(_format_exception_message(exc))
     except (KeyError, ValueError) as exc:
         _fail(_format_exception_message(exc))
 

--- a/src/ogcat/exceptions.py
+++ b/src/ogcat/exceptions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 
-class PurgeIncompleteError(ValueError):
+class PurgeIncompleteError(RuntimeError):
     """Raised when purge cleanup is incomplete and the tombstone is retained.
 
     Args:

--- a/src/ogcat/exceptions.py
+++ b/src/ogcat/exceptions.py
@@ -1,0 +1,38 @@
+"""Public exception types raised by ogcat APIs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+class PurgeIncompleteError(ValueError):
+    """Raised when purge cleanup is incomplete and the tombstone is retained.
+
+    Args:
+        record_id: Record id whose purge could not fully complete.
+        operation_id: Audit operation id for the failed purge attempt.
+        failed_artifact_ids: Managed artifact ids that could not be removed.
+        repository_error: Optional repository hard-delete failure.
+    """
+
+    def __init__(
+        self,
+        *,
+        record_id: str | None,
+        operation_id: str,
+        failed_artifact_ids: Sequence[str] = (),
+        repository_error: BaseException | None = None,
+    ) -> None:
+        self.record_id = record_id
+        self.operation_id = operation_id
+        self.failed_artifact_ids = tuple(failed_artifact_ids)
+        self.repository_error = repository_error
+        problem_parts: list[str] = []
+        if self.failed_artifact_ids:
+            problem_parts.append("failed artifacts: " + ", ".join(self.failed_artifact_ids))
+        if repository_error is not None:
+            problem_parts.append(
+                f"repository delete failed: {type(repository_error).__name__}: {repository_error}"
+            )
+        problems = "; ".join(problem_parts) or "unknown purge failure"
+        super().__init__(f"Purge incomplete for record {record_id}; tombstone retained ({problems}).")

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -702,10 +702,10 @@ class CatalogRecord:
         stored_relpath: Backwards-compatible catalog-relative path.
         storage_mode: Storage mode such as ``"copy"``, ``"move"``, or
             ``"external"``.
-        status: Record lifecycle status. ``"active"`` records are visible in
-            normal searches; ``"deleted"`` records are tombstones.
-        lifecycle_metadata: Internal JSON-compatible lifecycle details such as
-            delete and restore operation ids.
+        status: Reserved record lifecycle status. ``"active"`` records are
+            visible in normal searches; ``"deleted"`` records are tombstones.
+        lifecycle_metadata: Reserved JSON-compatible lifecycle details such as
+            delete/restore operation ids and incomplete purge attempt metadata.
         original_path: Original source path or URI.
         original_filename: Original source filename.
         suffixes: Source suffixes.

--- a/src/ogcat/models.py
+++ b/src/ogcat/models.py
@@ -702,6 +702,10 @@ class CatalogRecord:
         stored_relpath: Backwards-compatible catalog-relative path.
         storage_mode: Storage mode such as ``"copy"``, ``"move"``, or
             ``"external"``.
+        status: Record lifecycle status. ``"active"`` records are visible in
+            normal searches; ``"deleted"`` records are tombstones.
+        lifecycle_metadata: Internal JSON-compatible lifecycle details such as
+            delete and restore operation ids.
         original_path: Original source path or URI.
         original_filename: Original source filename.
         suffixes: Source suffixes.
@@ -719,6 +723,8 @@ class CatalogRecord:
     stored_abspath: str | None = None
     stored_relpath: str | None = None
     storage_mode: str | None = None
+    status: str = "active"
+    lifecycle_metadata: MetadataDict = field(default_factory=dict)
     original_path: str | None = None
     original_filename: str | None = None
     suffixes: list[str] = field(default_factory=list)
@@ -736,6 +742,11 @@ class CatalogRecord:
         self.naming_metadata = normalize_metadata(
             self.naming_metadata,
             field_name="naming_metadata",
+        )
+        self.status = str(self.status or "active")
+        self.lifecycle_metadata = normalize_metadata(
+            self.lifecycle_metadata,
+            field_name="lifecycle_metadata",
         )
         if not self.locator.value and self.stored_abspath is not None:
             self.locator = ArtifactLocator.path(
@@ -773,6 +784,11 @@ class CatalogRecord:
                 "stored_abspath": self.stored_abspath,
                 "stored_relpath": self.stored_relpath,
                 "storage_mode": self.storage_mode,
+                "status": self.status,
+                "lifecycle_metadata": normalize_metadata(
+                    self.lifecycle_metadata,
+                    field_name="lifecycle_metadata",
+                ),
                 "time_added": self.time_added,
                 "original_path": self.original_path,
                 "original_filename": self.original_filename,
@@ -804,6 +820,8 @@ class CatalogRecord:
             stored_abspath=(None if data.get("stored_abspath") is None else str(data["stored_abspath"])),
             stored_relpath=(None if data.get("stored_relpath") is None else str(data["stored_relpath"])),
             storage_mode=(None if data.get("storage_mode") is None else str(data["storage_mode"])),
+            status="active" if data.get("status") is None else str(data["status"]),
+            lifecycle_metadata=_coerce_metadata_dict(data.get("lifecycle_metadata", {})),
             original_path=(None if data.get("original_path") is None else str(data["original_path"])),
             original_filename=(
                 None if data.get("original_filename") is None else str(data["original_filename"])

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -16,14 +16,15 @@ separately testable and replaceable by future sibling runners.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from ogcat.audit import add_operation_note
 from ogcat.classification import CLASSIFICATION_METADATA_KEY, classify_artifact
+from ogcat.exceptions import PurgeIncompleteError
 from ogcat.hooks import (
     HOOK_PHASES,
     HookDispatcher,
@@ -60,6 +61,7 @@ ArtifactLocatorFactory = Callable[[OperationContext], ArtifactLocator]
 StoragePlanFactory = Callable[[OperationContext, ArtifactLocator], StoragePlan | None]
 DerivedMetadataCollector = Callable[[OperationContext, ArtifactLocator], None]
 _PhaseSetter = Callable[[str], None]
+_PurgeArtifactAction = Literal["removed", "skipped", "failed"]
 
 
 class OperationAuditEmitter(Protocol):
@@ -166,6 +168,25 @@ class RecordLifecycleOperationRequest:
     reason: str | None = None
     force: bool = False
     managed_roots: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _PurgeArtifactResult:
+    """Outcome of one artifact purge attempt."""
+
+    artifact_id: str
+    artifact_role: str
+    action: _PurgeArtifactAction
+    target_kind: TargetKind | None = None
+    reason: str | None = None
+    exception: Exception | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PurgeOutcome:
+    """Aggregate purge outcome returned before commit/raise handling."""
+
+    incomplete_error: PurgeIncompleteError | None = None
 
 
 @dataclass(slots=True)
@@ -639,6 +660,8 @@ class RecordLifecycleOperationRunner(OperationRunner):
             },
             locator=self.request.record.locator,
         )
+        result: CatalogRecord | None = None
+        incomplete_purge_error: PurgeIncompleteError | None = None
         current_phase = "operation-started"
         try:
             if self.request.operation_type == "delete":
@@ -649,16 +672,19 @@ class RecordLifecycleOperationRunner(OperationRunner):
                 result = self._restore(context)
             elif self.request.operation_type == "purge":
                 current_phase = "purge"
-                self._purge(context)
-                result = None
+                purge_outcome = self._purge(context)
+                incomplete_purge_error = purge_outcome.incomplete_error
             else:
                 raise ValueError(f"Unsupported record lifecycle operation: {self.request.operation_type}")
             current_phase = "commit"
             self._commit_if_owned(context)
-            return result
         except Exception as exc:
             self._handle_error(error=exc, context=context, current_phase=current_phase)
             raise
+        if incomplete_purge_error is not None:
+            add_operation_note(incomplete_purge_error, context.operation_id)
+            raise incomplete_purge_error
+        return result
 
     def _build_context(self) -> OperationContext:
         """Build the mutable context used for lifecycle audit events."""
@@ -742,16 +768,41 @@ class RecordLifecycleOperationRunner(OperationRunner):
         )
         return persisted
 
-    def _purge(self, context: OperationContext) -> None:
-        """Remove managed artifacts, then hard-delete the record."""
+    def _purge(self, context: OperationContext) -> _PurgeOutcome:
+        """Remove managed artifacts, then hard-delete the record on full success."""
         record = self.request.record
         if record.status != "deleted" and not self.request.force:
             raise ValueError(f"Record must be deleted before purge: {record.id}")
-        for artifact in record.artifacts:
-            self._purge_artifact(context, artifact)
         if record.id is None:
             raise ValueError("Cannot purge a record without an id.")
-        self.request.transaction.repository.delete(record.id)
+        results: list[_PurgeArtifactResult] = []
+        for artifact in record.artifacts:
+            try:
+                results.append(self._purge_artifact(context, artifact))
+            except Exception as exc:
+                results.append(self._emit_artifact_failure(context, artifact, exception=exc))
+
+        failed_results = _failed_purge_artifact_results(results)
+        if failed_results:
+            return _PurgeOutcome(
+                incomplete_error=self._retain_incomplete_purge(
+                    context,
+                    results=results,
+                    repository_error=None,
+                )
+            )
+
+        try:
+            self.request.transaction.repository.delete(record.id)
+        except Exception as exc:
+            return _PurgeOutcome(
+                incomplete_error=self._retain_incomplete_purge(
+                    context,
+                    results=results,
+                    repository_error=exc,
+                )
+            )
+
         self.dependencies.emit_operation_audit(
             context,
             event_type="purge",
@@ -760,30 +811,48 @@ class RecordLifecycleOperationRunner(OperationRunner):
                 "record_id": record.id,
                 "force": self.request.force,
                 "artifact_count": len(record.artifacts),
+                "purge_counts": _purge_counts(results),
                 "artifact_summaries": _artifact_audit_summaries(record),
             },
             locator=record.locator,
         )
+        return _PurgeOutcome()
 
-    def _purge_artifact(self, context: OperationContext, artifact: ArtifactDescriptor) -> None:
+    def _purge_artifact(
+        self,
+        context: OperationContext,
+        artifact: ArtifactDescriptor,
+    ) -> _PurgeArtifactResult:
         """Purge one managed artifact or audit why it was skipped."""
         if self.request.record.storage_mode == "reference":
-            self._emit_artifact_skip(context, artifact, reason="record storage mode is reference")
-            return
+            return self._emit_artifact_skip(context, artifact, reason="record storage mode is reference")
         locator = artifact.locator
         if locator is None:
-            self._emit_artifact_skip(context, artifact, reason="missing locator")
-            return
+            return self._emit_artifact_skip(context, artifact, reason="missing locator")
         target_path = locator.as_path()
         if target_path is None:
-            self._emit_artifact_skip(context, artifact, reason=f"unsupported locator kind: {locator.kind}")
-            return
+            return self._emit_artifact_skip(
+                context,
+                artifact,
+                reason=f"unsupported locator kind: {locator.kind}",
+            )
         if not _is_managed_path(target_path, managed_roots=self.request.managed_roots):
-            self._emit_artifact_skip(context, artifact, reason="locator is outside managed catalog roots")
-            return
+            return self._emit_artifact_skip(
+                context,
+                artifact,
+                reason="locator is outside managed catalog roots",
+            )
 
         target_kind = _target_kind_for_existing_path(target_path)
-        remove_target(locator, target_kind=target_kind)
+        try:
+            remove_target(locator, target_kind=target_kind)
+        except Exception as exc:
+            return self._emit_artifact_failure(
+                context,
+                artifact,
+                exception=exc,
+                target_kind=target_kind,
+            )
         self.dependencies.emit_operation_audit(
             context,
             event_type="purge_artifact",
@@ -796,6 +865,12 @@ class RecordLifecycleOperationRunner(OperationRunner):
             },
             locator=locator,
         )
+        return _PurgeArtifactResult(
+            artifact_id=artifact.id,
+            artifact_role=artifact.role,
+            action="removed",
+            target_kind=target_kind,
+        )
 
     def _emit_artifact_skip(
         self,
@@ -803,7 +878,7 @@ class RecordLifecycleOperationRunner(OperationRunner):
         artifact: ArtifactDescriptor,
         *,
         reason: str,
-    ) -> None:
+    ) -> _PurgeArtifactResult:
         """Audit that one artifact was intentionally not purged."""
         self.dependencies.emit_operation_audit(
             context,
@@ -817,6 +892,89 @@ class RecordLifecycleOperationRunner(OperationRunner):
             },
             locator=artifact.locator,
         )
+        return _PurgeArtifactResult(
+            artifact_id=artifact.id,
+            artifact_role=artifact.role,
+            action="skipped",
+            reason=reason,
+        )
+
+    def _emit_artifact_failure(
+        self,
+        context: OperationContext,
+        artifact: ArtifactDescriptor,
+        *,
+        exception: Exception,
+        target_kind: TargetKind | None = None,
+    ) -> _PurgeArtifactResult:
+        """Audit that one managed artifact could not be purged."""
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="purge_artifact",
+            level="error",
+            message="Managed artifact purge failed.",
+            details={
+                "artifact_id": artifact.id,
+                "artifact_role": artifact.role,
+                "target_kind": target_kind,
+                "purge_action": "failed",
+            },
+            exception=exception,
+            locator=artifact.locator,
+        )
+        return _PurgeArtifactResult(
+            artifact_id=artifact.id,
+            artifact_role=artifact.role,
+            action="failed",
+            target_kind=target_kind,
+            exception=exception,
+        )
+
+    def _retain_incomplete_purge(
+        self,
+        context: OperationContext,
+        *,
+        results: Sequence[_PurgeArtifactResult],
+        repository_error: Exception | None,
+    ) -> PurgeIncompleteError:
+        """Persist an incomplete purge attempt and return the caller-facing error."""
+        record = self.request.record
+        updated = replace(
+            record,
+            artifacts=_artifacts_with_purge_states(record.artifacts, results),
+            lifecycle_metadata=_incomplete_purge_lifecycle_metadata(
+                record,
+                operation_id=context.operation_id,
+                results=results,
+                repository_error=repository_error,
+            ),
+        )
+        persisted = self.request.transaction.update_staged_record(updated)
+        incomplete_error = PurgeIncompleteError(
+            record_id=record.id,
+            operation_id=context.operation_id,
+            failed_artifact_ids=[result.artifact_id for result in _failed_purge_artifact_results(results)],
+            repository_error=repository_error,
+        )
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="purge",
+            level="error",
+            message="Record purge incomplete; record retained.",
+            details={
+                "record_id": record.id,
+                "force": self.request.force,
+                "artifact_count": len(record.artifacts),
+                "purge_counts": _purge_counts(results),
+                "purge_status": "incomplete",
+                "repository_delete_failed": repository_error is not None,
+                "artifact_summaries": _artifact_audit_summaries(persisted),
+                "purge_result_summaries": _purge_result_summaries(results),
+            },
+            exception=repository_error,
+            locator=record.locator,
+        )
+        return incomplete_error
 
     def _commit_if_owned(self, context: OperationContext) -> None:
         """Commit internal lifecycle transactions."""
@@ -999,7 +1157,7 @@ def _updated_lifecycle_metadata(
     operation_id: str,
     reason: str | None,
 ) -> MetadataDict:
-    """Return lifecycle metadata with one lifecycle transition appended."""
+    """Return lifecycle metadata with latest transition fields recorded."""
     timestamp = _utc_timestamp()
     metadata: dict[str, object] = dict(record.lifecycle_metadata)
     metadata[f"{operation_type}_operation_id"] = operation_id
@@ -1007,6 +1165,32 @@ def _updated_lifecycle_metadata(
     metadata[timestamp_key] = timestamp
     if reason is not None:
         metadata[f"{operation_type}_reason"] = reason
+    return normalize_metadata(metadata, field_name="lifecycle_metadata")
+
+
+def _incomplete_purge_lifecycle_metadata(
+    record: CatalogRecord,
+    *,
+    operation_id: str,
+    results: Sequence[_PurgeArtifactResult],
+    repository_error: Exception | None,
+) -> MetadataDict:
+    """Return lifecycle metadata describing the latest incomplete purge attempt."""
+    counts = _purge_counts(results)
+    metadata: dict[str, object] = dict(record.lifecycle_metadata)
+    metadata["purge_operation_id"] = operation_id
+    metadata["purge_attempted_at"] = _utc_timestamp()
+    metadata["purge_status"] = "incomplete"
+    metadata["purge_removed_count"] = counts["removed_count"]
+    metadata["purge_skipped_count"] = counts["skipped_count"]
+    metadata["purge_failure_count"] = counts["failed_count"]
+    metadata["purge_repository_delete_failed"] = repository_error is not None
+    metadata["purge_failures"] = _purge_result_summaries(
+        _failed_purge_artifact_results(results),
+        include_exception_details=False,
+    )
+    if repository_error is not None:
+        metadata["purge_repository_error_type"] = type(repository_error).__name__
     return normalize_metadata(metadata, field_name="lifecycle_metadata")
 
 
@@ -1040,6 +1224,69 @@ def _artifact_audit_summaries(record: CatalogRecord) -> list[dict[str, object]]:
         }
         for artifact in record.artifacts
     ]
+
+
+def _failed_purge_artifact_results(
+    results: Sequence[_PurgeArtifactResult],
+) -> list[_PurgeArtifactResult]:
+    """Return failed artifact purge outcomes."""
+    return [result for result in results if result.action == "failed"]
+
+
+def _purge_counts(results: Sequence[_PurgeArtifactResult]) -> dict[str, int]:
+    """Return artifact purge outcome counts."""
+    return {
+        "removed_count": sum(1 for result in results if result.action == "removed"),
+        "skipped_count": sum(1 for result in results if result.action == "skipped"),
+        "failed_count": sum(1 for result in results if result.action == "failed"),
+    }
+
+
+def _purge_result_summaries(
+    results: Sequence[_PurgeArtifactResult],
+    *,
+    include_exception_details: bool = True,
+) -> list[dict[str, object]]:
+    """Return compact purge outcome summaries for audit and lifecycle metadata."""
+    summaries: list[dict[str, object]] = []
+    for result in results:
+        summary: dict[str, object] = {
+            "artifact_id": result.artifact_id,
+            "artifact_role": result.artifact_role,
+            "purge_action": result.action,
+            "target_kind": result.target_kind,
+            "reason": result.reason,
+        }
+        if include_exception_details and result.exception is not None:
+            summary["exception_type"] = type(result.exception).__name__
+            summary["exception_message"] = str(result.exception)
+        summaries.append(summary)
+    return summaries
+
+
+def _artifacts_with_purge_states(
+    artifacts: Sequence[ArtifactDescriptor],
+    results: Sequence[_PurgeArtifactResult],
+) -> list[ArtifactDescriptor]:
+    """Return artifact descriptors marked with retained purge outcome states."""
+    states_by_artifact_id = {
+        result.artifact_id: _artifact_state_for_purge_result(result)
+        for result in results
+        if result.action in {"removed", "failed"}
+    }
+    return [
+        replace(artifact, state=states_by_artifact_id.get(artifact.id, artifact.state))
+        for artifact in artifacts
+    ]
+
+
+def _artifact_state_for_purge_result(result: _PurgeArtifactResult) -> str:
+    """Return the retained descriptor state for a purge outcome."""
+    if result.action == "removed":
+        return "purged"
+    if result.action == "failed":
+        return "purge_failed"
+    return "available"
 
 
 def _is_managed_path(path: Path, *, managed_roots: tuple[Path, ...]) -> bool:

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -36,7 +37,14 @@ from ogcat.materialization import (
     materialization_plan_from_locator,
     validate_writer_matches_storage_plan,
 )
-from ogcat.models import ArtifactLocator, CatalogRecord, JsonValue, MetadataDict, normalize_metadata
+from ogcat.models import (
+    ArtifactDescriptor,
+    ArtifactLocator,
+    CatalogRecord,
+    JsonValue,
+    MetadataDict,
+    normalize_metadata,
+)
 from ogcat.operation_helpers import (
     artifact_locator_from_context,
     naming_metadata_from_storage_plan,
@@ -44,7 +52,7 @@ from ogcat.operation_helpers import (
 )
 from ogcat.secondary_artifacts import SecondaryArtifactOperation, SecondaryArtifactResult
 from ogcat.spec import RecordSchema
-from ogcat.storage import StoragePlan
+from ogcat.storage import StoragePlan, TargetKind, remove_target
 from ogcat.transactions import OperationState, RollbackFailure, UnitOfWork
 from ogcat.validation import ValidationReport
 
@@ -148,6 +156,19 @@ class AddOperationRequest:
 
 
 @dataclass(slots=True)
+class RecordLifecycleOperationRequest:
+    """Inputs required to run one record lifecycle operation."""
+
+    transaction: UnitOfWork
+    commit: bool
+    operation_type: str
+    record: CatalogRecord
+    reason: str | None = None
+    force: bool = False
+    managed_roots: tuple[Path, ...] = ()
+
+
+@dataclass(slots=True)
 class _AddOperationPlan:
     """Validated add-operation storage plan and its mutable hook context."""
 
@@ -161,7 +182,7 @@ class OperationRunner(ABC):
     """Explicit command interface for internal operation runners."""
 
     @abstractmethod
-    def run(self) -> CatalogRecord:
+    def run(self) -> CatalogRecord | None:
         """Run the operation and return the persisted or staged record."""
         ...
 
@@ -597,6 +618,275 @@ class AddOperationRunner(OperationRunner):
                 )
 
 
+@dataclass(slots=True)
+class RecordLifecycleOperationRunner(OperationRunner):
+    """Coordinator for delete, restore, and purge record lifecycle operations."""
+
+    dependencies: OperationServices
+    request: RecordLifecycleOperationRequest
+
+    def run(self) -> CatalogRecord | None:
+        """Run the requested record lifecycle operation."""
+        context = self._build_context()
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="operation-started",
+            message=f"Started {self.request.operation_type} operation.",
+            details={
+                "caller_owned_transaction": not self.request.commit,
+                "reason_present": self.request.reason is not None,
+                "record_status": self.request.record.status,
+            },
+            locator=self.request.record.locator,
+        )
+        current_phase = "operation-started"
+        try:
+            if self.request.operation_type == "delete":
+                current_phase = "tombstone"
+                result = self._delete(context)
+            elif self.request.operation_type == "restore":
+                current_phase = "restore"
+                result = self._restore(context)
+            elif self.request.operation_type == "purge":
+                current_phase = "purge"
+                self._purge(context)
+                result = None
+            else:
+                raise ValueError(f"Unsupported record lifecycle operation: {self.request.operation_type}")
+            current_phase = "commit"
+            self._commit_if_owned(context)
+            return result
+        except Exception as exc:
+            self._handle_error(error=exc, context=context, current_phase=current_phase)
+            raise
+
+    def _build_context(self) -> OperationContext:
+        """Build the mutable context used for lifecycle audit events."""
+        record = self.request.record
+        return OperationContext(
+            catalog_root=self.dependencies.catalog_root,
+            operation_id=self.request.transaction.operation_id,
+            operation_type=self.request.operation_type,
+            record_type=record.record_type,
+            user_metadata=record.user_metadata,
+            record_id=record.id,
+            derived_metadata=record.derived_metadata,
+            planned_locators=[record.locator],
+            register_rollback=self.request.transaction.register_rollback,
+            source=OperationSource(
+                kind="catalog_record",
+                path=record.path(),
+                descriptor=None if record.id is None else f"record:{record.id}",
+            ),
+            storage_mode=record.storage_mode,
+            original_path=record.original_path,
+            original_filename=record.original_filename,
+            suffixes=list(record.suffixes),
+        )
+
+    def _delete(self, context: OperationContext) -> CatalogRecord:
+        """Tombstone the record and return the updated record."""
+        record = self.request.record
+        if record.status == "deleted":
+            raise ValueError(f"Record is already deleted: {record.id}")
+        updated = replace(
+            record,
+            status="deleted",
+            lifecycle_metadata=_updated_lifecycle_metadata(
+                record,
+                operation_type="delete",
+                operation_id=context.operation_id,
+                reason=self.request.reason,
+            ),
+        )
+        persisted = self.request.transaction.update_staged_record(updated)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="lifecycle",
+            message="Record tombstoned.",
+            details=_lifecycle_audit_details(
+                before=record,
+                after=persisted,
+                reason=self.request.reason,
+            ),
+            locator=record.locator,
+        )
+        return persisted
+
+    def _restore(self, context: OperationContext) -> CatalogRecord:
+        """Restore a tombstoned record and return the updated record."""
+        record = self.request.record
+        if record.status != "deleted":
+            raise ValueError(f"Record is not deleted: {record.id}")
+        updated = replace(
+            record,
+            status="active",
+            lifecycle_metadata=_updated_lifecycle_metadata(
+                record,
+                operation_type="restore",
+                operation_id=context.operation_id,
+                reason=self.request.reason,
+            ),
+        )
+        persisted = self.request.transaction.update_staged_record(updated)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="lifecycle",
+            message="Record restored.",
+            details=_lifecycle_audit_details(
+                before=record,
+                after=persisted,
+                reason=self.request.reason,
+            ),
+            locator=record.locator,
+        )
+        return persisted
+
+    def _purge(self, context: OperationContext) -> None:
+        """Remove managed artifacts, then hard-delete the record."""
+        record = self.request.record
+        if record.status != "deleted" and not self.request.force:
+            raise ValueError(f"Record must be deleted before purge: {record.id}")
+        for artifact in record.artifacts:
+            self._purge_artifact(context, artifact)
+        if record.id is None:
+            raise ValueError("Cannot purge a record without an id.")
+        self.request.transaction.repository.delete(record.id)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="purge",
+            message="Record purged.",
+            details={
+                "record_id": record.id,
+                "force": self.request.force,
+                "artifact_count": len(record.artifacts),
+                "artifact_summaries": _artifact_audit_summaries(record),
+            },
+            locator=record.locator,
+        )
+
+    def _purge_artifact(self, context: OperationContext, artifact: ArtifactDescriptor) -> None:
+        """Purge one managed artifact or audit why it was skipped."""
+        locator = artifact.locator
+        if locator is None:
+            self._emit_artifact_skip(context, artifact, reason="missing locator")
+            return
+        target_path = locator.as_path()
+        if target_path is None:
+            self._emit_artifact_skip(context, artifact, reason=f"unsupported locator kind: {locator.kind}")
+            return
+        if not _is_managed_path(target_path, managed_roots=self.request.managed_roots):
+            self._emit_artifact_skip(context, artifact, reason="locator is outside managed catalog roots")
+            return
+
+        target_kind = _target_kind_for_existing_path(target_path)
+        remove_target(locator, target_kind=target_kind)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="purge_artifact",
+            message="Managed artifact removed.",
+            details={
+                "artifact_id": artifact.id,
+                "artifact_role": artifact.role,
+                "target_kind": target_kind,
+                "purge_action": "removed",
+            },
+            locator=locator,
+        )
+
+    def _emit_artifact_skip(
+        self,
+        context: OperationContext,
+        artifact: ArtifactDescriptor,
+        *,
+        reason: str,
+    ) -> None:
+        """Audit that one artifact was intentionally not purged."""
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="purge_artifact",
+            message="Artifact purge skipped.",
+            details={
+                "artifact_id": artifact.id,
+                "artifact_role": artifact.role,
+                "purge_action": "skipped",
+                "reason": reason,
+            },
+            locator=artifact.locator,
+        )
+
+    def _commit_if_owned(self, context: OperationContext) -> None:
+        """Commit internal lifecycle transactions."""
+        if not self.request.commit:
+            return
+        self.request.transaction.commit()
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="commit",
+            message="Commit succeeded.",
+            details={"transaction_state": self.request.transaction.state.value},
+            locator=self.request.record.locator,
+        )
+
+    def _handle_error(
+        self,
+        *,
+        error: Exception,
+        context: OperationContext,
+        current_phase: str,
+    ) -> None:
+        """Audit and roll back a failed lifecycle operation."""
+        add_operation_note(error, context.operation_id)
+        self.dependencies.emit_operation_audit(
+            context,
+            event_type="failure",
+            message=f"{self.request.operation_type} operation failed.",
+            details={
+                "phase": current_phase,
+                "transaction_state": self.request.transaction.state.value,
+                "caller_owned_transaction": not self.request.commit,
+            },
+            exception=error,
+            locator=self.request.record.locator,
+        )
+        if self.request.commit and self.request.transaction.state is not OperationState.COMMITTED:
+            self.dependencies.emit_operation_audit(
+                context,
+                event_type="rollback",
+                message="Rollback started.",
+                details={
+                    "rollback_phase": "started",
+                    "transaction_state": self.request.transaction.state.value,
+                },
+            )
+            self.request.transaction.rollback(original_exception=error)
+            if self.request.transaction.rollback_errors:
+                self.dependencies.emit_operation_audit(
+                    context,
+                    event_type="rollback",
+                    level="error",
+                    message="Rollback completed with failures.",
+                    details={
+                        "rollback_phase": "failed",
+                        "transaction_state": self.request.transaction.state.value,
+                        "rollback_errors": _rollback_errors_audit_details(
+                            self.request.transaction.rollback_errors
+                        ),
+                    },
+                    exception=self.request.transaction.rollback_errors[0].exception,
+                )
+            else:
+                self.dependencies.emit_operation_audit(
+                    context,
+                    event_type="rollback",
+                    message="Rollback completed.",
+                    details={
+                        "rollback_phase": "completed",
+                        "transaction_state": self.request.transaction.state.value,
+                    },
+                )
+
+
 def _metadata_with_hook_warnings(context: OperationContext) -> MetadataDict:
     """Return derived metadata with non-fatal hook warnings included."""
     metadata = normalize_metadata(context.derived_metadata, field_name="derived_metadata")
@@ -697,3 +987,82 @@ def _require_record_id(record: CatalogRecord) -> str:
     if record.id is None:
         raise RuntimeError("Repository returned a persisted record without an id.")
     return record.id
+
+
+def _updated_lifecycle_metadata(
+    record: CatalogRecord,
+    *,
+    operation_type: str,
+    operation_id: str,
+    reason: str | None,
+) -> MetadataDict:
+    """Return lifecycle metadata with one lifecycle transition appended."""
+    timestamp = _utc_timestamp()
+    metadata: dict[str, object] = dict(record.lifecycle_metadata)
+    metadata[f"{operation_type}_operation_id"] = operation_id
+    timestamp_key = "deleted_at" if operation_type == "delete" else f"{operation_type}d_at"
+    metadata[timestamp_key] = timestamp
+    if reason is not None:
+        metadata[f"{operation_type}_reason"] = reason
+    return normalize_metadata(metadata, field_name="lifecycle_metadata")
+
+
+def _lifecycle_audit_details(
+    *,
+    before: CatalogRecord,
+    after: CatalogRecord,
+    reason: str | None,
+) -> dict[str, object]:
+    """Return audit details for a lifecycle status transition."""
+    return {
+        "record_id": before.id,
+        "status_before": before.status,
+        "status_after": after.status,
+        "reason_present": reason is not None,
+        "metadata_keys": sorted(before.user_metadata),
+        "derived_metadata_keys": sorted(before.derived_metadata),
+        "artifact_summaries": _artifact_audit_summaries(before),
+    }
+
+
+def _artifact_audit_summaries(record: CatalogRecord) -> list[dict[str, object]]:
+    """Return compact artifact descriptor summaries for audit logging."""
+    return [
+        {
+            "id": artifact.id,
+            "role": artifact.role,
+            "state": artifact.state,
+            "locator_kind": None if artifact.locator is None else artifact.locator.kind,
+            "relative_path": None if artifact.locator is None else artifact.locator.relative_path,
+        }
+        for artifact in record.artifacts
+    ]
+
+
+def _is_managed_path(path: Path, *, managed_roots: tuple[Path, ...]) -> bool:
+    """Return whether a local path lives under one of the catalog-managed roots."""
+    try:
+        resolved_path = path.expanduser().resolve()
+    except OSError:
+        resolved_path = path.expanduser().absolute()
+    for root in managed_roots:
+        try:
+            resolved_root = root.expanduser().resolve()
+        except OSError:
+            resolved_root = root.expanduser().absolute()
+        if resolved_path == resolved_root or resolved_root in resolved_path.parents:
+            return True
+    return False
+
+
+def _target_kind_for_existing_path(path: Path) -> TargetKind:
+    """Infer the safest storage target kind for an existing local path."""
+    if path.exists() and path.is_dir() and not path.is_symlink():
+        return "directory"
+    return "file"
+
+
+def _utc_timestamp() -> str:
+    """Return a stable UTC timestamp string for lifecycle metadata."""
+    timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat()
+    return timestamp.replace("+00:00", "Z")

--- a/src/ogcat/operation_runner.py
+++ b/src/ogcat/operation_runner.py
@@ -767,6 +767,9 @@ class RecordLifecycleOperationRunner(OperationRunner):
 
     def _purge_artifact(self, context: OperationContext, artifact: ArtifactDescriptor) -> None:
         """Purge one managed artifact or audit why it was skipped."""
+        if self.request.record.storage_mode == "reference":
+            self._emit_artifact_skip(context, artifact, reason="record storage mode is reference")
+            return
         locator = artifact.locator
         if locator is None:
             self._emit_artifact_skip(context, artifact, reason="missing locator")

--- a/src/ogcat/search.py
+++ b/src/ogcat/search.py
@@ -21,6 +21,8 @@ _RESERVED_FIELDS = {
     "stored_abspath",
     "stored_relpath",
     "storage_mode",
+    "status",
+    "lifecycle_metadata",
     "time_added",
     "original_path",
     "original_filename",

--- a/src/ogcat/storage.py
+++ b/src/ogcat/storage.py
@@ -141,7 +141,8 @@ class LocalStorageAdapter:
         """Remove a local file or directory target."""
         path = require_local_path(locator)
         if target_kind == "directory":
-            shutil.rmtree(path, ignore_errors=True)
+            if path.exists():
+                shutil.rmtree(path)
             return
         path.unlink(missing_ok=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,66 @@ def test_search_json_output(tmp_path: Path) -> None:
     assert payload[0]["user_metadata"]["species"] == "CO2"
 
 
+def test_delete_restore_and_deleted_search_flags(tmp_path: Path) -> None:
+    """CLI delete tombstones records and deleted-search flags expose them."""
+    catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
+    record_id = _record_id(record)
+
+    delete_result = runner.invoke(
+        app,
+        ["delete", record_id, "--catalog", str(catalog.root), "--reason", "duplicate", "--json"],
+    )
+    default_search = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--ids"],
+    )
+    include_search = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--where", "species=CO2", "--include-deleted", "--ids"],
+    )
+    only_deleted_search = runner.invoke(
+        app,
+        ["search", "--catalog", str(catalog.root), "--only-deleted", "--ids"],
+    )
+    restore_result = runner.invoke(app, ["restore", record_id, "--catalog", str(catalog.root), "--json"])
+
+    assert delete_result.exit_code == 0
+    delete_payload = json.loads(strip_ansi(delete_result.stdout))
+    assert delete_payload["status"] == "deleted"
+    assert delete_payload["lifecycle_metadata"]["delete_reason"] == "duplicate"
+    assert default_search.exit_code == 0
+    assert strip_ansi(default_search.stdout).splitlines() == []
+    assert include_search.exit_code == 0
+    assert strip_ansi(include_search.stdout).splitlines() == [record_id]
+    assert only_deleted_search.exit_code == 0
+    assert strip_ansi(only_deleted_search.stdout).splitlines() == [record_id]
+    assert restore_result.exit_code == 0
+    assert json.loads(strip_ansi(restore_result.stdout))["status"] == "active"
+
+
+def test_purge_cli_requires_confirmation_and_removes_deleted_record(tmp_path: Path) -> None:
+    """CLI purge should require --yes and then permanently remove a tombstone."""
+    catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
+    record_id = _record_id(record)
+    path = record.path()
+    assert path is not None
+    delete_result = runner.invoke(app, ["delete", record_id, "--catalog", str(catalog.root)])
+
+    rejected = runner.invoke(app, ["purge", record_id, "--catalog", str(catalog.root)])
+    purged = runner.invoke(app, ["purge", record_id, "--catalog", str(catalog.root), "--yes", "--json"])
+    show_result = runner.invoke(app, ["show", record_id, "--catalog", str(catalog.root), "--json"])
+
+    assert delete_result.exit_code == 0
+    assert rejected.exit_code == 2
+    assert "Pass --yes to confirm" in strip_ansi(rejected.output)
+    assert purged.exit_code == 0
+    assert json.loads(strip_ansi(purged.stdout)) == {"id": record_id, "purged": True}
+    assert show_result.exit_code != 0
+    assert not path.exists()
+
+
 def test_root_help_uses_plain_click_formatting() -> None:
     """Root help output should not contain Rich box-drawing panels."""
     result = runner.invoke(app, ["--help"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+import ogcat.operation_runner as operation_runner
 from ogcat import Catalog, CatalogSpec, MetadataFieldDescription, RecordSchema
 from ogcat.cli import app
 from ogcat.models import ArtifactLocator, CatalogRecord
@@ -123,6 +124,25 @@ def test_delete_restore_and_deleted_search_flags(tmp_path: Path) -> None:
     assert json.loads(strip_ansi(restore_result.stdout))["status"] == "active"
 
 
+def test_search_rejects_conflicting_deleted_flags(tmp_path: Path) -> None:
+    """CLI search should reject mutually exclusive deleted-record flags."""
+    catalog = _create_catalog(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "search",
+            "--catalog",
+            str(catalog.root),
+            "--include-deleted",
+            "--only-deleted",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --include-deleted or --only-deleted" in strip_ansi(result.output)
+
+
 def test_purge_cli_requires_confirmation_and_removes_deleted_record(tmp_path: Path) -> None:
     """CLI purge should require --yes and then permanently remove a tombstone."""
     catalog = _create_catalog(tmp_path)
@@ -143,6 +163,40 @@ def test_purge_cli_requires_confirmation_and_removes_deleted_record(tmp_path: Pa
     assert json.loads(strip_ansi(purged.stdout)) == {"id": record_id, "purged": True}
     assert show_result.exit_code != 0
     assert not path.exists()
+
+
+def test_purge_cli_reports_incomplete_purge_without_success_json(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """CLI purge should not print a success payload when cleanup is incomplete."""
+    catalog = _create_catalog(tmp_path)
+    record = catalog.search()[0]
+    record_id = _record_id(record)
+    path = record.path()
+    assert path is not None
+    original_remove_target = operation_runner.remove_target
+
+    def fail_remove_target(
+        locator: ArtifactLocator,
+        *,
+        target_kind: operation_runner.TargetKind = "file",
+    ) -> None:
+        """Fail the managed file removal used by CLI purge."""
+        if locator.as_path() == path:
+            raise PermissionError("locked managed artifact")
+        original_remove_target(locator, target_kind=target_kind)
+
+    delete_result = runner.invoke(app, ["delete", record_id, "--catalog", str(catalog.root)])
+    monkeypatch.setattr(operation_runner, "remove_target", fail_remove_target)
+
+    result = runner.invoke(app, ["purge", record_id, "--catalog", str(catalog.root), "--yes", "--json"])
+
+    assert delete_result.exit_code == 0
+    assert result.exit_code != 0
+    output = strip_ansi(result.output)
+    assert "Purge incomplete" in output
+    assert '"purged": true' not in output
 
 
 def test_root_help_uses_plain_click_formatting() -> None:

--- a/tests/test_record_lifecycle.py
+++ b/tests/test_record_lifecycle.py
@@ -179,6 +179,28 @@ def test_purge_skips_external_path_artifacts(tmp_path: Path) -> None:
     assert any(event.details["purge_action"] == "skipped" for event in skip_events)
 
 
+def test_purge_skips_reference_paths_under_managed_roots(tmp_path: Path) -> None:
+    """Reference-only records must not delete user-owned paths under catalog roots."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    referenced = catalog.root / catalog.spec.files_root / "user-owned.nc"
+    referenced.write_text("user data", encoding="utf-8")
+    record = catalog.add_reference(referenced, metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    catalog.delete(record_id)
+
+    catalog.purge(record_id)
+
+    assert referenced.exists()
+    assert referenced.read_text(encoding="utf-8") == "user data"
+    assert catalog.get(record_id) is None
+    skip_events = catalog.audit_events(event_type="purge_artifact")
+    assert any(
+        event.details["reason"] == "record storage mode is reference"
+        and event.details["purge_action"] == "skipped"
+        for event in skip_events
+    )
+
+
 def test_purge_requires_deleted_record_unless_forced(tmp_path: Path) -> None:
     """Active records should not be purged unless force is explicit."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))

--- a/tests/test_record_lifecycle.py
+++ b/tests/test_record_lifecycle.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from ogcat import ArtifactLocator, Catalog, CatalogRecord, CatalogSpec
+import ogcat.operation_runner as operation_runner
+from ogcat import (
+    ArtifactDescriptor,
+    ArtifactLocator,
+    Catalog,
+    CatalogRecord,
+    CatalogSpec,
+    PurgeIncompleteError,
+)
 
 
 def _source_file(tmp_path: Path, name: str = "source.nc") -> Path:
@@ -20,6 +28,24 @@ def _record_id(record: CatalogRecord) -> str:
     """Return a persisted test record id."""
     assert record.id is not None
     return record.id
+
+
+def _add_managed_secondary_artifact(catalog: Catalog, record_id: str, name: str) -> Path:
+    """Attach an extra managed artifact descriptor to a stored record."""
+    secondary_path = catalog.root / catalog.spec.objects_root / name
+    secondary_path.parent.mkdir(parents=True, exist_ok=True)
+    secondary_path.write_text("secondary", encoding="utf-8")
+    record = catalog.get(record_id)
+    assert record is not None
+    record.artifacts.append(
+        ArtifactDescriptor(
+            id="secondary",
+            role="manifest",
+            locator=ArtifactLocator.path(secondary_path),
+        )
+    )
+    catalog.repository.update(record)
+    return secondary_path
 
 
 def test_delete_tombstones_record_and_hides_default_search(tmp_path: Path) -> None:
@@ -163,6 +189,89 @@ def test_purge_removes_managed_artifacts_and_hard_deletes_record(tmp_path: Path)
         assert not path.is_symlink()
 
 
+def test_purge_continues_after_artifact_failure_and_retains_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial artifact purge should keep an accurate tombstone record."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "managed.nc"), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    failed_path = record.path()
+    assert failed_path is not None
+    removed_path = _add_managed_secondary_artifact(catalog, record_id, "secondary.txt")
+    catalog.delete(record_id)
+    original_remove_target = operation_runner.remove_target
+
+    def flaky_remove_target(
+        locator: ArtifactLocator,
+        *,
+        target_kind: operation_runner.TargetKind = "file",
+    ) -> None:
+        """Fail the primary artifact removal but allow later removals."""
+        if locator.as_path() == failed_path:
+            raise PermissionError("locked managed artifact")
+        original_remove_target(locator, target_kind=target_kind)
+
+    monkeypatch.setattr(operation_runner, "remove_target", flaky_remove_target)
+
+    with pytest.raises(PurgeIncompleteError, match="Purge incomplete"):
+        catalog.purge(record_id)
+
+    retained = catalog.get(record_id)
+    assert retained is not None
+    assert retained.status == "deleted"
+    assert failed_path.exists()
+    assert not removed_path.exists()
+    states = {artifact.id: artifact.state for artifact in retained.artifacts}
+    assert states["data"] == "purge_failed"
+    assert states["secondary"] == "purged"
+    assert any(state == "purged" for artifact_id, state in states.items() if artifact_id != "secondary")
+    assert retained.lifecycle_metadata["purge_status"] == "incomplete"
+    assert retained.lifecycle_metadata["purge_failure_count"] == 1
+    removed_count = retained.lifecycle_metadata["purge_removed_count"]
+    assert isinstance(removed_count, int)
+    assert removed_count >= 1
+    artifact_events = catalog.audit_events(record_id=record_id, event_type="purge_artifact")
+    assert any(event.details["purge_action"] == "failed" for event in artifact_events)
+    assert any(event.details["purge_action"] == "removed" for event in artifact_events)
+    purge_events = catalog.audit_events(record_id=record_id, event_type="purge")
+    assert purge_events[-1].level == "error"
+    assert purge_events[-1].details["purge_status"] == "incomplete"
+
+
+def test_purge_retains_tombstone_when_repository_delete_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repository hard-delete failure should retain purge outcome metadata."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "managed.nc"), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    artifact_path = record.path()
+    assert artifact_path is not None
+    catalog.delete(record_id)
+
+    def fail_delete(record_id: str) -> None:
+        """Simulate a repository failure after artifact cleanup."""
+        raise RuntimeError(f"repository unavailable for {record_id}")
+
+    monkeypatch.setattr(catalog.repository, "delete", fail_delete)
+
+    with pytest.raises(PurgeIncompleteError, match="repository delete failed"):
+        catalog.purge(record_id)
+
+    retained = catalog.get(record_id)
+    assert retained is not None
+    assert retained.status == "deleted"
+    assert not artifact_path.exists()
+    assert retained.artifacts[0].state == "purged"
+    assert retained.lifecycle_metadata["purge_status"] == "incomplete"
+    assert retained.lifecycle_metadata["purge_repository_delete_failed"] is True
+    purge_events = catalog.audit_events(record_id=record_id, event_type="purge")
+    assert purge_events[-1].exception_type == "RuntimeError"
+
+
 def test_purge_skips_external_path_artifacts(tmp_path: Path) -> None:
     """Purge should skip user-owned paths outside managed catalog roots."""
     external = _source_file(tmp_path, "external.nc")
@@ -211,6 +320,14 @@ def test_purge_requires_deleted_record_unless_forced(tmp_path: Path) -> None:
         catalog.purge(record_id)
 
     assert catalog.get(record_id) is not None
+
+
+def test_search_rejects_conflicting_deleted_visibility_flags(tmp_path: Path) -> None:
+    """Deleted-record search flags should be mutually exclusive."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+
+    with pytest.raises(ValueError, match="include_deleted and only_deleted"):
+        catalog.search(include_deleted=True, only_deleted=True)
 
 
 def test_delete_restore_and_purge_emit_audit_events(tmp_path: Path) -> None:

--- a/tests/test_record_lifecycle.py
+++ b/tests/test_record_lifecycle.py
@@ -1,0 +1,226 @@
+"""Record tombstone, restore, and purge behavior tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ogcat import ArtifactLocator, Catalog, CatalogRecord, CatalogSpec
+
+
+def _source_file(tmp_path: Path, name: str = "source.nc") -> Path:
+    """Create a small source file for lifecycle tests."""
+    source = tmp_path / name
+    source.write_text("dummy", encoding="utf-8")
+    return source
+
+
+def _record_id(record: CatalogRecord) -> str:
+    """Return a persisted test record id."""
+    assert record.id is not None
+    return record.id
+
+
+def test_delete_tombstones_record_and_hides_default_search(tmp_path: Path) -> None:
+    """Deleting a record should tombstone it without dropping locator metadata."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+
+    deleted = catalog.delete(record_id, reason="superseded")
+
+    assert deleted.id == record_id
+    assert deleted.status == "deleted"
+    assert deleted.locator == record.locator
+    assert deleted.artifacts == record.artifacts
+    assert deleted.user_metadata == record.user_metadata
+    assert deleted.lifecycle_metadata["delete_reason"] == "superseded"
+    assert "delete_operation_id" in deleted.lifecycle_metadata
+    assert "deleted_at" in deleted.lifecycle_metadata
+    assert catalog.get(record_id) == deleted
+    assert catalog.path(record_id) == record.path()
+    assert catalog.search(where={"species": "CO2"}) == []
+    assert catalog.search(where={"species": "CO2"}, include_deleted=True).ids == [record_id]
+    assert catalog.search(only_deleted=True).ids == [record_id]
+    with pytest.raises(ValueError, match="found no records"):
+        catalog.get_one(where={"species": "CO2"})
+
+
+def test_restore_returns_record_to_default_search(tmp_path: Path) -> None:
+    """Restoring a deleted record should preserve its id and make it searchable."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    catalog.delete(record_id)
+
+    restored = catalog.restore(record_id, reason="needed again")
+
+    assert restored.id == record_id
+    assert restored.status == "active"
+    assert restored.lifecycle_metadata["restore_reason"] == "needed again"
+    assert "restore_operation_id" in restored.lifecycle_metadata
+    assert "restored_at" in restored.lifecycle_metadata
+    assert catalog.search(where={"species": "CO2"}).ids == [record_id]
+    assert catalog.search(only_deleted=True) == []
+
+
+def test_old_records_load_as_active() -> None:
+    """Legacy serialized records without lifecycle fields should load as active."""
+    record = CatalogRecord.from_dict(
+        {
+            "id": "1",
+            "catalog": "files",
+            "time_added": "2026-04-23T12:00:00Z",
+            "locator": {"kind": "uri", "value": "s3://bucket/example.zarr", "relative_path": None},
+        }
+    )
+
+    assert record.status == "active"
+    assert record.lifecycle_metadata == {}
+    assert record.to_dict()["status"] == "active"
+
+
+def test_active_summaries_exclude_deleted_records_by_default(tmp_path: Path) -> None:
+    """Catalog summaries and field helpers should use active records by default."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    active = catalog.add_reference(
+        ArtifactLocator(kind="uri", value="s3://bucket/active.zarr"),
+        metadata={"species": "CO2", "active_only": "yes"},
+    )
+    deleted = catalog.add_reference(
+        ArtifactLocator(kind="uri", value="s3://bucket/deleted.zarr"),
+        metadata={"species": "CH4", "deleted_only": "yes"},
+    )
+    catalog.delete(_record_id(deleted))
+
+    description = catalog.describe()
+
+    assert description["record_count"] == 1
+    assert description["deleted_record_count"] == 1
+    assert catalog.describe(include_deleted=True)["record_count"] == 2
+    assert "user_metadata.active_only" in catalog.list_record_fields()
+    assert "user_metadata.deleted_only" not in catalog.list_record_fields()
+    assert "user_metadata.deleted_only" in catalog.list_record_fields(include_deleted=True)
+    assert catalog.unique_values("species") == ["CO2"]
+    assert sorted(str(value) for value in catalog.unique_values("species", include_deleted=True)) == [
+        "CH4",
+        "CO2",
+    ]
+    assert catalog.get_one(where={"species": "CO2"}).id == active.id
+
+
+def test_plan_view_excludes_deleted_records(tmp_path: Path) -> None:
+    """Replica view planning should not include tombstoned records."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "alpha.nc"), metadata={"product": "flux"})
+    catalog.delete(_record_id(record))
+
+    plan = catalog.plan_view(tmp_path / "view", "{product}/{id}_{original_filename}")
+
+    assert plan.items == ()
+
+
+def test_delete_rolls_back_with_caller_owned_transaction(tmp_path: Path) -> None:
+    """Caller-owned transactions should restore tombstones when not committed."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+
+    with catalog.transaction() as transaction:
+        deleted = catalog.delete(record_id, transaction=transaction)
+        assert deleted.status == "deleted"
+        stored = catalog.get(record_id)
+        assert stored is not None
+        assert stored.status == "deleted"
+
+    rolled_back = catalog.get(record_id)
+    assert rolled_back is not None
+    assert rolled_back.status == "active"
+    assert catalog.search(where={"species": "CO2"}).ids == [record_id]
+
+
+def test_purge_removes_managed_artifacts_and_hard_deletes_record(tmp_path: Path) -> None:
+    """Purging a tombstone should remove catalog-managed files and the record."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path, "managed.nc"), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    artifact_paths = [
+        artifact.locator.as_path()
+        for artifact in record.artifacts
+        if artifact.locator is not None and artifact.locator.as_path() is not None
+    ]
+    assert artifact_paths
+    assert all(path.exists() or path.is_symlink() for path in artifact_paths if path is not None)
+    catalog.delete(record_id)
+
+    catalog.purge(record_id)
+
+    assert catalog.get(record_id) is None
+    for path in artifact_paths:
+        assert path is not None
+        assert not path.exists()
+        assert not path.is_symlink()
+
+
+def test_purge_skips_external_path_artifacts(tmp_path: Path) -> None:
+    """Purge should skip user-owned paths outside managed catalog roots."""
+    external = _source_file(tmp_path, "external.nc")
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_reference(external, metadata={"species": "CO2"})
+    record_id = _record_id(record)
+    catalog.delete(record_id)
+
+    catalog.purge(record_id)
+
+    assert external.exists()
+    assert catalog.get(record_id) is None
+    skip_events = catalog.audit_events(event_type="purge_artifact")
+    assert any(event.details["purge_action"] == "skipped" for event in skip_events)
+
+
+def test_purge_requires_deleted_record_unless_forced(tmp_path: Path) -> None:
+    """Active records should not be purged unless force is explicit."""
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))
+    record = catalog.add_file(_source_file(tmp_path), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+
+    with pytest.raises(ValueError, match="must be deleted before purge"):
+        catalog.purge(record_id)
+
+    assert catalog.get(record_id) is not None
+
+
+def test_delete_restore_and_purge_emit_audit_events(tmp_path: Path) -> None:
+    """Lifecycle operations should write structured audit events."""
+    catalog = Catalog.create(
+        tmp_path / "catalog",
+        CatalogSpec(catalog_name="files"),
+        audit_user_id="alice",
+    )
+    record = catalog.add_file(_source_file(tmp_path), metadata={"species": "CO2"})
+    record_id = _record_id(record)
+
+    catalog.delete(record_id, reason="bad input")
+    catalog.restore(record_id, reason="false alarm")
+    catalog.delete(record_id)
+    catalog.purge(record_id)
+
+    delete_lifecycle = [
+        event
+        for event in catalog.audit_events(record_id=record_id, event_type="lifecycle")
+        if event.details["status_after"] == "deleted"
+    ]
+    restore_lifecycle = [
+        event
+        for event in catalog.audit_events(record_id=record_id, event_type="lifecycle")
+        if event.details["status_after"] == "active"
+    ]
+    purge_events = catalog.audit_events(record_id=record_id, event_type="purge")
+
+    assert delete_lifecycle
+    assert restore_lifecycle
+    assert purge_events
+    assert all(event.user_id == "alice" for event in [*delete_lifecycle, *restore_lifecycle, *purge_events])
+    assert delete_lifecycle[0].details["reason_present"] is True
+    assert "artifact_summaries" in delete_lifecycle[0].details

--- a/tests/test_record_lifecycle.py
+++ b/tests/test_record_lifecycle.py
@@ -107,6 +107,18 @@ def test_old_records_load_as_active() -> None:
     assert record.to_dict()["status"] == "active"
 
 
+def test_purge_incomplete_error_is_not_a_value_error() -> None:
+    """Incomplete purge failures should not be mistaken for validation errors."""
+    error = PurgeIncompleteError(
+        record_id="1",
+        operation_id="operation",
+        failed_artifact_ids=["data"],
+    )
+
+    assert isinstance(error, RuntimeError)
+    assert not isinstance(error, ValueError)
+
+
 def test_active_summaries_exclude_deleted_records_by_default(tmp_path: Path) -> None:
     """Catalog summaries and field helpers should use active records by default."""
     catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="files"))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -74,6 +74,24 @@ def test_search_prefers_top_level_fields_when_names_are_ambiguous(tmp_path: Path
     assert catalog.search(where={"time_added": "user-time"}) == []
 
 
+def test_search_status_prefers_lifecycle_field_over_user_metadata(tmp_path: Path) -> None:
+    """Unqualified status should resolve to the reserved lifecycle field."""
+    source = tmp_path / "status.202401.nc"
+    source.write_text("dummy", encoding="utf-8")
+
+    catalog = Catalog.create(tmp_path / "catalog", CatalogSpec(catalog_name="fluxes"))
+    record = catalog.add_file(source, metadata={"status": "domain-ready"})
+    record_id = record.id
+    assert record_id is not None
+    catalog.delete(record_id)
+
+    assert catalog.search(where={"status": "domain-ready"}, include_deleted=True) == []
+    assert catalog.search(where={"status": "deleted"}, include_deleted=True).ids == [record_id]
+    assert catalog.search(where={"user_metadata.status": "domain-ready"}, include_deleted=True).ids == [
+        record_id
+    ]
+
+
 def test_search_prefers_user_metadata_before_derived_metadata(tmp_path: Path) -> None:
     source = tmp_path / "precedence.202401.nc"
     source.write_text("dummy", encoding="utf-8")


### PR DESCRIPTION
Implemented the trash-style deletion lifecycle and opened [issue #130](https://github.com/openghg/ogcat/issues/130).

Added:
- `Catalog.delete()`, `Catalog.restore()`, `Catalog.purge()`
- `CatalogRecord.status` and `lifecycle_metadata`
- active-only default search, plus `include_deleted` / `only_deleted`
- lifecycle operation runner via the existing operation layer
- CLI commands: `ogcat delete`, `ogcat restore`, `ogcat purge`
- docs updates and focused lifecycle/CLI tests

Key files changed include [catalog.py](/Users/bm13805/.codex/worktrees/790e/ogcat/src/ogcat/catalog.py), [operation_runner.py](/Users/bm13805/.codex/worktrees/790e/ogcat/src/ogcat/operation_runner.py), [catalog_application.py](/Users/bm13805/.codex/worktrees/790e/ogcat/src/ogcat/catalog_application.py), [models.py](/Users/bm13805/.codex/worktrees/790e/ogcat/src/ogcat/models.py), [cli.py](/Users/bm13805/.codex/worktrees/790e/ogcat/src/ogcat/cli.py), and new [test_record_lifecycle.py](/Users/bm13805/.codex/worktrees/790e/ogcat/tests/test_record_lifecycle.py).

Checks run:
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pyright`
- `uv run pytest tests/test_record_lifecycle.py tests/test_search.py tests/test_audit.py tests/test_storage.py tests/test_cli.py -q`
- `uv run pytest` → `487 passed, 4 skipped`

